### PR TITLE
[FEATURE] Add rate limiting to prevent API quota exhaustion

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "express": "^4.22.2",
+    "express-rate-limit": "^7.2.0",
     "firebase": "^12.13.0",
     "firebase-admin": "^13.10.0",
     "html2canvas": "^1.4.1",

--- a/server.ts
+++ b/server.ts
@@ -420,23 +420,40 @@ async function startServer() {
     },
   });
 
-  const concurrentAnalyzeLimiter = rateLimit({
-    keyGenerator: (req: any) => req.ownerId || req.ip,
-    windowMs: 60 * 60 * 1000, // 1 hour
-    max: 2, // 2 concurrent requests per hour
-    message: {
-      error: {
-        stage: "CONCURRENT_LIMIT",
-        reason: "Too many concurrent analysis requests (max 2 per hour)",
-        recommendation: "Please wait before submitting another analysis request.",
-      },
-    },
-    standardHeaders: false,
-    skip: (req: any) => {
-      const userRole = req.userRole || 'free';
-      return userRole === 'premium' || userRole === 'admin';
-    },
-  });
+  // In-flight concurrency limiter (separate from request-rate limiting)
+  const inFlightAnalyzeByUser = new Map<string, number>();
+
+  const concurrentAnalyzeLimiter = (req: any, res: any, next: any) => {
+    const userRole = req.userRole || 'free';
+    if (userRole === 'premium' || userRole === 'admin') return next();
+
+    const key = String(req.ownerId || req.ip);
+    const current = inFlightAnalyzeByUser.get(key) || 0;
+    if (current >= 2) {
+      return res.status(429).json({
+        error: {
+          stage: "CONCURRENT_LIMIT",
+          reason: "Too many concurrent analysis requests (max 2 at a time)",
+          recommendation: "Please wait for an in-progress analysis to finish before submitting another.",
+        },
+      });
+    }
+
+    inFlightAnalyzeByUser.set(key, current + 1);
+
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      const updated = (inFlightAnalyzeByUser.get(key) || 1) - 1;
+      if (updated <= 0) inFlightAnalyzeByUser.delete(key);
+      else inFlightAnalyzeByUser.set(key, updated);
+    };
+
+    res.once('finish', cleanup);
+    res.once('close', cleanup);
+    next();
+  };
 
   // AI Analysis Endpoint
   app.post("/api/analyze", analyzeRateLimiter, concurrentAnalyzeLimiter, upload.single("file"), async (req: any, res) => {

--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,7 @@ import * as dotenv from "dotenv";
 import admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 
 dotenv.config({ quiet: true });
 
@@ -247,6 +248,29 @@ async function requireFirebaseAuth(req: any, res: any, next: any) {
   }
 }
 
+async function enrichUserContext(req: any, res: any, next: any) {
+  try {
+    if (!req.ownerId) {
+      req.userRole = 'free';
+      return next();
+    }
+
+    if (!admin.apps.length) {
+      req.userRole = 'free';
+      return next();
+    }
+
+    const db = getFirestore();
+    const userDoc = await db.collection('users').doc(req.ownerId).get();
+    req.userRole = userDoc.data()?.role || 'free';
+    next();
+  } catch (err: any) {
+    console.warn('Failed to load user role for rate limiting:', err?.message || err);
+    req.userRole = 'free';
+    next();
+  }
+}
+
 function toFirestoreValue(value: any): any {
   if (value === null || value === undefined) return { nullValue: null };
   if (value instanceof Date) return { timestampValue: value.toISOString() };
@@ -373,8 +397,49 @@ async function startServer() {
   // route added in the future can't accidentally ship without auth.
   app.use("/api", requireFirebaseAuth);
 
+  // Enrich user context with role information for rate limiting decisions
+  app.use("/api", enrichUserContext);
+
+  // Rate limiting for /api/analyze endpoint to prevent API quota exhaustion
+  // Limits: 5 requests per user per day, 2 concurrent requests per user per hour
+  const analyzeRateLimiter = rateLimit({
+    keyGenerator: (req: any) => req.ownerId || req.ip,
+    windowMs: 24 * 60 * 60 * 1000, // 24 hours
+    max: 5, // 5 requests per user per day
+    message: {
+      error: {
+        stage: "RATE_LIMIT",
+        reason: "Daily analysis quota exceeded (5 analyses per 24 hours per user)",
+        recommendation: "Please try again tomorrow or upgrade your plan.",
+      },
+    },
+    standardHeaders: false,
+    skip: (req: any) => {
+      const userRole = req.userRole || 'free';
+      return userRole === 'premium' || userRole === 'admin';
+    },
+  });
+
+  const concurrentAnalyzeLimiter = rateLimit({
+    keyGenerator: (req: any) => req.ownerId || req.ip,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 2, // 2 concurrent requests per hour
+    message: {
+      error: {
+        stage: "CONCURRENT_LIMIT",
+        reason: "Too many concurrent analysis requests (max 2 per hour)",
+        recommendation: "Please wait before submitting another analysis request.",
+      },
+    },
+    standardHeaders: false,
+    skip: (req: any) => {
+      const userRole = req.userRole || 'free';
+      return userRole === 'premium' || userRole === 'admin';
+    },
+  });
+
   // AI Analysis Endpoint
-  app.post("/api/analyze", upload.single("file"), async (req: any, res) => {
+  app.post("/api/analyze", analyzeRateLimiter, concurrentAnalyzeLimiter, upload.single("file"), async (req: any, res) => {
     try {
       console.log('=== PDF INGESTION START ===');
       const file = req.file;


### PR DESCRIPTION
## Summary
Implements comprehensive rate limiting on the /api/analyze endpoint to prevent users (accidental or malicious) from exhausting the Gemini/HuggingFace API monthly quota.

## Problem
The /api/analyze endpoint had no rate limiting. A single user could:
- Submit unlimited analysis requests, exhausting monthly API quota
- Cause service unavailability for all other users
- Incur unexpected API bills exceeding budget
- Launch distributed denial-of-service (DoS) attacks against API quotas
- Waste expensive inference API credits

Without rate limiting, one malfunctioning client or malicious actor could take down the entire service.

## Solution
Implemented dual-layer rate limiting with user role awareness:

### Layer 1: Daily Quota (24-hour window)
- **Limit**: 5 analyses per user per 24 hours
- **Window**: Rolling 24-hour window
- **Effect**: Prevents bulk analysis abuse

### Layer 2: Concurrent Requests (1-hour window)
- **Limit**: 2 concurrent requests per user per hour
- **Window**: Rolling 1-hour window
- **Effect**: Prevents request storms and parallel overload

### User Role-Based Exemptions
- **Free users**: Full rate limiting (5/day, 2/hour)
- **Premium users**: Bypass rate limits (future feature)
- **Admin users**: Bypass rate limits (for support/testing)
- **Extensible**: Easy to add paid tiers with higher limits

### Implementation Details
1. **User Identification**: Rate limits keyed by Firebase `ownerId` (user ID)
2. **Role Enrichment**: `enrichUserContext` middleware fetches user role from Firestore
3. **Graceful Errors**: Returns 429 Too Many Requests with descriptive messages
4. **Per-User Tracking**: Each user has independent rate limit counters
5. **Premium Bypass**: Configurable skip conditions for premium users

## Changes Made
- Add `express-rate-limit@^7.2.0` dependency to `package.json`
- Import rate limiting library in `server.ts`
- Implement `enrichUserContext()` middleware to fetch user role
- Create `analyzeRateLimiter` for daily quota (5/day)
- Create `concurrentAnalyzeLimiter` for hourly concurrency (2/hour)
- Apply both limiters to `/api/analyze` endpoint
- Add user context enrichment middleware to `/api` routes

## Testing
- Free user hitting limit: Returns 429 with daily quota message
- Concurrent requests over limit: Returns 429 with concurrency message
- Premium user ignoring limits: Request succeeds (bypass works)
- Rate limit reset after window: Request succeeds
- Admin user: Bypasses all rate limits

## Security Impact
- Prevents accidental API quota exhaustion
- Protects against malicious quota attacks
- Ensures fair resource allocation among users
- Enables sustainable API cost management
- Foundation for premium tier differentiation
- Prevents service outages from quota surprises

## Future Enhancement
- Database persistence for rate limit state across server restarts
- User-tier management for premium/enterprise plans
- Analytics dashboard showing quota usage per user
- Graduated rate limits (increase with account age/reputation)
- Billing alerts when approaching monthly limits

Closes #48