### PR TITLE
Fix: Invalid properties assigned to PrivacySettings in PrivacyDashboard.tsx

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,9 @@ export interface PrivacySettings {
   retentionPeriod: "6months" | "1year" | "2years" | "indefinite";
   exportFormat: "json" | "csv";
   lastUpdated: string;
+  dataRetentionEnabled: boolean;
+  analyticsEnabled: boolean;
+  sharingEnabled: boolean;
 }
 
 export interface ActivityLogEntry {
@@ -41,6 +44,9 @@ export const DEFAULT_PRIVACY_SETTINGS: PrivacySettings = {
   retentionPeriod: "1year",
   exportFormat: "json",
   lastUpdated: new Date().toISOString(),
+  dataRetentionEnabled: false,
+  analyticsEnabled: false,
+  sharingEnabled: false,
 };
 
 export async function getPrivacySettings(


### PR DESCRIPTION
## Description
This Pull Request resolves a TypeScript type checking error in PrivacyDashboard.tsx where several missing boolean properties were being accessed and assigned on the PrivacySettings state object.

## Changes Made
- Modified the PrivacySettings interface in src/lib/privacyUtils.ts to include the dataRetentionEnabled, nalyticsEnabled, and sharingEnabled properties.
- Updated the DEFAULT_PRIVACY_SETTINGS object to initialize these new boolean fields to alse, ensuring backward compatibility and safe default states.

## Related Issues
- Resolves #282

## Testing
- Verified that updating PrivacySettings state in the dashboard component no longer throws error TS2339: Property does not exist on type 'PrivacySettings'.