### PR TITLE
fix : use formatCurrencyDisplay for currency-aware formatting in PortfolioTracker.tsx

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -43,6 +43,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/src/components/ui/ta
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/src/components/ui/dialog';
 import { Select } from '@/src/components/ui/select';
 import { cn, formatCurrency } from '@/src/lib/utils';
+import { formatCurrencyDisplay } from '@/src/lib/currencyUtils';
 import { auth, db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import {
   type Holding,
@@ -674,7 +675,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
                       'text-2xl font-bold tabular-nums',
                       (performanceHistory[performanceHistory.length - 1]?.profitLoss ?? 0) >= 0 ? 'text-emerald-400' : 'text-red-400'
                     )}>
-                      {formatCurrency((performanceHistory[performanceHistory.length - 1]?.profitLoss ?? 0), 'USD')}
+                      {formatCurrencyDisplay((performanceHistory[performanceHistory.length - 1]?.profitLoss ?? 0), 'USD')}
                     </p>
                     <p className={cn(
                       'text-xs mt-1',
@@ -689,7 +690,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
                   <CardContent className="p-5">
                     <p className="text-xs text-slate-500 mb-1">Latest Total Value</p>
                     <p className="text-2xl font-bold text-white tabular-nums">
-                      {formatCurrency(performanceHistory[0]?.totalValue ?? 0, 'USD')}
+                      {formatCurrencyDisplay(performanceHistory[0]?.totalValue ?? 0, 'USD')}
                     </p>
                     <p className="text-xs text-slate-500 mt-1">
                       {performanceHistory.length} snapshots


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed incorrect `formatCurrency` usage in `src/components/portfolio/PortfolioTracker.tsx`. The `formatCurrency` function from `@/src/lib/utils` only accepts a single numeric argument, but it was being called with two arguments including a currency code at lines 678 and 693.

## Changes Made

- Added `formatCurrencyDisplay` import from `@/src/lib/currencyUtils`
- Replaced `formatCurrency((performanceHistory[...].profitLoss ?? 0), 'USD')` with `formatCurrencyDisplay((performanceHistory[...].profitLoss ?? 0), 'USD')`
- Replaced `formatCurrency(performanceHistory[0]?.totalValue ?? 0, 'USD')` with `formatCurrencyDisplay(performanceHistory[0]?.totalValue ?? 0, 'USD')`

## Impact it Made

Fixes TypeScript compilation error `Expected 1 arguments, but got 2` and ensures portfolio value displays are correctly formatted with currency codes.

Closes #296

Note: Please assign this PR to the `tmdeveloper007` account.