### PR TITLE
fix : added error logging to bare catch block in getPrivacySettings in privacyUtils.ts

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -52,7 +52,8 @@ export async function getPrivacySettings(
     if (snap.exists()) return snap.data() as PrivacySettings;
     await setDoc(docRef, DEFAULT_PRIVACY_SETTINGS);
     return DEFAULT_PRIVACY_SETTINGS;
-  } catch {
+  } catch (err) {
+    console.error("getPrivacySettings: failed to retrieve privacy settings", err);
     return DEFAULT_PRIVACY_SETTINGS;
   }
 }


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced bare `catch {}` in `src/lib/privacyUtils.ts` `getPrivacySettings` function (line 55) with `catch (err)` and added `console.error` logging before returning the fallback value.

## Changes Made
- Changed `} catch {` to `} catch (err) {` in `getPrivacySettings` function
- Added `console.error("getPrivacySettings: failed to retrieve privacy settings", err);` before the fallback return

## Impact it Made
- Developers can now see Firestore privacy settings retrieval failures in production logs
- Better debugging for permission and connectivity issues
- Consistent error logging pattern across the privacy module

Closes #208

## Note: Please assign this PR to the `tmdeveloper007` account.