### PR TITLE
fix : added addHolding function to save to portfolioHoldings collection

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -61,6 +61,7 @@ import {
   getAssetClassColor,
   savePortfolioSnapshot,
   fetchPortfolioHistory,
+  addHolding,
 } from '@/src/lib/portfolioUtils';
 
 interface PortfolioTrackerProps {
@@ -156,7 +157,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
   const allocation = useMemo(() => calculateAllocation(holdings), [holdings]);
 
   const handleAddHolding = async () => {
-    if (!user || !portfolioId) return;
+    if (!user) return;
     const q = parseFloat(quantity);
     const cost = parseFloat(avgCost);
     const price = parseFloat(currentPrice);
@@ -165,27 +166,17 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
       return;
     }
     try {
-      const ok = await updatePortfolio(user.uid, portfolioId, {
-        holdings: [
-          ...holdings,
-          {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            userId: user.uid,
-            symbol,
-            name: name || symbol,
-            assetClass,
-            quantity: q,
-            avgCost: cost,
-            currentPrice: price,
-            currency: currency || 'USD',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-        ],
+      const holding = await addHolding(user.uid, {
+        symbol,
+        name: name || symbol,
+        assetClass,
+        quantity: q,
+        avgCost: cost,
+        currentPrice: price,
+        currency: currency || 'USD',
       });
-      if (ok) {
-        const h = await fetchUserHoldings(user.uid);
-        setHoldings(h);
+      if (holding) {
+        setHoldings((prev) => [holding, ...prev]);
         setSymbol('');
         setName('');
         setQuantity('');
@@ -195,7 +186,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
         toast.success('Holding added');
       }
     } catch (error) {
-      handleFirestoreError(error, OperationType.UPDATE, `portfolios/${portfolioId}`);
+      console.error('Error adding holding:', error);
       toast.error('Failed to add holding');
     }
   };

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -257,6 +257,36 @@ export async function addTransaction(userId: string, input: TransactionInput): P
 
     return { ...transaction, id: id || '' };
   } catch (error) {
+
+export async function addHolding(userId: string, input: HoldingInput): Promise<Holding | null> {
+  try {
+    const id = doc(collection(db, 'portfolioHoldings')).id;
+    const now = new Date().toISOString();
+    const holding: Omit<Holding, 'id'> = {
+      userId,
+      symbol: input.symbol.trim().toUpperCase(),
+      name: input.name.trim() || input.symbol.trim().toUpperCase(),
+      assetClass: input.assetClass,
+      quantity: input.quantity,
+      avgCost: input.avgCost,
+      currentPrice: input.currentPrice,
+      currency: input.currency || 'USD',
+      createdAt: now,
+      updatedAt: now,
+    };
+    await setDoc(doc(db, 'portfolioHoldings', id), {
+      ...holding,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+    return { ...holding, id };
+  } catch (error) {
+    console.error('Error adding holding:', error);
+    handleFirestoreError(error, OperationType.CREATE, 'portfolioHoldings');
+    return null;
+  }
+}
+
     console.error('Error adding transaction:', error);
     handleFirestoreError(error, OperationType.CREATE, 'portfolioTransactions');
     return null;


### PR DESCRIPTION
Summary of What Has Been Done
In `src/lib/portfolioUtils.ts`, added a new `addHolding(userId, input)` async function that saves holdings to the `portfolioHoldings` Firestore collection, matching where `fetchUserHoldings` reads from. Updated `PortfolioTracker.tsx` `handleAddHolding` to call the new function.

Changes Made
- `src/lib/portfolioUtils.ts`: Added `addHolding` function that creates a document in `portfolioHoldings` collection with the holding data.
- `src/components/portfolio/PortfolioTracker.tsx`: Updated `handleAddHolding` to call `addHolding` from portfolioUtils instead of `updatePortfolio`. Added `addHolding` to imports.

Impact it Made
Newly added holdings are now saved to the `portfolioHoldings` collection and will be found by `fetchUserHoldings`, so holdings persist correctly across page reloads.

Closes #263

Note: Please assign this PR to the `tmdeveloper007` account.