### PR TITLE
fix : corrected spending pattern average calculation in chatUtils.ts

### DIFF
--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -328,7 +328,7 @@ export function analyzeSpendingPatterns(context: FinancialContext): ChatResponse
     response += `Spending increased by ${formatCurrency(maxIncrease.amount)} in ${maxIncrease.month}. `;
   }
 
-  const avg = totalSpending / Math.max(months.length, 1);
+  const avg = totalSpending / Math.max(spendingByMonth.length, 1);
   response += `Your average monthly spending is ${formatCurrency(Math.round(avg))}.`;
 
   return {


### PR DESCRIPTION
## Summary of What Has Been Done
The `analyzeSpendingPatterns` function in `src/lib/chatUtils.ts` incorrectly used `months.length` (the number of month keys in the `monthlySpending` object) to calculate average monthly spending. This was changed to use `spendingByMonth.length` (the length of the sliced spending data array), which is the correct denominator.

## Changes Made
- Changed `const avg = totalSpending / Math.max(months.length, 1)` to `const avg = totalSpending / Math.max(spendingByMonth.length, 1)` in `src/lib/chatUtils.ts` line 331

## Impact it Made
- Corrects the average monthly spending figure shown in AI chat responses
- Users receive accurate spending comparisons and reliable financial advice
- Fixes misleading financial data generated by the chat assistant

## Note: Please assign this PR to the `tmdeveloper007` account.