### PR TITLE
fix: reject non-PDF uploads before buffering, handle oversized files cleanly

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -13,9 +13,19 @@ dotenv.config({ quiet: true });
 console.log("HF_KEY_EXISTS:", !!process.env.HUGGINGFACE_API_KEY);
 
 
+const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
+
 const upload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 20 * 1024 * 1024 },
+  limits: { fileSize: MAX_UPLOAD_BYTES, files: 1 },
+  // Reject non-PDF uploads before multer buffers the file into memory,
+  // instead of buffering it fully and only checking mimetype afterwards.
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype !== "application/pdf") {
+      return cb(new Error("Only PDF files are accepted"));
+    }
+    cb(null, true);
+  },
 });
 
 type AnalysisResponse = {
@@ -626,6 +636,35 @@ CRITICAL RULES:
         }
       });
     }
+  });
+
+  // Catches errors from the upload.single("file") middleware above —
+  // oversized files (LIMIT_FILE_SIZE) and non-PDF rejections from
+  // fileFilter — and returns clean JSON instead of falling through to
+  // Express's default HTML error page.
+  app.use((err: any, req: any, res: any, next: any) => {
+    if (err instanceof multer.MulterError) {
+      const status = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;
+      return res.status(status).json({
+        error: {
+          stage: "PDF_INGESTION",
+          reason: err.message,
+          recommendation: err.code === "LIMIT_FILE_SIZE"
+            ? `File exceeds the ${MAX_UPLOAD_BYTES / (1024 * 1024)}MB upload limit.`
+            : "Please check the uploaded file and try again.",
+        },
+      });
+    }
+    if (err && err.message === "Only PDF files are accepted") {
+      return res.status(400).json({
+        error: {
+          stage: "PDF_INGESTION",
+          reason: err.message,
+          recommendation: "Only PDF files are supported. Please convert your file to PDF format.",
+        },
+      });
+    }
+    next(err);
   });
 
   // Vite middleware for development


### PR DESCRIPTION
Fixes #27

## Context
`main` already sets multer's `fileSize` limit to 20MB, which substantially mitigates the unbounded-memory scenario the issue describes. Two real gaps remained on top of that:

1. The mimetype check ran **after** multer had already buffered the entire upload into memory — a non-PDF file up to 20MB was fully read before being rejected.
2. There was no error-handling middleware for multer. A file over the 20MB limit throws a `MulterError` that fell through to Express's default HTML error page instead of the API's normal JSON error shape — the frontend had no clean signal to show "file too large".

## Fix
- Move the PDF-only check into multer's `fileFilter`, rejecting non-PDF uploads before their bytes are read into memory
- Add `files: 1` to the upload limits (defense in depth on a single-file endpoint)
- Add dedicated error-handling middleware: `413` for `LIMIT_FILE_SIZE`, `400` for other multer/fileFilter rejections, both in the same `{ error: { stage, reason, recommendation } }` shape the rest of the API uses

## Verification
Ran an isolated Express instance with the identical multer config:
```
--- oversized file vs test limit ---
HTTP/1.1 413 Payload Too Large   (JSON body)

--- non-PDF upload ---
HTTP/1.1 400 Bad Request         (JSON body, rejected by fileFilter)

--- valid small PDF ---
HTTP/1.1 200 OK
```

`npx tsc --noEmit`: no new errors (the pre-existing `pdf-parse` error on `main` is unrelated, fixed in #26 / PR #39).