### PR TITLE
fix: update pdf-parse usage to installed v2 class-based API

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { createServer as createViteServer } from "vite";
 import { InferenceClient } from "@huggingface/inference";
 import multer from "multer";
-import pdf from "pdf-parse";
+import { PDFParse } from "pdf-parse";
 import * as dotenv from "dotenv";
 import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
@@ -345,16 +345,21 @@ async function startServer() {
       // Extract text from PDF buffer
       console.log('PDF_EXTRACTION_START: using pdf-parse');
       let extractedText = '';
-      try {
-        const parsed = await pdf(file.buffer);
-        extractedText = (parsed?.text || "").trim();
-      } catch (extractError: any) {
-        console.error('PDF_EXTRACTION_ERROR: Failed to parse PDF', extractError?.message || extractError);
-        throw new PipelineError(
-          "PDF_EXTRACTION",
-          `Failed to parse PDF: ${extractError?.message || 'Unknown error'}`,
-          "Ensure the uploaded file is a valid, uncorrupted, and unencrypted PDF."
-        );
+      {
+        const parser = new PDFParse({ data: file.buffer });
+        try {
+          const parsed = await parser.getText();
+          extractedText = (parsed?.text || "").trim();
+        } catch (extractError: any) {
+          console.error('PDF_EXTRACTION_ERROR: Failed to parse PDF', extractError?.message || extractError);
+          throw new PipelineError(
+            "PDF_EXTRACTION",
+            `Failed to parse PDF: ${extractError?.message || 'Unknown error'}`,
+            "Ensure the uploaded file is a valid, uncorrupted, and unencrypted PDF."
+          );
+        } finally {
+          await parser.destroy();
+        }
       }
 
       console.log(`PDF_EXTRACTION_COMPLETE: extracted ${extractedText.length} characters`);


### PR DESCRIPTION
Fixes #26

## Problem
`npm run lint` (`tsc --noEmit`) currently fails on `main`:

```
server.ts(6,8): error TS1192: Module '.../pdf-parse/dist/pdf-parse/esm/index' has no default export.
```

`package.json` pins `pdf-parse@^2.4.5`. That major version replaced the old `module.exports = function pdf(buffer)` shape with a named `PDFParse` class (`new PDFParse({ data }).getText()`). `server.ts` still does `import pdf from "pdf-parse"` and calls it as `pdf(file.buffer)` — the old API. This isn't just a type error: since there's no default export and nothing callable at runtime either, **PDF ingestion (the app's core feature) is completely broken**, not just failing to compile.

## Fix
- `import { PDFParse } from "pdf-parse"`
- Instantiate `new PDFParse({ data: file.buffer })`, call `.getText()` for the extracted text
- `await parser.destroy()` in a `finally` block so the worker is released whether extraction succeeds or throws

## Verification
```
npx tsc --noEmit
# (no output — passes cleanly, was previously exit code 2)
```

Also manually exercised the exact installed `pdf-parse` version against a generated test PDF outside the repo's git tree to confirm the new API actually extracts text at runtime (not just type-checks):
```
EXTRACTED_TEXT: "Hello FinSight AI Test Document\n\n-- 1 of 1 --\n\n"
```

No other behavior changes — error handling, logging, and the surrounding pipeline are untouched.