### PR TITLE
fix : return empty array when no historical data for forecast generation

### DIFF
--- a/src/lib/forecastUtils.ts
+++ b/src/lib/forecastUtils.ts
@@ -52,10 +52,7 @@ export function generateMonthlyForecast(
   monthsAhead = 6
 ): MonthlyForecast[] {
   if (!historicalData.length) {
-    return Array.from({ length: monthsAhead }, (_, i) => {
-      const month = format(addMonths(new Date(), i + 1), 'yyyy-MM');
-      return { month, income: 0, expenses: 0, net: 0, confidence: 0 };
-    });
+    return [];
   }
 
   const avgIncome = historicalData.reduce((s, d) => s + d.income, 0) / historicalData.length;


### PR DESCRIPTION
Summary of What Has Been Done
In `src/lib/forecastUtils.ts`, changed `generateMonthlyForecast` to return an empty array `[]` instead of an array of zero-filled forecast objects when `historicalData` is empty.

Changes Made
- `src/lib/forecastUtils.ts` line ~54-58: Replaced the zero-filled forecast generation with `return []`.

Impact it Made
Forecast comparison will not display meaningless zero-income/expense projections. Callers that pass empty `historicalData` will receive an empty array and handle it gracefully, preventing spurious zero-filled forecasts from being saved to the database.

Closes #264

Note: Please assign this PR to the `tmdeveloper007` account.