### PR TITLE
fix : add missing Wallet icon import and remove duplicate NavItem in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import {
   Target,
   Bell,
   Trophy,
+  Wallet,
   Calculator,
   RefreshCw,
   HeartPulse,
@@ -905,12 +906,6 @@ export default function App() {
             label="Trends" 
             active={activeTab === 'trends'} 
             onClick={() => setActiveTab('trends')} 
-          />
-          <NavItem 
-            icon={<Clock size={20} />} 
-            label="AI Intelligence" 
-            active={activeTab === 'history'} 
-            onClick={() => setActiveTab('history')} 
           />
           <NavItem 
             icon={<Globe size={20} />} 


### PR DESCRIPTION
## Summary of What Has Been Done

Two fixes in App.tsx: (1) Added missing Wallet icon import from lucide-react - the icon was used for the 'Budgets' nav item but not imported. (2) Removed duplicate 'AI Intelligence' NavItem entry in the sidebar navigation - two identical entries existed side-by-side causing a React key conflict warning.

## Changes Made

- src/App.tsx: Added `Wallet` to lucide-react icon imports
- src/App.tsx: Removed duplicate 'AI Intelligence' NavItem block from sidebar

## Impact it Made

- Fixes incorrect behavior / documentation inconsistency
- Prevents potential runtime errors
- Improves code quality and accuracy

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #116
