### PR TITLE
docs: run docker container in detached mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Build the image:
 docker build -t finsight-ai .
 ```
 
-Run the container:
+Run the container in detached mode so it doesn't block your terminal:
 
 ```bash
-docker run --env-file .env -p 3001:3001 finsight-ai
+docker run -d --env-file .env -p 3001:3001 finsight-ai
 ```
 
 The application will be available at:


### PR DESCRIPTION
## Description

This PR resolves a minor but annoying workflow issue in the "Docker Setup" instructions. The provided `docker run` command previously ran the container in the foreground, which blocks the user's terminal. I added the `-d` flag to run the container in detached mode, allowing developers to keep their terminal free for other commands while the application runs in the background.

## Related Issue

Fixes #None (just a documentation fix)

## Type of Change

* [ ] Bug Fix
* [ ] New Feature
* [x] Documentation Update
* [ ] Code Refactoring
* [ ] Performance Improvement

## Checklist

* [x] My code follows the project guidelines.
* [x] I have tested my changes.
* [x] I have updated documentation where necessary.
* [x] My changes do not break existing functionality.

## Screenshots (if applicable)

None

## Additional Notes

None