### PR TITLE
fix : corrected conservative and aggressive contribution amounts in goalUtils.ts

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -64,11 +64,11 @@ export function generateContributionSuggestions(
     },
     {
       label: 'Conservative',
-      amount: Math.ceil(baseMonthly * (options.conservative ? 1.2 : 1.1)),
+      amount: Math.ceil(baseMonthly * (options.conservative ? 0.8 : 0.9)),
     },
     {
       label: 'Aggressive',
-      amount: Math.max(1, Math.floor(baseMonthly * (options.aggressive ? 0.85 : 0.9))),
+      amount: Math.max(1, Math.floor(baseMonthly * (options.aggressive ? 1.2 : 1.1))),
     },
   ];
 


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the swapped conservative and aggressive contribution amounts in the `generateContributionSuggestions` function in `src/lib/goalUtils.ts`. Conservative was suggesting MORE money (1.2x) and aggressive was suggesting LESS money (0.85x), which is the opposite of the intended behavior.

## Changes Made
- Conservative: Changed `baseMonthly * (options.conservative ? 1.2 : 1.1)` to `baseMonthly * (options.conservative ? 0.8 : 0.9)`
- Aggressive: Changed `baseMonthly * (options.aggressive ? 0.85 : 0.9)` to `baseMonthly * (options.aggressive ? 1.2 : 1.1)`

## Impact it Made
Users now receive accurate contribution suggestions: conservative users see lower contribution amounts suitable for cautious planning, while aggressive users see higher amounts for accelerated goal achievement.

Closes #178

## Note
Please assign this PR to the `tmdeveloper007` account.
