### PR TITLE
feat(api): add timeout and AbortController support to apiFetch

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,22 +3,68 @@
  */
 
 // Save original fetch
-const originalFetch = typeof window !== 'undefined' ? window.fetch.bind(window) : null;
+const originalFetch =
+  typeof window !== 'undefined' ? window.fetch.bind(window) : null;
+
+interface ApiFetchOptions {
+  timeout?: number;
+}
 
 /**
  * Standardized fetch wrapper that uses the browser's original fetch.
  * This avoids issues with getter-only fetch properties on the window object.
  */
-export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  // If we are in the browser and have the original fetch bound
-  if (originalFetch) {
-    return originalFetch(input, init);
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: ApiFetchOptions
+): Promise<Response> {
+  const timeout = options?.timeout ?? 10000;
+
+  const fetchImpl =
+    originalFetch ?? (typeof fetch !== 'undefined' ? fetch : null);
+
+  if (!fetchImpl) {
+    throw new Error('Fetch API is not available in this environment');
   }
-  
-  // Fallback to global fetch (Node or if window.fetch was already available)
-  if (typeof fetch !== 'undefined') {
-    return fetch(input, init);
+
+  // Create a new controller for this request
+  const controller = new AbortController();
+
+  // Respect an existing AbortSignal provided by the caller
+  if (init?.signal) {
+    if (init.signal.aborted) {
+      controller.abort(init.signal.reason);
+    } else {
+      init.signal.addEventListener(
+        'abort',
+        () => controller.abort(init.signal?.reason),
+        { once: true }
+      );
+    }
   }
-  
-  throw new Error('Fetch API is not available in this environment');
+
+  // Abort the request after the timeout
+  const timeoutId = setTimeout(() => {
+    controller.abort(new Error(`Request timed out after ${timeout}ms`));
+  }, timeout);
+
+  try {
+    return await fetchImpl(input, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (
+      error instanceof DOMException &&
+      error.name === 'AbortError' &&
+      !init?.signal?.aborted
+    ) {
+      throw new Error(`Request timed out after ${timeout}ms`);
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }


### PR DESCRIPTION
## Summary

This PR enhances the `apiFetch` wrapper by adding configurable request timeout support using `AbortController` while preserving compatibility with existing callers.

## Changes

* Added optional timeout configuration via `ApiFetchOptions`.
* Introduced an internal `AbortController` for each request.
* Automatically aborts requests that exceed the configured timeout.
* Preserved compatibility with existing caller-provided `AbortSignal`s.
* Ensured timeout timers are cleared after request completion.
* Added descriptive timeout errors instead of relying solely on generic `AbortError`s.

## Why

Previously, `apiFetch` simply forwarded requests to the browser's native `fetch`, allowing requests to remain pending indefinitely if the server became unresponsive or the network stalled.

This change improves application reliability by providing standardized timeout handling while maintaining backward compatibility.

## Testing

* Verified existing `apiFetch` usage remains unchanged.
* Verified requests complete successfully before the timeout.
* Verified requests are aborted when the timeout is exceeded.
* Verified external `AbortSignal`s continue to function as expected.

Fixes #22 
