### PR TITLE
fix(portfolio): hoist addHolding out of addTransaction catch block

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -257,6 +257,11 @@ export async function addTransaction(userId: string, input: TransactionInput): P
 
     return { ...transaction, id: id || '' };
   } catch (error) {
+    console.error('Error adding transaction:', error);
+    handleFirestoreError(error, OperationType.CREATE, 'portfolioTransactions');
+    return null;
+  }
+}
 
 export async function addHolding(userId: string, input: HoldingInput): Promise<Holding | null> {
   try {
@@ -283,12 +288,6 @@ export async function addHolding(userId: string, input: HoldingInput): Promise<H
   } catch (error) {
     console.error('Error adding holding:', error);
     handleFirestoreError(error, OperationType.CREATE, 'portfolioHoldings');
-    return null;
-  }
-}
-
-    console.error('Error adding transaction:', error);
-    handleFirestoreError(error, OperationType.CREATE, 'portfolioTransactions');
     return null;
   }
 }


### PR DESCRIPTION
## Problem

`addHolding` was declared with `export` inside `addTransaction`'s `catch` block, which is illegal in TypeScript/ES modules (`TS1184`/`SyntaxError`). This broke the compile of `src/lib/portfolioUtils.ts` and every module importing it, so the entire client build failed.

## Fix

- Closed `addTransaction`'s `catch` block with its real body (`console.error`, `handleFirestoreError`, `return null`) immediately after the catch opens.
- Re-declared `addHolding` as a standalone top-level `export async function` after `addTransaction`.
- Verified `addTransaction` and `removeHolding` remain intact.

## Files changed

- `src/lib/portfolioUtils.ts`

## Testing

- Ran `npm run typecheck` (`tsc --noEmit`); `portfolioUtils.ts` reports no errors.

Closes #317
