### PR TITLE
fix: increase timeout for PDF analysis requests

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -79,6 +79,9 @@ export function FileUpload({ user, onComplete, onCancel }: any) {
         method: 'POST',
         body: formData,
         headers,
+      },
+      {
+        timeout: 180000,
       });
 
       if (!analysisRes.ok) {


### PR DESCRIPTION
## Summary

Increase the timeout for `/api/analyze` requests to prevent long-running PDF analysis operations from being cancelled after the default 10-second limit.

## Related Issue

Closes #55

## Changes Made

* Added a dedicated timeout for `/api/analyze` requests
* Set the timeout to 180 seconds (3 minutes)
* Kept the default timeout unchanged for all other API requests

## Testing

* Verified the analysis request uses the custom timeout
* Verified no changes were made to other API calls
* Verified existing functionality remains unchanged
