### PR TITLE
fix(#237): rename deleteBill to softDeleteBill with deprecation

### DIFF
--- a/src/components/bills/BillReminders.tsx
+++ b/src/components/bills/BillReminders.tsx
@@ -46,7 +46,7 @@ import {
   type BillInput,
   fetchUserBills,
   createBill,
-  deleteBill,
+  softDeleteBill,
   markBillAsPaid,
   getUpcomingBills,
   getOverdueBills,
@@ -188,7 +188,7 @@ export function BillReminders({ user }: BillRemindersProps) {
   };
 
   const handleDelete = async (billId: string) => {
-    const ok = await deleteBill(billId);
+    const ok = await softDeleteBill(billId);
     if (ok) {
       setBills((prev) => prev.filter((b) => b.id !== billId));
       toast.success('Bill removed');

--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -115,15 +115,22 @@ export async function createBill(userId: string, input: BillInput): Promise<Bill
   }
 }
 
-export async function deleteBill(billId: string): Promise<boolean> {
+export async function softDeleteBill(billId: string): Promise<boolean> {
   try {
     await updateDoc(doc(db, 'bills', billId), { deleted: true });
     return true;
   } catch (error) {
-    console.error('Error deleting bill:', error);
+    console.error('Error soft-deleting bill:', error);
     handleFirestoreError(error, OperationType.DELETE, `bills/${billId}`);
     return false;
   }
+}
+
+/**
+ * @deprecated Use softDeleteBill instead. This function performs a soft delete, not an actual deletion.
+ */
+export async function deleteBill(billId: string): Promise<boolean> {
+  return softDeleteBill(billId);
 }
 
 export function calculateNextDueDate(


### PR DESCRIPTION
The deleteBill function was performing a soft delete (setting deleted: true) but was named as if it performs an actual deletion. This was misleading.

Changes:
- Created new softDeleteBill() function with descriptive name
- Deprecated old deleteBill() function with JSDoc @deprecated notice
- Updated BillReminders.tsx to use the new function name

Impact:
- Eliminates confusion about actual behavior
- Maintains backward compatibility via deprecated wrapper