### PR TITLE
fix : added error logging to bare catch block in formatCurrency in taxUtils.ts

### DIFF
--- a/src/lib/taxUtils.ts
+++ b/src/lib/taxUtils.ts
@@ -410,7 +410,8 @@ export function formatCurrency(amount: number, currencyCode: string): string {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(amount);
-  } catch {
+  } catch (err) {
+    console.error("formatCurrency: failed to format currency in taxUtils", err);
     return `${currencyCode} ${amount.toFixed(2)}`;
   }
 }


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced bare `catch {}` in `src/lib/taxUtils.ts` `formatCurrency` function (line 413) with `catch (err)` and added `console.error` logging before returning the fallback value.

## Changes Made
- Changed `} catch {` to `} catch (err) {` in `formatCurrency` function in taxUtils.ts
- Added `console.error("formatCurrency: failed to format currency in taxUtils", err);` before the fallback return

## Impact it Made
- Developers can now trace currency formatting failures in tax utilities in production logs
- Better debugging for international tax formatting edge cases
- Consistent error handling across tax utility functions

Closes #209

## Note: Please assign this PR to the `tmdeveloper007` account.