### PR TITLE
fix: fix/229-sensitive-content-logging

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,13 @@ dotenv.config({ quiet: true });
 
 console.log("HF_KEY_EXISTS:", !!process.env.HUGGINGFACE_API_KEY);
 
+// NEVER log extracted document text or raw AI responses by default: they
+// contain sensitive financial content. For local debugging only, set
+// LOG_DOC_CONTENT=true; content previews stay suppressed in production
+// regardless of the flag.
+const logDocumentContent =
+  process.env.LOG_DOC_CONTENT === "true" && process.env.NODE_ENV !== "production";
+
 const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
 
 const upload = multer({
@@ -704,7 +711,9 @@ async function startServer() {
         console.log(
           `PDF_EXTRACTION_COMPLETE: extracted ${extractedText.length} characters`,
         );
-        console.log(`PDF_TEXT_PREVIEW: ${extractedText.slice(0, 500)}`);
+        if (logDocumentContent) {
+          console.log(`PDF_TEXT_PREVIEW: ${extractedText.slice(0, 500)}`);
+        }
 
         // Validate extraction
         if (!extractedText || extractedText.length < 100) {
@@ -841,7 +850,9 @@ CRITICAL RULES:
                   "AI_JSON_PARSE_ERROR:",
                   parseError?.message || parseError,
                 );
-                console.error("AI_RAW_RESPONSE_SAMPLE:", rawText.slice(0, 500));
+                if (logDocumentContent) {
+                  console.error("AI_RAW_RESPONSE_SAMPLE:", rawText.slice(0, 500));
+                }
                 if (retries >= maxRetries) {
                   throw new PipelineError(
                     "JSON_PARSING",
@@ -860,11 +871,13 @@ CRITICAL RULES:
                 validPayload = validateAnalysisPayload(parsedResponse);
                 console.log("AI_SCHEMA_VALIDATION_SUCCESS");
                 console.log(
-                  `AI_ANALYSIS_GENERATED: summary=${validPayload.summary.substring(0, 100)}...`,
+                  `AI_ANALYSIS_GENERATED: summaryLength=${validPayload.summary.length}, fullReportLength=${validPayload.full_report.length}`,
                 );
-                console.log(
-                  `AI_FULL_REPORT_LENGTH: ${validPayload.full_report.length} characters`,
-                );
+                if (logDocumentContent) {
+                  console.log(
+                    `AI_ANALYSIS_SUMMARY: ${validPayload.summary.substring(0, 200)}`,
+                  );
+                }
               } catch (validateError: any) {
                 console.error(
                   "AI_SCHEMA_VALIDATION_ERROR:",


### PR DESCRIPTION
## Problem

The analyze pipeline logged sensitive content unconditionally:

- `PDF_TEXT_PREVIEW: ${extractedText.slice(0, 500)}` — first 500 chars of the extracted financial document.
- `AI_RAW_RESPONSE_SAMPLE: ${rawText.slice(0, 500)}` — raw model output.
- `AI_ANALYSIS_GENERATED: summary=${...substring(0, 100)}` — generated analysis preview.

Logs often end up in aggregators accessible to the whole team, so this leaks private document and analysis content.

## Fix

- Content previews are now gated behind `LOG_DOC_CONTENT=true` **and** `NODE_ENV !== "production"` — never emitted in production.
- Default logging is metadata-only (lengths, IDs, durations): the summary/report preview log was replaced with `summaryLength` / `fullReportLength`.
- `PDF_EXTRACTION_COMPLETE` still logs only the extracted character count.

## Files changed

- `server.ts`

## Testing

- `esbuild server.ts --bundle --platform=node --format=cjs --packages=external` bundles cleanly.

Closes #229
