### PR TITLE
fix: correct pdf-parse API usage to resolve PDF parsing crash (Issue #1)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { createServer as createViteServer } from "vite";
 import { InferenceClient } from "@huggingface/inference";
 import multer from "multer";
-import { PDFParse } from "pdf-parse";
+import pdfParse from "pdf-parse";
 import * as dotenv from "dotenv";
 import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
@@ -270,10 +270,8 @@ async function startServer() {
       console.log('PDF_EXTRACTION_START: using pdf-parse');
       let extractedText = '';
       try {
-        const parser = new PDFParse({ data: file.buffer });
-        const parsed = await parser.getText();
+        const parsed = await pdfParse(file.buffer);
         extractedText = (parsed?.text || "").trim();
-        await parser.destroy();
       } catch (extractError: any) {
         console.error('PDF_EXTRACTION_ERROR: Failed to parse PDF', extractError?.message || extractError);
         return res.status(400).json({ error: `PDF extraction failed: ${extractError?.message || 'Unknown error'}` });


### PR DESCRIPTION
## Summary

Fixes Issue #1 � PDF parsing was completely broken due to incorrect pdf-parse v2 API usage.

## Root Cause

In server.ts:6, the code used named import from pdf-parse. However, pdf-parse v2 exports a function, not a class. The named import evaluates to undefined, causing TypeError on PDF upload.

## Changes

- server.ts: Changed named import to default import
- server.ts: Replaced class instantiation with direct function call

Closes #1
