### PR TITLE
fix: fix/231-sw-cache-auth-logout

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const API_CACHE = `api-${CACHE_VERSION}`;
 const OFFLINE_CACHE = `offline-${CACHE_VERSION}`;
@@ -13,6 +13,11 @@ const STATIC_ASSETS = [
 const API_PATTERNS = [
   /\/api\//,
 ];
+
+// Only public, unauthenticated endpoints may ever be cached. Everything else
+// under /api/ returns user-specific data or short-lived signed URLs and must
+// stay out of the cache.
+const PUBLIC_API_PATTERN = /^\/api\/health/;
 
 const OFFLINE_PATHS = ['/'];
 
@@ -71,12 +76,32 @@ async function handleStaticRequest(request) {
 async function handleApiRequest(request) {
   try {
     const response = await fetch(request.clone());
-    const cache = await caches.open(API_CACHE);
-    cache.put(request, response.clone());
+    // Only cache public GET responses without credentials. Authenticated
+    // responses (per-user data, signed document URLs) must never be stored:
+    // they are session-bound and could leak to another user.
+    if (
+      response.ok &&
+      request.method === 'GET' &&
+      request.headers.get('Authorization') == null &&
+      PUBLIC_API_PATTERN.test(new URL(request.url).pathname)
+    ) {
+      const cache = await caches.open(API_CACHE);
+      cache.put(request, response.clone());
+    }
     return response;
   } catch {
-    const cached = await caches.match(request);
-    if (cached) return cached;
+    // Never serve a stale cached copy for authenticated or sensitive
+    // requests — the cached entry may belong to another account.
+    const url = new URL(request.url);
+    const isSafeToServeFromCache =
+      request.method === 'GET' &&
+      request.headers.get('Authorization') == null &&
+      PUBLIC_API_PATTERN.test(url.pathname);
+
+    if (isSafeToServeFromCache) {
+      const cached = await caches.match(request);
+      if (cached) return cached;
+    }
 
     return new Response(
       JSON.stringify({ error: 'Offline', message: 'No cached data available' }),
@@ -124,6 +149,11 @@ self.addEventListener('message', (event) => {
     case 'STORE_PENDING_REQUEST':
       pendingSync.set(payload.id, payload);
       self.registration.sync.register('sync-pending-requests');
+      break;
+    case 'CLEAR_API_CACHE':
+      // Purge every cached API response on sign-out so session-bound data
+      // cannot survive into the next user's session.
+      caches.delete(API_CACHE);
       break;
     default:
       break;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,6 +195,7 @@ import { ForecastComparison } from './components/forecast/ForecastComparison';
 import { PortfolioTracker } from './components/portfolio/PortfolioTracker';
 import { ThemeProvider } from '@/src/lib/themeContext';
 import { ThemeToggle } from '@/src/components/ThemeToggle';
+import { purgeApiCaches } from './pwa/registerSW';
 
 export default function App() {
   const [user, setUser] = useState<User | null>(null);
@@ -510,6 +511,9 @@ export default function App() {
 
   const handleLogout = () => {
     signOut(auth);
+    // Drop every cached API response (may include session-bound data or
+    // signed URLs) before the next user signs in on this device.
+    void purgeApiCaches();
     setActiveTab("dashboard");
     setShowVerificationScreen(false);
     setUsername("");

--- a/src/pwa/registerSW.ts
+++ b/src/pwa/registerSW.ts
@@ -76,6 +76,28 @@ export async function unregisterServiceWorker(): Promise<boolean> {
   return false;
 }
 
+export async function purgeApiCaches(): Promise<void> {
+  if ('caches' in window) {
+    try {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.filter(key => key.startsWith('api-')).map(key => caches.delete(key)),
+      );
+    } catch {
+      // Ignore cache purge failures; the service worker path below is the fallback.
+    }
+  }
+
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (registration?.active) {
+    registration.active.postMessage({ type: 'CLEAR_API_CACHE' });
+  }
+}
+
 export async function checkForUpdates(registration?: ServiceWorkerRegistration): Promise<boolean> {
   if (!registration) {
     registration = await navigator.serviceWorker.getRegistration();


### PR DESCRIPTION
## Problem

The service worker cached **every** `/api/` response (including POSTs) in `API_CACHE` and served stale cached copies when offline. All API responses are session-bound user data or short-lived signed document URLs, so this leaked data across sessions and stored signed URLs without any logout purge.

## Fix

- Only public, unauthenticated `GET` responses (the `/api/health` endpoint) are written to the cache; cached responses are only served back offline in that same case. Authenticated or sensitive requests always hit the network and get a clean 503 offline instead of a stale copy.
- Added a `CLEAR_API_CACHE` message handler in `sw.js` that deletes `API_CACHE`.
- `registerSW.ts` exports `purgeApiCaches()` which deletes `api-*` caches directly and messages the active service worker.
- `handleLogout` in `App.tsx` calls `purgeApiCaches()` so session-bound data cannot survive into the next user's session.
- `CACHE_VERSION` bumped to `v3`, so the old `api-v2` cache is purged on activate.

## Files changed

- `public/sw.js`
- `src/pwa/registerSW.ts`
- `src/App.tsx`

## Testing

- `node --check public/sw.js` passes.
- `registerSW.ts` and `App.tsx` parse successfully with esbuild.

Closes #231
