### PR TITLE
fix : exported getUserFriendlyError helper from firebase.ts for consistent error UX

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -37,7 +37,7 @@ export enum OperationType {
   BUDGET = "budget",
 }
 
-interface FirestoreErrorInfo {
+export interface FirestoreErrorInfo {
   error: string;
   code?: string;
   operationType: OperationType;
@@ -53,6 +53,71 @@ interface FirestoreErrorInfo {
       email?: string | null;
     }[];
   };
+}
+
+export interface UserFriendlyError {
+  title: string;
+  description: string;
+}
+
+const ERROR_MESSAGES: Record<string, UserFriendlyError> = {
+  "permission-denied": {
+    title: "Access denied",
+    description:
+      "You do not have permission to view this data. Please sign in or contact support.",
+  },
+  "not-found": {
+    title: "Data not found",
+    description: "The requested record could not be found.",
+  },
+  "already-exists": {
+    title: "Duplicate entry",
+    description: "A record with this identifier already exists.",
+  },
+  "resource-exhausted": {
+    title: "Quota exceeded",
+    description:
+      "Firestore read quota has been reached. Please try again later.",
+  },
+  "unauthenticated": {
+    title: "Not signed in",
+    description: "Please sign in to continue.",
+  },
+  "cancelled": {
+    title: "Operation cancelled",
+    description: "The requested operation was cancelled. Please try again.",
+  },
+  "deadline-exceeded": {
+    title: "Request timed out",
+    description:
+      "The operation took too long. Please check your connection and try again.",
+  },
+  "internal": {
+    title: "Internal error",
+    description:
+      "An internal error occurred. Please try again in a few minutes.",
+  },
+  "unknown": {
+    title: "Unknown error",
+    description: "An unexpected error occurred. Please try again.",
+  },
+};
+
+const GENERIC_ERROR: UserFriendlyError = {
+  title: "Something went wrong",
+  description: "An error occurred while accessing data. Please try again.",
+};
+
+/**
+ * Translates a Firebase error code into a user-friendly title and description.
+ * Components can use this to display consistent, readable error messages
+ * instead of raw Firebase error messages.
+ */
+export function getUserFriendlyError(error: unknown): UserFriendlyError {
+  if (!(error instanceof FirebaseError)) {
+    return GENERIC_ERROR;
+  }
+  return ERROR_MESSAGES[error.code] ?? GENERIC_ERROR;
 }
 
 export function handleFirestoreError(


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `getUserFriendlyError` helper function and `UserFriendlyError` / `FirestoreErrorInfo` types to `src/lib/firebase.ts` so all Firestore-using components can translate error codes into user-facing messages consistently.

## Changes Made

1. **Exported `FirestoreErrorInfo` type** for TypeScript consumers.
2. **Added `UserFriendlyError` interface**: `{ title: string; description: string }`.
3. **Added `getUserFriendlyError(error: unknown): UserFriendlyError`**: Maps Firebase error codes to human-readable `{ title, description }` pairs:
   - `permission-denied`: "Access denied" / "You do not have permission to view this data..."
   - `not-found`: "Data not found" / "The requested record could not be found."
   - `already-exists`: "Duplicate entry" / "A record with this identifier already exists."
   - `resource-exhausted`: "Quota exceeded" / "Firestore read quota has been reached..."
   - `unauthenticated`: "Not signed in" / "Please sign in to continue."
   - `cancelled`: "Operation cancelled"
   - `deadline-exceeded`: "Request timed out"
   - `internal` / `unknown`: generic fallback
4. **Returns generic fallback** for any unrecognized error code.
5. **Exported both** so other modules can import and use them.

## Impact it Made

- Consistent, user-friendly error messages across all Firestore operations.
- Developers can import and use `getUserFriendlyError` instead of raw Firebase error messages.
- Improved UX when Firestore operations fail.

Closes #110

## Note: please assign this PR to the `tmdeveloper007` account.