### PR TITLE
fix : added error logging to bare catch block in formatRelativeTime in utils.ts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,7 +52,8 @@ export function formatRelativeTime(value: any, fallback = "Recently") {
 
   try {
     return formatDistanceToNow(date, { addSuffix: true });
-  } catch {
+  } catch (err) {
+    console.error("formatRelativeTime: failed to compute relative time", err);
     return fallback;
   }
 }


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced bare `catch {}` in `src/lib/utils.ts` `formatRelativeTime` function (line 55) with `catch (err)` and added `console.error` logging before returning the fallback value.

## Changes Made
- Changed `} catch {` to `} catch (err) {` in `formatRelativeTime` function
- Added `console.error("formatRelativeTime: failed to compute relative time", err);` before the fallback return

## Impact it Made
- Developers can now debug timestamp formatting issues in production
- Consistent logging across utility functions
- Better traceability for date handling edge cases

Closes #210

## Note: Please assign this PR to the `tmdeveloper007` account.