### PR TITLE
fix: fix/226-signed-url-idor

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1136,7 +1136,40 @@ CRITICAL RULES:
         });
       }
 
-      // Verify user owns the document by checking Firestore
+      // Collapse redundant slashes and reject traversal / absolute paths so
+      // the ownership prefix check below cannot be bypassed with `..`.
+      const normalizedPath = storagePath.replace(/\/+/g, "/").replace(/^\/+/, "");
+      if (
+        normalizedPath !== storagePath ||
+        normalizedPath.split("/").includes("..")
+      ) {
+        return res.status(403).json({
+          error: {
+            stage: "AUTHORIZATION",
+            reason: "Invalid storage path",
+            recommendation: "Use the storagePath returned by the API.",
+          },
+        });
+      }
+
+      // Signing a URL for an arbitrary path is an IDOR: previously ownership
+      // was proven only by a Firestore document, but any client can write such
+      // a document referencing another user's storage path. Ownership must be
+      // verified against the storage object itself (namespace + uploadedBy).
+      const expectedPrefix = `analyses/${req.ownerId}/`;
+      if (!normalizedPath.startsWith(expectedPrefix)) {
+        console.warn(
+          `UNAUTHORIZED_DOWNLOAD_ATTEMPT: userId=${req.ownerId}, path=${normalizedPath}`,
+        );
+        return res.status(403).json({
+          error: {
+            stage: "AUTHORIZATION",
+            reason: "You do not have access to this document",
+            recommendation: "Verify the document belongs to your account.",
+          },
+        });
+      }
+
       if (!admin.apps.length) {
         return res.status(503).json({
           error: {
@@ -1148,17 +1181,13 @@ CRITICAL RULES:
       }
 
       try {
-        const dbAdmin = getFirestore(firestoreDatabaseId);
-        const docSnap = await dbAdmin
-          .collectionGroup("documents")
-          .where("ownerId", "==", req.ownerId)
-          .where("storagePath", "==", storagePath)
-          .limit(1)
-          .get();
+        const bucket = getStorage().bucket();
+        const [metadata] = await bucket.file(normalizedPath).getMetadata();
+        const uploadedBy = metadata?.metadata?.uploadedBy;
 
-        if (docSnap.empty) {
+        if (!metadata || uploadedBy !== req.ownerId) {
           console.warn(
-            `UNAUTHORIZED_DOWNLOAD_ATTEMPT: userId=${req.ownerId}, path=${storagePath}`,
+            `UNAUTHORIZED_DOWNLOAD_ATTEMPT: userId=${req.ownerId}, path=${normalizedPath}`,
           );
           return res.status(403).json({
             error: {
@@ -1169,12 +1198,24 @@ CRITICAL RULES:
           });
         }
 
-        const signedUrl = await generateShortLivedSignedUrl(storagePath, 15 * 60 * 1000);
+        const signedUrl = await generateShortLivedSignedUrl(normalizedPath, 15 * 60 * 1000);
         return res.status(200).json({
           signedUrl,
           expiresIn: 15 * 60, // seconds
         });
       } catch (error: any) {
+        if (error?.code === 404) {
+          console.warn(
+            `UNAUTHORIZED_DOWNLOAD_ATTEMPT: userId=${req.ownerId}, path=${normalizedPath}`,
+          );
+          return res.status(403).json({
+            error: {
+              stage: "AUTHORIZATION",
+              reason: "You do not have access to this document",
+              recommendation: "Verify the document belongs to your account.",
+            },
+          });
+        }
         console.error(
           "DOWNLOAD_URL_GENERATION_ERROR:",
           error?.message || error,


### PR DESCRIPTION
## Problem

`POST /api/document-download-url` minted a signed URL for any client-supplied `storagePath` as long as a Firestore `documents` document existed with matching `ownerId` + `storagePath`. That check is not an ownership proof: any client can write such a document (firestore rules only require `ownerId == request.auth.uid`, with no `storagePath` format validation) referencing another user's storage object, and then obtain a signed download URL for it. Insecure direct object reference.

## Fix

Ownership is now verified against the storage object itself, not a client-writable document:

- `storagePath` is normalized; paths containing `..` traversal or absolute paths are rejected with 403.
- The path must live under `analyses/{req.ownerId}/`.
- `getMetadata()` on the object is required to return `uploadedBy == req.ownerId` (the metadata the server sets on every upload); otherwise 403. A 404 object also returns 403, not 500.
- Only after all checks pass is the short-lived signed URL generated.

## Files changed

- `server.ts`

## Testing

- `esbuild server.ts --bundle --platform=node --format=cjs --packages=external` bundles cleanly.

Closes #226
