### PR TITLE
fix : remove asChild prop from DropdownMenuTrigger in GoalCard.tsx

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -74,7 +74,7 @@ export function GoalCard({
             </div>
           </div>
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+            <DropdownMenuTrigger>
               <Button variant="ghost" size="icon" className="h-8 w-8 text-slate-500 hover:text-slate-300">
                 <MoreVertical size={16} />
               </Button>


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the `asChild` prop from the `DropdownMenuTrigger` component in `src/components/goals/GoalCard.tsx`. The `DropdownMenuTrigger` is implemented using `@base-ui/react/menu`'s `MenuPrimitive.Trigger`, which does not support the `asChild` prop (that pattern belongs to Radix UI). This caused a TypeScript error: `Type '{ children: Element; asChild: true; }' is not assignable to type 'IntrinsicAttributes & Props<unknown>'`.

## Changes Made

- Removed `asChild` prop from `DropdownMenuTrigger` in `src/components/goals/GoalCard.tsx`

## Impact it Made

Fixes TypeScript compilation error in GoalCard.tsx, ensuring the dropdown menu trigger renders correctly without type errors.

Closes #297

Note: Please assign this PR to the `tmdeveloper007` account.