### PR TITLE
fix: fix/230-auditlogs-server-write

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -84,8 +84,14 @@ service cloud.firestore {
     }
 
     match /auditLogs/{logId} {
+      // SECURITY: Audit entries are server-generated. The Firebase Admin SDK
+      // (service account) bypasses rules entirely, so allow create only for
+      // trusted admin-signed tokens and block every signed-in client from
+      // forging entries. The log is append-only: no updates or deletes.
       allow read: if isAdmin();
-      allow create: if isSignedIn(); // Allow app to log actions
+      allow create: if request.auth != null && request.auth.token.admin_sdk == true;
+      allow update: if false;
+      allow delete: if false;
     }
 
     match /goals/{goalId} {


### PR DESCRIPTION
## Problem

`match /auditLogs/{logId}` allowed `create` for any signed-in user (`allow create: if isSignedIn()`), so anyone could forge audit-trail entries and hide or fake activity.

## Fix

Audit logs are now append-only and server-only:

- `allow create` requires `request.auth.token.admin_sdk == true` — real server writes via the Firebase Admin SDK bypass rules entirely, and this additionally admits only admin-signed tokens.
- `allow update` and `allow delete` are explicitly denied, so the log cannot be tampered with.

## Files changed

- `firestore.rules`

## Testing

- Rules reviewed against Firebase Security Rules semantics (default deny covers unauthenticated access; Admin SDK writes bypass rules and remain unaffected).

Closes #230
