### PR TITLE
fix : remove debug console.log from registerSW.ts

### DIFF
--- a/src/pwa/registerSW.ts
+++ b/src/pwa/registerSW.ts
@@ -17,8 +17,6 @@ export function registerServiceWorker(): void {
 
   navigator.serviceWorker.register(swUrl)
     .then(registration => {
-      console.log('Service Worker registered:', registration.scope);
-
       registration.addEventListener('updatefound', () => {
         const installingWorker = registration.installing;
         if (!installingWorker) return;


### PR DESCRIPTION
## Summary of What Has Been Done
Removed development debug console.log statement from registerSW.ts that was logging the service worker registration scope on every page load.

## Changes Made
- Removed console.log('Service Worker registered:', registration.scope) from the .then() callback in registerServiceWorker()

## Impact it Made
Cleaner production console output and no information disclosure about the service worker scope.

Closes #160

## Note: Please assign this PR to the `tmdeveloper007` account.