### PR TITLE
fix : correct property name confidenceScore to confidence in AnomalyCard.tsx

### DIFF
--- a/src/components/anomaly/AnomalyCard.tsx
+++ b/src/components/anomaly/AnomalyCard.tsx
@@ -80,7 +80,7 @@ export function AnomalyCard({
   historicalCount = 0,
   historicalLabel,
 }: AnomalyCardProps) {
-  const severity = getSeverity(anomaly.confidenceScore);
+  const severity = getSeverity(anomaly.confidence);
   const colors = getSeverityColor(severity);
   const icon = getTypeIcon(anomaly.type);
 
@@ -139,13 +139,13 @@ export function AnomalyCard({
               Confidence
             </span>
             <span className={`font-mono font-bold ${colors.text}`}>
-              {anomaly.confidenceScore}%
+              {anomaly.confidence}%
             </span>
           </div>
-          <Progress value={anomaly.confidenceScore} className="h-1.5">
+          <Progress value={anomaly.confidence} className="h-1.5">
             <div
               className={`h-full rounded-full transition-all ${colors.progress}`}
-              style={{ width: `${anomaly.confidenceScore}%` }}
+              style={{ width: `${anomaly.confidence}%` }}
             />
           </Progress>
         </div>


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed TypeScript compilation errors in src/components/anomaly/AnomalyCard.tsx. The component was referencing anomaly.confidenceScore but the Anomaly interface (defined in anomalyUtils.ts) uses the property name confidence. Corrected all four occurrences.

## Changes Made

1. Line 83: `anomaly.confidenceScore` -> `anomaly.confidence`
2. Line 142: `anomaly.confidenceScore` -> `anomaly.confidence`
3. Line 145: `anomaly.confidenceScore` -> `anomaly.confidence`
4. Line 148: `anomaly.confidenceScore` -> `anomaly.confidence`

## Impact it Made

- Fixes TypeScript compilation errors (TS2551: Property does not exist on type Anomaly)
- AnomalyCard now correctly reads the confidence property from the Anomaly type
- Confidence scores are properly displayed in the anomaly detection dashboard

Closes #174

## Note: please assign this PR to the `tmdeveloper007` account.