### PR TITLE
fix : update conversation lastMessageAt and title in Firestore after sending message

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -69,6 +69,7 @@ import {
   loadMessages,
   buildFinancialContext,
   generateChatResponse,
+  updateConversation,
 } from '@/src/lib/chatUtils';
 import {
   fetchTransactionsForPeriod,
@@ -310,19 +311,24 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
     setSuggestions(response.suggestions || []);
 
     const conversation = conversations.find((c) => c.id === currentConversationId);
+    const derivedTitle = content.trim().slice(0, 50) + (content.trim().length > 50 ? '...' : '');
     if (conversation) {
       setConversations((prev) =>
         prev.map((c) =>
           c.id === currentConversationId
             ? {
                 ...c,
-                title: content.slice(0, 40) + (content.length > 40 ? '...' : ''),
+                title: derivedTitle,
                 updatedAt: new Date().toISOString(),
                 lastMessageAt: new Date().toISOString(),
               }
             : c
         )
       );
+      await updateConversation(currentConversationId, {
+        title: derivedTitle,
+        lastMessageAt: new Date().toISOString(),
+      });
     }
   };
 

--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -11,6 +11,7 @@ import {
   where,
   orderBy,
   setDoc,
+  updateDoc,
   deleteDoc,
   serverTimestamp,
 } from 'firebase/firestore';
@@ -77,6 +78,21 @@ export async function saveConversation(conversation: Omit<Conversation, 'id'>): 
     console.error('Error saving conversation:', error);
     handleFirestoreError(error, OperationType.CREATE, CHAT_COLLECTION);
     return null;
+  }
+}
+
+
+export async function updateConversation(conversationId: string, patch: Partial<Conversation>): Promise<boolean> {
+  try {
+    await updateDoc(doc(db, CHAT_COLLECTION, conversationId), {
+      ...patch,
+      updatedAt: serverTimestamp(),
+    });
+    return true;
+  } catch (error) {
+    console.error('Error updating conversation:', error);
+    handleFirestoreError(error, OperationType.UPDATE, `${CHAT_COLLECTION}/${conversationId}`);
+    return false;
   }
 }
 


### PR DESCRIPTION
Summary of What Has Been Done
In `src/lib/chatUtils.ts`, added `updateConversation(conversationId, patch)` function that persists conversation updates to Firestore. Updated `ChatAssistant.tsx` `handleSendMessage` to call `updateConversation` after saving a message, passing the derived title (first 50 chars of user message) and `lastMessageAt`.

Changes Made
- `src/lib/chatUtils.ts`: Added `updateConversation` function and `updateDoc` import.
- `src/components/chat/ChatAssistant.tsx`: Added `updateConversation` to imports, call it after saving the assistant message to persist title and `lastMessageAt`.

Impact it Made
Conversation titles and recency ordering now persist across page reloads. The sidebar will show meaningful conversation titles instead of "New Chat" for all conversations.

Closes #266

Note: Please assign this PR to the `tmdeveloper007` account.