### PR TITLE
docs: add MIT License, Code of Conduct, and contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in the FinSight AI community a respectful, inclusive, and harassment-free experience for everyone.
+
+FinSight AI focuses on financial intelligence, risk assessment, and AI-powered document analysis. We welcome contributors from diverse backgrounds and experience levels.
+
+## Our Standards
+
+Examples of positive behavior include:
+
+* Being respectful and professional.
+* Providing constructive feedback.
+* Supporting new contributors.
+* Encouraging collaboration and knowledge sharing.
+* Promoting transparency and responsible AI development.
+
+Examples of unacceptable behavior include:
+
+* Harassment, discrimination, or hateful conduct.
+* Personal attacks or intimidation.
+* Publishing confidential information.
+* Deliberately introducing malicious or misleading code.
+* Misrepresenting financial analysis or model capabilities.
+
+## Responsible AI and Financial Data
+
+Contributors should:
+
+* Respect privacy and confidentiality.
+* Avoid exposing sensitive financial information.
+* Clearly communicate model limitations.
+* Follow ethical AI and data-handling practices.
+* Prioritize transparency, reliability, and security.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for enforcing community standards and may take appropriate action when necessary.
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including issues, pull requests, discussions, documentation, and community communication channels.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported through official project communication channels.
+
+## Attribution
+
+Adapted from Contributor Covenant v2.1:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,119 @@
+# Contributing to FinSight AI
+
+Thank you for your interest in contributing to FinSight AI! 🚀
+
+FinSight AI is an AI-assisted BFSI intelligence platform for financial document ingestion, portfolio risk assessment, and automated insight generation. We welcome contributions that improve reliability, security, explainability, analytics, and user experience.
+
+---
+
+## ⭐ Star the Repository
+
+If you find the project useful, please consider starring the repository to support its growth.
+
+---
+
+## Ways to Contribute
+
+You can contribute by:
+
+* Fixing bugs
+* Improving financial data processing workflows
+* Enhancing AI-powered analysis pipelines
+* Improving portfolio risk assessment features
+* Enhancing dashboards and reporting
+* Improving documentation
+* Adding test coverage
+* Strengthening security and compliance features
+
+---
+
+## Getting Started
+
+### 1. Fork the Repository
+
+Fork the repository to your GitHub account.
+
+### 2. Clone Your Fork
+
+```bash
+git clone https://github.com/YOUR_USERNAME/finsight-ai.git
+cd finsight-ai
+```
+
+### 3. Create a Branch
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+---
+
+## Development Guidelines
+
+Please ensure that:
+
+* Code follows the project's architecture and coding standards.
+* Changes remain focused on a single issue.
+* New functionality includes appropriate tests.
+* Documentation is updated when necessary.
+* Security and data privacy best practices are followed.
+
+---
+
+## Linting & Testing
+
+Before submitting a Pull Request:
+
+```bash
+npm run lint
+npm test
+```
+
+Please ensure:
+
+* All lint checks pass.
+* Existing tests pass successfully.
+* New features include relevant tests where applicable.
+* No unrelated files are included in the PR.
+
+---
+
+## Pull Request Guidelines
+
+Before opening a PR:
+
+* Test your changes locally.
+* Perform a self-review.
+* Reference the related issue.
+* Include screenshots for UI changes.
+* Keep PRs focused and easy to review.
+
+Example:
+
+```text
+Fixes #123
+```
+
+---
+
+## Financial Data & AI Principles
+
+As FinSight AI operates in the BFSI domain:
+
+* Respect data privacy and confidentiality.
+* Avoid exposing sensitive financial information.
+* Clearly communicate AI limitations.
+* Promote transparency and explainability.
+* Follow responsible AI development practices.
+
+---
+
+## Community Standards
+
+By contributing to FinSight AI, you agree to follow the project's Code of Conduct.
+
+Please review `CODE_OF_CONDUCT.md` before participating.
+
+---
+
+Thank you for contributing to FinSight AI and helping build trustworthy financial intelligence tools.

--- a/MIT LICENSE
+++ b/MIT LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 FinSight AI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Added an MIT License, CODE_OF_CONDUCT.md, and CONTRIBUTING.md to establish licensing terms, community standards, responsible AI practices, and contribution guidelines. Hence resolves issue #11, #12 & #13 