### PR TITLE
fix: add explicit CORS origin allowlist instead of implicit default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vitejs/plugin-react": "^5.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cors": "^2.8.6",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
         "express": "^4.22.2",
@@ -36,6 +37,7 @@
         "vite": "^6.2.3"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.21",
         "@types/multer": "^2.1.0",
         "@types/node": "^22.14.0",
@@ -2748,6 +2750,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3640,6 +3652,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/css-line-break": {
@@ -6550,6 +6579,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-hash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cors": "^2.8.6",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "express": "^4.22.2",
@@ -39,6 +40,7 @@
     "vite": "^6.2.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.14.0",

--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import pdf from "pdf-parse";
 import * as dotenv from "dotenv";
 import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
+import cors from "cors";
 
 dotenv.config({ quiet: true });
 
@@ -33,6 +34,17 @@ const firestoreDatabaseId = String(process.env.FIREBASE_FIRESTORE_DATABASE_ID ||
 const firestoreBaseUrl = firebaseProjectId
   ? `https://firestore.googleapis.com/v1/projects/${firebaseProjectId}/databases/${encodeURIComponent(firestoreDatabaseId)}/documents`
   : "";
+
+// Explicit CORS allowlist. In production, only APP_URL (the deployed
+// frontend origin) may call this API with credentials. Local Vite dev
+// ports are allowed so `npm run dev` keeps working out of the box.
+const allowedOrigins = new Set(
+  [
+    process.env.APP_URL,
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+  ].filter((origin): origin is string => Boolean(origin) && origin !== "MY_APP_URL")
+);
 
 type VerifiedUser = {
   uid: string;
@@ -267,6 +279,24 @@ async function startServer() {
       }
     }
   }
+
+  // Explicit CORS policy — only the deployed frontend origin (and local
+  // dev ports) may call this API, instead of the implicit wildcard that
+  // cors() with no options would produce.
+  app.use(
+    cors({
+      origin(origin, callback) {
+        // Allow same-origin/non-browser requests (no Origin header).
+        if (!origin || allowedOrigins.has(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error(`Origin ${origin} is not allowed by CORS policy`));
+      },
+      credentials: true,
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: ["Authorization", "Content-Type"],
+    })
+  );
 
   app.use(express.json());
 


### PR DESCRIPTION
Fixes #30

## Context
`server.ts` currently has **no CORS configuration at all** — not even `cors()` with defaults. In this project's normal deployment (a single Express process serves the Vite frontend and the `/api/*` routes on one origin) that isn't exploitable today. But `.env.example` already anticipates a split deployment: `APP_URL` is documented as *"the URL where this applet is hosted... used for self-referential links, OAuth callbacks, and API endpoints"* for Cloud Run. Adding CORS reactively, under time pressure, once a split frontend actually needs it is exactly how projects end up reaching for `cors()` with no `origin` option (the wildcard the issue warns about) as a quick unblock.

## Fix
Adds an explicit allowlist now, before it's forced on anyone:
- `APP_URL` (the deployed frontend origin) + `localhost:5173`/`127.0.0.1:5173` for `npm run dev`
- `credentials: true` (the API is called with a Firebase `Authorization` header)
- `methods`/`allowedHeaders` restricted to what `/api/*` actually uses

## Verification
```
npx tsc --noEmit
```
No new errors (the one pre-existing `pdf-parse` error on `main` is unrelated — fixed in #26 / PR #39).

Also booted an isolated Express instance with the identical `cors()` config to confirm behavior at runtime:
```
--- allowed origin ---
Access-Control-Allow-Origin: http://localhost:5173
Access-Control-Allow-Credentials: true

--- disallowed origin ---
(no Access-Control-Allow-Origin header — request rejected)
```