### PR TITLE
fix(#235): remove duplicate goals tab rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1166,18 +1166,6 @@ export default function App() {
               </motion.div>
             )}
 
-            {activeTab === 'goals' && (
-              <motion.div 
-                key="goals"
-                initial={false}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -10 }}
-                className="space-y-6"
-              >
-                <GoalPlanner user={user} />
-              </motion.div>
-            )}
-
             {activeTab === 'bills' && (
               <motion.div 
                 key="bills"


### PR DESCRIPTION
The GoalPlanner component was being rendered twice when activeTab equals 'goals' due to a duplicate conditional rendering block.

Impact:
- Component was mounting twice, wasting React resources
- Could cause unexpected UI behavior

Resolution:
- Removed the duplicate {activeTab === 'goals' && (...)} block