### PR TITLE
fix: update parent document in Firestore REST fallback

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -332,6 +332,43 @@ async function createFirestoreDocumentViaRest(collectionPath: string, data: Reco
   return name.split("/").pop() || "";
 }
 
+async function updateFirestoreDocumentViaRest(
+  documentPath: string,
+  data: Record<string, any>,
+  idToken: string
+): Promise<void> {
+  if (!firestoreBaseUrl) {
+    throw new Error("FIREBASE_PROJECT_ID is not configured");
+  }
+
+  const fieldMask = Object.keys(data)
+    .map((key) => `updateMask.fieldPaths=${encodeURIComponent(key)}`)
+    .join("&");
+
+  const response = await fetch(
+    `${firestoreBaseUrl}/${documentPath}?${fieldMask}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        fields: toFirestoreFields(data),
+      }),
+    }
+  );
+
+  const body: any = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(
+      body?.error?.message ||
+        `Firestore REST update failed with status ${response.status}`
+    );
+  }
+}
+
 async function startServer() {
   const app = express();
   const PORT = Number(process.env.PORT) || 3001;
@@ -787,6 +824,16 @@ CRITICAL RULES:
             idToken
           );
           console.log(`FIRESTORE_ANALYSIS_CREATED_REST: analysisId=${analysisId}`);
+
+          await updateFirestoreDocumentViaRest(
+            `documents/${documentId}`,
+            {
+              latestAnalysis: analysisDoc,
+              updatedAt: now,
+            },
+            idToken
+          );
+          console.log(`FIRESTORE_PARENT_UPDATED_REST: latestAnalysis snapshot stored`);
         } catch (restError: any) {
           console.error('FIRESTORE_REST_WRITE_FAILED:', restError?.message || restError);
           throw new PipelineError(


### PR DESCRIPTION
## Summary

Fixes #95 by updating the parent Firestore document when the application falls back to Firestore REST API writes.

Previously, the REST fallback flow only created analysis records in the `analyses` subcollection and did not update the parent document with the latest analysis snapshot. This caused inconsistent data compared to the Firebase Admin SDK path.

## Changes

* Added a Firestore REST document update helper
* Updated the parent document after creating an analysis record via REST
* Stored `latestAnalysis` on the parent document
* Updated the `updatedAt` timestamp
* Added logging for successful parent document updates

## Result

The Firestore REST fallback path now mirrors the Firebase Admin SDK behavior, ensuring consistent document structures and reducing the need for additional Firestore reads.

Closes #95.
