### PR TITLE
fix : added missing GoalCard import in GoalPlanner.tsx

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -45,6 +45,7 @@ import { Badge } from '@/src/components/ui/badge';
 import { Progress, ProgressTrack, ProgressIndicator } from '@/src/components/ui/progress';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/src/components/ui/dialog';
 import { cn, formatCurrency } from '@/src/lib/utils';
+import { GoalCard } from './GoalCard';
 import {
   type Goal,
   calculateMonthlyContribution,


### PR DESCRIPTION
## Summary of What Has Been Done

Added the missing `GoalCard` import from `'./GoalCard'` in `src/components/goals/GoalPlanner.tsx`. The `GoalCard` component was being used on lines 448 and 479 but was not imported.

## Changes Made

- Added `import { GoalCard } from './GoalCard';` to `src/components/goals/GoalPlanner.tsx`

## Impact it Made

Fixes TypeScript compilation error `Cannot find name 'GoalCard'` and ensures the GoalPlanner component renders GoalCard instances correctly.

Closes #293

Note: Please assign this PR to the `tmdeveloper007` account.