### PR TITLE
fix : move challenge/tax_estimates/emergency_funds rules inside database match block

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -109,8 +109,6 @@ service cloud.firestore {
       allow update: if isOwner(existing().userId) || isAdmin();
       allow delete: if isOwner(existing().userId) || isAdmin();
     }
-  }
-}
 
     match /challenges/{challengeId} {
       allow read: if isOwner(existing().userId) || isAdmin();


### PR DESCRIPTION
## Summary of What Has Been Done

The `firestore.rules` file had a structural issue where the `match /challenges/{challengeId}`, `match /tax_estimates/{estimateId}`, and `match /emergency_funds/{fundId}` rules were placed OUTSIDE the main `match /databases/{database}/documents` block. The file had two extra closing braces (`}`) that prematurely closed the database and service blocks, leaving these rules at the top level of the service scope (which is invalid in Firestore security rules).

## Changes Made

- Removed the erroneous closing braces that were prematurely ending the `match /databases/{database}/documents` and `service cloud.firestore` blocks
- Moved the `match /challenges/{challengeId}`, `match /tax_estimates/{estimateId}`, and `match /emergency_funds/{fundId}` rules inside the `match /databases/{database}/documents` block where they belong
- The file now has the correct nesting: `service cloud.firestore` -> `match /databases/{database}/documents` -> individual collection matches

## Changes Files

- `firestore.rules`

## Impact it Made

- The `challenges`, `tax_estimates`, and `emergency_funds` collections are now properly protected by Firestore security rules
- Without these rules inside the database match block, these collections would fall under the deny-all `match /{document=**}` rule and be inaccessible

Closes #141

Note: Please assign this PR to the `tmdeveloper007` account.