### PR TITLE
fix : replace subMonths with negative arg with addMonths in generateMonthlyForecast

### DIFF
--- a/src/lib/forecastUtils.ts
+++ b/src/lib/forecastUtils.ts
@@ -10,7 +10,7 @@ import {
   orderBy,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
-import { format, subMonths, startOfMonth, endOfMonth, eachMonthOfInterval, isWithinInterval } from 'date-fns';
+import { format, subMonths, addMonths, startOfMonth, endOfMonth, eachMonthOfInterval, isWithinInterval } from 'date-fns';
 import { toDate } from './utils';
 
 export interface ForecastData {
@@ -53,7 +53,7 @@ export function generateMonthlyForecast(
 ): MonthlyForecast[] {
   if (!historicalData.length) {
     return Array.from({ length: monthsAhead }, (_, i) => {
-      const month = format(subMonths(new Date(), -i - 1), 'yyyy-MM');
+      const month = format(addMonths(new Date(), i + 1), 'yyyy-MM');
       return { month, income: 0, expenses: 0, net: 0, confidence: 0 };
     });
   }
@@ -69,7 +69,7 @@ export function generateMonthlyForecast(
 
   const forecasts: MonthlyForecast[] = [];
   for (let i = 0; i < monthsAhead; i++) {
-    const month = format(subMonths(new Date(), -i - 1), 'yyyy-MM');
+    const month = format(addMonths(new Date(), i + 1), 'yyyy-MM');
     const income = avgIncome + (Math.random() - 0.5) * incomeVariance;
     const expenses = avgExpenses + (Math.random() - 0.5) * expenseVariance;
     const confidence = Math.max(0, Math.min(100, 100 - (i * 8) - (incomeVariance + expenseVariance) / 100));


### PR DESCRIPTION
## Summary of What Has Been Done

In `src/lib/forecastUtils.ts`, the `generateMonthlyForecast` function used `subMonths(new Date(), -i - 1)` to generate future month dates. While this technically works (subtracting a negative amount adds months), relying on `subMonths` with a negative amount is:
1. Confusing and non-obvious to future maintainers
2. Not the idiomatic date-fns pattern for adding months

Replaced both occurrences of `subMonths(new Date(), -i - 1)` with the explicit and clear `addMonths(new Date(), i + 1)`:

```typescript
// BEFORE (confusing - subMonths with negative):
const month = format(subMonths(new Date(), -i - 1), 'yyyy-MM');

// AFTER (clear - explicit addMonths):
const month = format(addMonths(new Date(), i + 1), 'yyyy-MM');
```

Also added `addMonths` to the date-fns import.

## Changes Made

- `src/lib/forecastUtils.ts`: Replaced `subMonths(new Date(), -i - 1)` with `addMonths(new Date(), i + 1)` in two locations within `generateMonthlyForecast`
- Added `addMonths` to the date-fns import statement

## Impact

- Code is clearer and uses the idiomatic `addMonths` API from date-fns
- Future months are unambiguously generated going forward from today
- Easier to maintain and understand for contributors unfamiliar with date-fns internals

Closes #133

Note: Please assign this PR to the `tmdeveloper007` account.