### PR TITLE
fix: correct Firestore list rule - use request.query instead of resource.data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -50,7 +50,7 @@ service cloud.firestore {
 
     match /documents/{docId} {
       allow read: if isOwner(existing().ownerId) || isAdmin();
-      allow list: if isSignedIn() && (resource.data.ownerId == request.auth.uid || isAdmin());
+      allow list: if request.auth != null && (request.query.ownerId == request.auth.uid || isAdmin());
       allow create: if isSignedIn() && isValidDocument(incoming());
       allow update: if (isOwner(existing().ownerId) && incoming().diff(existing()).affectedKeys().hasOnly(['status', 'updatedAt', 'riskLevel'])) || isAdmin();
       allow delete: if isOwner(existing().ownerId) || isAdmin();


### PR DESCRIPTION
## Description
Fixes #20

In Firestore Security Rules, `resource` is **not available** for `list` operations — it only exists for individual document reads (get/create/update/delete). Using `resource.data.ownerId` in the `list` rule denies ALL list requests.

## Changes
- `firestore.rules`: Replace `resource.data.ownerId` with `request.query.ownerId` in the `list` rule
- Clients must now query with `.where('ownerId', '==', user.uid)` to list documents, which is validated by the security rule

## Impact
Resolves permission-denied errors on the Documents list page. Users can now view their documents when querying with the correct ownerId filter.
