### PR TITLE
fix : correct AI provider documentation in README from Gemini to Hugging Face Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The platform combines modern web technologies with generative AI to transform co
 
 ### 🤖 AI-Powered Financial Analysis
 
-- Automated document understanding using Google Gemini API
+- Automated document understanding using Hugging Face Inference (Llama-3.3-70B-Instruct)
 - Financial metric extraction from unstructured documents
 - AI-generated executive summaries
 - Intelligent insight generation
@@ -55,7 +55,7 @@ Frontend (React + TypeScript + TailwindCSS)
  |
 Backend API (Node.js + Express)
  |
-AI Processing Layer (Google Gemini API)
+AI Processing Layer (Hugging Face Inference)
  |
 Firebase Services
  ├── Authentication
@@ -81,7 +81,7 @@ Firebase Services
 
 ## AI Integration
 
-- Google Gemini API
+- Hugging Face Inference API (Llama-3.3-70B-Instruct)
 
 ## Database & Cloud Infrastructure
 
@@ -104,7 +104,7 @@ Before running the project, make sure you have:
 
 - Node.js 18+
 - Firebase Project
-- Google Gemini API Key
+- Hugging Face Inference API Key
 - Docker (optional)
 
 ---
@@ -130,7 +130,7 @@ npm install
 Create a `.env` file in the project root and add:
 
 ```env
-GEMINI_API_KEY=your_gemini_api_key
+HUGGINGFACE_API_KEY=your_huggingface_inference_api_key
 
 FIREBASE_API_KEY=your_firebase_api_key
 FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com


### PR DESCRIPTION
## Summary of What Has Been Done

Updated README.md to correctly reflect the AI provider used in production. The README incorrectly stated 'Google Gemini API' everywhere, but server.ts actually uses Hugging Face Inference API with Llama-3.3-70B-Instruct. Updated 5 locations: Key Features, System Architecture diagram, Tech Stack, Prerequisites, and .env example.

## Changes Made

- README.md: Changed 'Google Gemini API' to 'Hugging Face Inference (Llama-3.3-70B-Instruct)' in Key Features
- README.md: Updated System Architecture AI layer label
- README.md: Updated Tech Stack AI Integration section
- README.md: Updated Prerequisites from 'Google Gemini API Key' to 'Hugging Face Inference API Key'
- README.md: Changed GEMINI_API_KEY to HUGGINGFACE_API_KEY in .env example

## Impact it Made

- Fixes incorrect behavior / documentation inconsistency
- Prevents potential runtime errors
- Improves code quality and accuracy

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #123
