### PR TITLE
fix: run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,14 @@ FROM node:20-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/dist ./dist
+# node:20-alpine ships with a non-root "node" user (uid 1000) — reuse it
+# instead of running the app as root, so a container escape or dependency
+# exploit does not grant root privileges on the host.
+COPY --from=builder --chown=node:node /app/package*.json ./
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/dist ./dist
+
+USER node
 
 EXPOSE 3001
 


### PR DESCRIPTION
Fixes #33

## Problem
The runtime stage of the `Dockerfile` had no `USER` directive, so the Node/Express process ran as `UID 0` (root) inside the container. A dependency vulnerability, path traversal, or command injection in the app would let an attacker operate as root inside the container, and a subsequent container escape would grant full root access to the host.

## Fix
`node:20-alpine` ships a built-in non-root `node` user (uid 1000) intended exactly for this. The runtime stage now:
- Copies build artifacts with `--chown=node:node` so the app can still read/execute them
- Adds `USER node` before `CMD`, so the container never runs as root

## Verification
```bash
docker build -t finsight-ai .
docker run --rm finsight-ai sh -c whoami
# node   (was: root)
```

No other behavior changes; the app listens on the same port and starts the same way.