### PR TITLE
fix : hoist timer declaration to while loop scope in server.ts for finally block access

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -811,10 +811,11 @@ CRITICAL RULES:
             });
           }
 
+          let timer: ReturnType<typeof setTimeout> | undefined;
           try {
             const controller = new AbortController();
             const timeoutMs = 30_000;
-            const timer = setTimeout(() => controller.abort(), timeoutMs);
+            timer = setTimeout(() => controller.abort(), timeoutMs);
 
             try {
               const completion = await hfClient.chatCompletion({


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a TypeScript scoping issue in `server.ts`. The `timer` variable was declared inside an inner `try` block but referenced in a `finally` block belonging to the outer `try`. TypeScript reported: `Cannot find name 'timer'`. The fix hoists the `timer` declaration to the while-loop scope (before the inner try) so it is accessible in the finally block.

## Changes Made

- Changed `const timer = setTimeout(...)` declaration inside the inner try to `let timer` declared before the try, then assigned inside
- Type: `let timer: ReturnType<typeof setTimeout> | undefined`

## Impact it Made

Fixes TypeScript compilation error and ensures the `clearTimeout(timer)` in the finally block runs correctly to prevent timer resource leaks from aborted Hugging Face inference requests.

Closes #302

Note: Please assign this PR to the `tmdeveloper007` account.