### PR TITLE
fix : add proper error logging to catch blocks in privacyUtils.ts

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -67,8 +67,8 @@ export async function updatePrivacySettings(
       { ...settings, lastUpdated: new Date().toISOString() },
       { merge: true },
     );
-  } catch {
-    handleFirestoreError(settings, OperationType.UPDATE, "privacy_settings");
+  } catch (error) {
+    handleFirestoreError(error, OperationType.UPDATE, "privacy_settings");
   }
 }
 
@@ -88,13 +88,16 @@ export async function exportUserData(
         query(collection(db, colName), where("userId", "==", userId)),
       );
       data[colName] = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-    } catch {
+    } catch (error) {
+      console.error('exportUserData: failed to fetch', colName, error);
       data[colName] = [];
     }
   }
   try {
     data.profile = (await getDoc(doc(db, "users", userId))).data();
-  } catch {}
+  } catch (error) {
+    console.error('exportUserData: failed to fetch user profile', error);
+  }
   return data;
 }
 
@@ -114,7 +117,9 @@ export async function deleteUserData(userId: string): Promise<void> {
           query(collection(db, colName), where("userId", "==", userId)),
         )
       ).docs.forEach((d) => batch.delete(d.ref));
-    } catch {}
+    } catch (error) {
+      console.error('deleteUserData: failed to delete', colName, error);
+    }
   }
   try {
     batch.delete(doc(db, "users", userId));


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed multiple silent error swallows in privacyUtils.ts by adding proper error logging via console.error and handleFirestoreError.

## Changes Made
- updatePrivacySettings: Changed empty catch block to pass the actual error to handleFirestoreError (was incorrectly passing settings object)
- exportUserData: Added console.error logging to per-collection catch blocks and profile fetch catch block
- deleteUserData: Added console.error logging to per-collection catch blocks in the deletion loop

## Impact it Made
Better observability and debugging capability when privacy operations fail. Proper error handling now surfaces failures instead of silently ignoring them.

Closes #161
Closes #162
Closes #163

## Note: Please assign this PR to the `tmdeveloper007` account.