### PR TITLE
fix : add missing CashFlowDashboard import in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,7 @@ import { ChallengesDashboard } from './components/challenges/ChallengesDashboard
 import { TaxEstimation } from './components/tax/TaxEstimation';
 import { EmergencyFundPlanner } from './components/emergency/EmergencyFundPlanner';
 import { HealthScoreDashboard } from './components/health/HealthScoreDashboard';
+import { CashFlowDashboard } from './components/cashflow/CashFlowDashboard';
 import { ChatAssistant } from './components/chat/ChatAssistant';
 import { ForecastComparison } from './components/forecast/ForecastComparison';
 import { PortfolioTracker } from './components/portfolio/PortfolioTracker';


### PR DESCRIPTION
## Summary of What Has Been Done

Added the missing import statement for CashFlowDashboard component in App.tsx. The component is used in the JSX (around line 1115) when the 'cashflow' tab is active, but the import was never added to the imports section, causing a potential undefined component error at runtime.

## Changes Made

- src/App.tsx: Added `import { CashFlowDashboard } from './components/cashflow/CashFlowDashboard';` to the component imports section

## Impact it Made

- Fixes incorrect behavior / documentation inconsistency
- Prevents potential runtime errors
- Improves code quality and accuracy

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #117
