### PR TITLE
fix : correct confidenceScore property to confidence in AnomalyDashboard.tsx

### DIFF
--- a/src/components/anomaly/AnomalyDashboard.tsx
+++ b/src/components/anomaly/AnomalyDashboard.tsx
@@ -22,7 +22,6 @@ import {
   checkHistoricalSimilarAnomalies,
   Anomaly,
   Transaction,
-  CategoryBaseline,
 } from "@/src/lib/anomalyUtils";
 import {
   Card,
@@ -370,7 +369,7 @@ async function runDetection(userId: string) {
       category: tx.category,
       amount: tx.amount,
       description: `Transaction of $${tx.amount.toLocaleString()} in ${tx.category} exceeds the category average by more than 2 standard deviations.`,
-      confidenceScore: confidence,
+      confidence,
       transactionId: tx.id,
       dismissed: false,
       createdAt: tx.date,
@@ -398,7 +397,7 @@ async function runDetection(userId: string) {
       category: spike.category,
       amount: spike.amount,
       description: `${spike.category} spending is ${pctOver}% above the 3-month average.`,
-      confidenceScore: confidence,
+      confidence,
       transactionId:
         spike.transactions[spike.transactions.length - 1]?.id || "",
       dismissed: false,


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed TypeScript compilation errors in src/components/anomaly/AnomalyDashboard.tsx. Anomaly objects were being created with a confidenceScore property that does not exist in the Anomaly interface. The correct property name is confidence.

## Changes Made

1. Line 373: Changed `confidenceScore: confidence,` to `confidence,`
2. Line 401: Changed `confidenceScore: confidence,` to `confidence,`
3. Removed unused import `CategoryBaseline` from the anomalyUtils import statement

## Impact it Made

- Fixes TypeScript compilation errors (TS2561: Object literal may only specify known properties)
- Aligns anomaly object creation with the Anomaly interface definition
- Removes unused import for cleaner code

Closes #175

## Note: please assign this PR to the `tmdeveloper007` account.