### PR TITLE
fix: correct PDF parsing import for pdf-parse v2

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { createServer as createViteServer } from "vite";
 import { InferenceClient } from "@huggingface/inference";
 import multer from "multer";
-import { PDFParse } from "pdf-parse";
+import pdf from "pdf-parse";
 import * as dotenv from "dotenv";
 import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
@@ -346,13 +346,8 @@ async function startServer() {
       console.log('PDF_EXTRACTION_START: using pdf-parse');
       let extractedText = '';
       try {
-        const parser = new PDFParse({ data: file.buffer });
-        try {
-          const parsed = await parser.getText();
-          extractedText = (parsed?.text || "").trim();
-        } finally {
-          await parser.destroy().catch(() => undefined);
-        }
+        const parsed = await pdf(file.buffer);
+        extractedText = (parsed?.text || "").trim();
       } catch (extractError: any) {
         console.error('PDF_EXTRACTION_ERROR: Failed to parse PDF', extractError?.message || extractError);
         throw new PipelineError(


### PR DESCRIPTION
## Description
Fixes #19

`pdf-parse` v2.x exports a **function** as default, not a named `PDFParse` class. This PR fixes the import and usage to match the correct API.

## Changes
- `server.ts`: Replace `import { PDFParse } from "pdf-parse"` with `import pdf from "pdf-parse"`
- Use `pdf(file.buffer)` directly instead of `new PDFParse(...)` + `getText()` + `destroy()`

## Impact
Resolves `TypeError: PDFParse is not a constructor` that caused PDF upload + AI analysis to crash with a 500 response.
