### PR TITLE
feat : added light dark theme toggle support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,6 +189,8 @@ import { HealthScoreDashboard } from './components/health/HealthScoreDashboard';
 import { ChatAssistant } from './components/chat/ChatAssistant';
 import { ForecastComparison } from './components/forecast/ForecastComparison';
 import { PortfolioTracker } from './components/portfolio/PortfolioTracker';
+import { ThemeProvider } from '@/src/lib/themeContext';
+import { ThemeToggle } from '@/src/components/ThemeToggle';
 
 export default function App() {
   const [user, setUser] = useState<User | null>(null);
@@ -769,6 +771,7 @@ export default function App() {
   }
 
   return (
+    <ThemeProvider>
     <div className="flex h-screen w-full bg-[#0a0c10] text-slate-300 font-sans overflow-hidden">
       {/* Sidebar */}
       <aside className="hidden w-64 border-r border-slate-800 flex flex-col md:flex">
@@ -923,6 +926,7 @@ export default function App() {
             >
               <LogOut size={18} />
             </Button>
+            <ThemeToggle />
           </div>
         </div>
       </aside>
@@ -1253,6 +1257,7 @@ export default function App() {
       )}
       <Toaster position="bottom-right" richColors />
     </div>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/src/lib/themeContext";
+import { Button } from "@/src/components/ui/button";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className="h-9 w-9 rounded-lg text-slate-400 hover:text-white hover:bg-slate-800"
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {theme === "dark" ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -56,7 +56,44 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+/* Light theme variables — used when html has no .dark class */
 :root {
+  --background: #ffffff;
+  --foreground: #0f172a;
+  --card: #f8fafc;
+  --card-foreground: #0f172a;
+  --popover: #ffffff;
+  --popover-foreground: #0f172a;
+  --primary: #4f46e5;
+  --primary-foreground: #ffffff;
+  --secondary: #f1f5f9;
+  --secondary-foreground: #0f172a;
+  --muted: #f1f5f9;
+  --muted-foreground: #64748b;
+  --accent: #f1f5f9;
+  --accent-foreground: #0f172a;
+  --destructive: #ef4444;
+  --border: #e2e8f0;
+  --input: #e2e8f0;
+  --ring: #4f46e5;
+  --radius: 0.5rem;
+
+  /* Enterprise Semantic Colors */
+  --success: #10b981;
+  --warning: #f59e0b;
+  --critical: #ef4444;
+  --info: #3b82f6;
+
+  /* Charts */
+  --chart-1: #4f46e5;
+  --chart-2: #10b981;
+  --chart-3: #f59e0b;
+  --chart-4: #ef4444;
+  --chart-5: #8b5cf6;
+}
+
+/* Dark theme variables — used when html has .dark class */
+.dark {
   --background: #0a0c10;
   --foreground: #f8fafc;
   --card: #0f1219;

--- a/src/lib/themeContext.tsx
+++ b/src/lib/themeContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+type Theme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === "undefined") return "dark";
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return ctx;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,14 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+// Apply initial dark class before render to prevent flash
+const storedTheme = localStorage.getItem("theme");
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+const isDark = storedTheme === "dark" || (!storedTheme && prefersDark);
+if (isDark) {
+  document.documentElement.classList.add("dark");
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary of What Has Been Done

Added a complete light/dark theme toggle system with localStorage persistence and system-preference detection.

## Changes Made

1. **src/lib/themeContext.tsx** (new): Created `ThemeProvider` and `useTheme` hook exposing `theme` (`dark`|`light`) and `toggleTheme`.
2. **src/components/ThemeToggle.tsx** (new): Added a toggle button with sun/moon icon that calls `toggleTheme`.
3. **src/App.tsx**: Imported and wrapped the app in `<ThemeProvider>`, added `<ThemeToggle />` button in the sidebar user section.
4. **src/main.tsx**: Added initial dark class application on mount to prevent flash before React hydrates.
5. **src/index.css**: Split CSS variables into `:root` (light theme) and `.dark` class scope (dark theme), so Tailwind dark: variants work automatically.

## Impact it Made

- Users can now switch between light and dark themes with a single click.
- Theme preference is persisted in localStorage across sessions.
- System preference is respected on first visit.
- All existing dark-theme components continue to work without modification.

Closes #109

## Note: Please assign this PR to the `tmdeveloper007` account.