### PR TITLE
fix : added correct date range calculation in generateWeeklyComparison in trendsUtils.ts

### DIFF
--- a/src/lib/trendsUtils.ts
+++ b/src/lib/trendsUtils.ts
@@ -23,6 +23,7 @@ import {
   startOfMonth,
   endOfMonth,
   subMonths,
+  subWeeks,
   eachWeekOfInterval,
   eachMonthOfInterval,
 } from 'date-fns';
@@ -223,9 +224,7 @@ export function generateWeeklyComparison(
   weeks: number = 4,
   end: Date = new Date(),
 ): { data: CategoryPeriodDatum[]; periods: { key: string; label: string }[] } {
-  const start = startOfWeek(subMonths(end, 0));
-  const startRange = new Date(start);
-  startRange.setDate(startRange.getDate() - (weeks - 1) * 7);
+  const startRange = subWeeks(end, weeks - 1);
   const periods = eachWeekOfInterval({ start: startRange, end: end }).map((d) => ({
     key: formatWeekKey(d),
     label: format(d, "'W'II MMM"),


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the `generateWeeklyComparison` function in `src/lib/trendsUtils.ts` by replacing the incorrect date calculation `startOfWeek(subMonths(end, 0))` with the correct `subWeeks(end, weeks - 1)`. Also added `subWeeks` to the date-fns import list.

## Changes Made
- Added `subWeeks` to the date-fns imports in `src/lib/trendsUtils.ts`
- Replaced `const start = startOfWeek(subMonths(end, 0))` and subsequent manual date arithmetic with `const startRange = subWeeks(end, weeks - 1)` for correct weekly date range calculation

## Impact it Made
The weekly comparison chart now correctly displays spending trends over the requested number of past weeks with accurate date boundaries. Users will receive correct weekly trend data.

Closes #174

## Note
Please assign this PR to the `tmdeveloper007` account.
