### PR TITLE
Feature: Export Monthly Reports to PDF

### DIFF
--- a/src/components/budget/BudgetDashboard.tsx
+++ b/src/components/budget/BudgetDashboard.tsx
@@ -23,6 +23,7 @@ import {
 import {
   Wallet,
   Loader2,
+  Download,
   TrendingUp,
   TrendingDown,
   Calendar,
@@ -245,6 +246,14 @@ export function BudgetDashboard({ user }: { user: any }) {
               Saved for {currentMonth}
             </Badge>
           )}
+          <Button
+            variant="outline"
+            className="text-slate-400 hover:text-white hover:bg-slate-800 h-9 px-3 gap-2 border-slate-700 hidden md:flex"
+            onClick={() => window.print()}
+          >
+            <Download className="h-4 w-4" />
+            <span className="text-xs font-bold uppercase tracking-wider">Export PDF</span>
+          </Button>
           <Button
             variant="ghost"
             className="text-slate-400 hover:text-white hover:bg-slate-800 h-9 w-9 p-0"


### PR DESCRIPTION
## Description
This Pull Request resolves Issue #310 by introducing an 'Export PDF' action to the Budget Dashboard.

## Changes Made
- Added a new 'Export PDF' button using the \Download\ icon from \lucide-react\ in \BudgetDashboard.tsx\.
- Implemented the PDF export functionality using the browser's native \window.print()\ API, which allows users to save the styled dashboard layout cleanly as a PDF document.

## Impact
Users can now effortlessly generate shareable financial reports directly from the Budget Dashboard without needing to configure complex third-party PDF generators.

## Related Issues
- Resolves #310
