### PR TITLE
fix : reset isPaid to false after advancing nextDueDate in markBillAsPaid

### DIFF
--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -226,7 +226,7 @@ export async function markBillAsPaid(
     );
 
     await updateDoc(doc(db, 'bills', bill.id), {
-      isPaid: true,
+      isPaid: false,
       lastPaidDate: paidDate.toISOString(),
       nextDueDate,
     });


### PR DESCRIPTION
Summary of What Has Been Done
In `src/lib/billUtils.ts`, the `markBillAsPaid` function was permanently setting `isPaid: true` when advancing `nextDueDate` for a recurring bill. Changed `isPaid: true` to `isPaid: false` so the bill resets to active state for the next billing cycle.

Changes Made
- `src/lib/billUtils.ts` line ~229: changed `isPaid: true` to `isPaid: false` in the Firestore update call inside `markBillAsPaid`.

Impact it Made
Recurring bills will remain visible in upcoming/active bill views after being marked paid. Users will continue to receive reminders for subsequent billing cycles instead of the bill permanently disappearing.

Closes #262

Note: Please assign this PR to the `tmdeveloper007` account.