### PR TITLE
fix : add fallback query with date filter in cashflowUtils fetchUserTransactions

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -95,6 +95,39 @@ export async function fetchUserTransactions(
       };
     });
   } catch (error) {
+    if ((error as any)?.code === "failed-precondition") {
+      const q = query(
+        collection(db, "transactions"),
+        where("userId", "==", userId),
+        where("date", ">=", Timestamp.fromDate(startDate)),
+      );
+      const snapshot = await getDocs(q);
+      return snapshot.docs.map((doc) => {
+        const data = doc.data();
+        let date: Date;
+        if (data.date instanceof Timestamp) {
+          date = data.date.toDate();
+        } else if (data.date instanceof Date) {
+          date = data.date;
+        } else if (
+          typeof data.date === "string" ||
+          typeof data.date === "number"
+        ) {
+          date = new Date(data.date);
+        } else {
+          date = new Date();
+        }
+        return {
+          id: doc.id,
+          userId: data.userId || "",
+          amount: Number(data.amount) || 0,
+          category: data.category || "Other",
+          type: data.type === "income" ? "income" : "expense",
+          date,
+          description: data.description,
+        };
+      });
+    }
     handleFirestoreError(error, OperationType.LIST, "transactions");
     return [];
   }


### PR DESCRIPTION
## Summary of What Has Been Done

In `src/lib/cashflowUtils.ts`, the `fetchUserTransactions` function had no fallback path when the primary Firestore query fails. When Firestore throws `failed-precondition` (due to a missing composite index), the function would call `handleFirestoreError` and return an empty array — meaning the caller gets no data at all.

Added a `failed-precondition` fallback that retries the query with the same `date` filter:

```typescript
// BEFORE (no fallback):
} catch (error) {
  handleFirestoreError(error, OperationType.LIST, "transactions");
  return [];
}

// AFTER (with fallback):
} catch (error) {
  if ((error as any)?.code === "failed-precondition") {
    const q = query(
      collection(db, "transactions"),
      where("userId", "==", userId),
      where("date", ">=", Timestamp.fromDate(startDate)),
    );
    const snapshot = await getDocs(q);
    return snapshot.docs.map(...);
  }
  handleFirestoreError(error, OperationType.LIST, "transactions");
  return [];
}
```

## Changes Made

- `src/lib/cashflowUtils.ts`: Added `failed-precondition` fallback path with date filter in `fetchUserTransactions`

## Impact

- When Firestore index is missing, the function no longer silently returns empty data
- Fallback path correctly respects the `months` parameter
- Users continue to get transaction data even when Firestore composite indexes are not yet created

Closes #131

Note: Please assign this PR to the `tmdeveloper007` account.