### PR TITLE
fix : pass error to handleFirestoreError in updatePrivacySettings

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -67,8 +67,8 @@ export async function updatePrivacySettings(
       { ...settings, lastUpdated: new Date().toISOString() },
       { merge: true },
     );
-  } catch {
-    handleFirestoreError(settings, OperationType.UPDATE, "privacy_settings");
+  } catch (error) {
+    handleFirestoreError(error, OperationType.UPDATE, "privacy_settings");
   }
 }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the `updatePrivacySettings` function in `src/lib/privacyUtils.ts`. The catch block was passing the `settings` parameter (the input) to `handleFirestoreError` instead of the actual caught `error` variable. This caused incorrect error reporting where the settings object was logged instead of the real error details.

## Changes Made

- Changed `catch {` to `catch (error) {` in `updatePrivacySettings`
- Changed `handleFirestoreError(settings, ...)` to `handleFirestoreError(error, ...)`

## Changes Files

- `src/lib/privacyUtils.ts`

## Impact it Made

- Correct error details are now passed to `handleFirestoreError` when privacy settings update fails
- Error logging will show actual Firestore error codes and messages instead of the settings object

Closes #139

Note: Please assign this PR to the `tmdeveloper007` account.