### PR TITLE
fix : added error logging to bare catch block in formatCurrency in currencyUtils.ts

### DIFF
--- a/src/lib/currencyUtils.ts
+++ b/src/lib/currencyUtils.ts
@@ -179,7 +179,8 @@ export function formatCurrencyDisplay(amount: number, currencyCode: string): str
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(amount);
-  } catch {
+  } catch (err) {
+    console.error("formatCurrency: failed to format currency", err);
     return `${symbol}${amount.toFixed(2)}`;
   }
 }


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced bare `catch {}` in `src/lib/currencyUtils.ts` `formatCurrency` function (line 182) with `catch (err)` and added `console.error` logging before returning the fallback value. This makes currency formatting failures observable in production.

## Changes Made
- Changed `} catch {` to `} catch (err) {` in `formatCurrency` function
- Added `console.error("formatCurrency: failed to format currency", err);` before the fallback return

## Impact it Made
- Developers can now see currency formatting failures in production logs
- Better observability for unsupported currency code edge cases
- Consistent error logging pattern with other utility functions

Closes #207

## Note: Please assign this PR to the `tmdeveloper007` account.
