### PR TITLE
fix: enforce Firebase auth globally on /api/* instead of per-route

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -190,6 +190,41 @@ async function verifyFirebaseIdToken(idToken: string): Promise<VerifiedUser> {
   return { uid: decoded.uid };
 }
 
+/**
+ * Verifies the Firebase ID token on every /api/* request (except /api/health)
+ * before any route handler runs, so a new route can never be added without
+ * authentication by accident. Attaches the verified uid to req.ownerId.
+ */
+async function requireFirebaseAuth(req: any, res: any, next: any) {
+  const authHeader = String(req.headers.authorization || '');
+  if (!authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({
+      error: {
+        stage: "AUTH_VERIFICATION",
+        reason: "Missing or invalid Authorization token",
+        recommendation: "You are not authorized. Please refresh your session or sign in again.",
+      },
+    });
+  }
+
+  const idToken = authHeader.split(' ')[1];
+  try {
+    const decoded = await verifyFirebaseIdToken(idToken);
+    req.ownerId = decoded.uid;
+    req.idToken = idToken;
+    next();
+  } catch (err: any) {
+    console.error('AUTH_ERROR: ID token verification failed', err?.message || err);
+    return res.status(401).json({
+      error: {
+        stage: "AUTH_VERIFICATION",
+        reason: `Invalid ID token: ${err?.message || String(err)}`,
+        recommendation: "Your session token has expired or is invalid. Please sign out and sign in again.",
+      },
+    });
+  }
+}
+
 function toFirestoreValue(value: any): any {
   if (value === null || value === undefined) return { nullValue: null };
   if (value instanceof Date) return { timestampValue: value.toISOString() };
@@ -294,8 +329,12 @@ async function startServer() {
     res.json({ status: "ok", timestamp: new Date().toISOString() });
   });
 
+  // Require a valid Firebase ID token on every other /api/* route so a
+  // route added in the future can't accidentally ship without auth.
+  app.use("/api", requireFirebaseAuth);
+
   // AI Analysis Endpoint
-  app.post("/api/analyze", upload.single("file"), async (req, res) => {
+  app.post("/api/analyze", upload.single("file"), async (req: any, res) => {
     try {
       console.log('=== PDF INGESTION START ===');
       const file = req.file;
@@ -318,29 +357,10 @@ async function startServer() {
         );
       }
 
-      // Check auth before spending resources.
-      const authHeader = String(req.headers.authorization || '');
-      if (!authHeader.startsWith('Bearer ')) {
-        throw new PipelineError(
-          "AUTH_VERIFICATION",
-          "Missing or invalid Authorization token",
-          "You are not authorized. Please refresh your session or sign in again."
-        );
-      }
-
-      const idToken = authHeader.split(' ')[1];
-      let ownerId = 'unknown';
-      try {
-        const decoded = await verifyFirebaseIdToken(idToken);
-        ownerId = decoded.uid;
-      } catch (err: any) {
-        console.error('AUTH_ERROR: ID token verification failed', err?.message || err);
-        throw new PipelineError(
-          "AUTH_VERIFICATION",
-          `Invalid ID token: ${err.message || String(err)}`,
-          "Your session token has expired or is invalid. Please sign out and sign in again."
-        );
-      }
+      // requireFirebaseAuth middleware has already verified the token
+      // and attached the uid/token before this handler runs.
+      const ownerId = req.ownerId as string;
+      const idToken = req.idToken as string;
 
       // Extract text from PDF buffer
       console.log('PDF_EXTRACTION_START: using pdf-parse');


### PR DESCRIPTION
Fixes #29

## Problem
Authentication was checked with an inline `if` block written directly into the `/api/analyze` handler. That protects the one route it happens to be pasted into, but nothing stops a future `/api/*` route from being added without copying the same check — it would be publicly reachable and able to trigger paid Hugging Face inference calls with no attribution.

Additionally, unauthenticated/invalid-token requests were thrown as a `PipelineError` and caught by the route's generic handler, which returned **500** instead of the correct **401**.

## Fix
- Extracted the check into a `requireFirebaseAuth` Express middleware
- Applied it via `app.use("/api", requireFirebaseAuth)`, registered **after** `/api/health` (which stays public) and **before** every other route — so any route added later is authenticated by default, not by convention
- Verified uid and raw ID token are attached to `req.ownerId` / `req.idToken` so `/api/analyze` no longer re-parses the header itself
- Missing/invalid tokens now correctly return `401` instead of falling through to a `500`

## Verification
```bash
# No token -> 401 (was 500)
curl -i -X POST http://localhost:3001/api/analyze -F "file=@test.pdf"

# Health check still public
curl -i http://localhost:3001/api/health
```

`npx tsc --noEmit` (project's lint command) shows no new type errors from this change — the single pre-existing `pdf-parse` import error on `main` is unrelated and tracked separately in #26.