### PR TITLE
fix : removed debug console.log statements from AnalysisDetail.tsx

### DIFF
--- a/src/components/AnalysisDetail.tsx
+++ b/src/components/AnalysisDetail.tsx
@@ -478,11 +478,8 @@ export function AnalysisDetail({ docId, user, onBack }: AnalysisDetailProps) {
         analysesQuery,
         (snapshot) => {
           if (!snapshot.empty) {
-            console.log("Loading latest analysis from subcollection...");
             const analysisDoc = snapshot.docs[0];
-            console.log("Loaded analysis doc ID:", analysisDoc.id);
             const data = analysisDoc.data();
-            console.log("Loaded sentiment_score:", data?.sentiment_score);
             setAnalysis(data);
           }
           // Keep the view renderable with any latestAnalysis already stored on the parent doc.


### PR DESCRIPTION
## Summary of What Has Been Done

Removed three debug console.log statements from src/components/AnalysisDetail.tsx inside the onSnapshot callback:

1. Removed `console.log("Loading latest analysis from subcollection...")`
2. Removed `console.log("Loaded analysis doc ID:", analysisDoc.id)`
3. Removed `console.log("Loaded sentiment_score:", data?.sentiment_score)`

## Changes Made

- Removed 3 lines of debug logging code from the analysis subcollection snapshot listener

## Impact it Made

- Eliminates unnecessary console noise during analysis loading
- Removes potential information disclosure of internal document IDs and analysis data
- Clean, production-ready code without debug artifacts

Closes #170

## Note: please assign this PR to the `tmdeveloper007` account.