### PR TITLE
fix : remove debug console.log statements from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,12 +263,10 @@ export default function App() {
     selectedDocIdRef.current = docId;
     setSelectedDocId(docId);
     setSharedDocId(docId);
-    console.log("App selectedDocId set to ...", docId);
-    console.log("App switching to analysis view for ...", docId);
     setActiveTab("detail");
 
     if (source === "upload") {
-      console.log("App received uploaded docId ...", docId);
+      // uploaded docId handled via setSelectedDocId above
     }
   };
 


### PR DESCRIPTION
## Summary of What Has Been Done
Removed development debug console.log statements from App.tsx that were leaking sensitive document IDs.

## Changes Made
- Removed 3 debug console.log statements that logged document IDs in the App component.

## Impact it Made
Cleaner production console and improved privacy.

Closes #159

## Note: Please assign this PR to the `tmdeveloper007` account.