### PR TITLE
fix(rules): add owner-scoped transactions collection rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -86,6 +86,16 @@ service cloud.firestore {
       allow delete: if isOwner(existing().userId) || isAdmin();
     }
 
+    match /transactions/{txnId} {
+      // SECURITY: Per-user RLS for the transactions collection
+      // Prevents cross-user access to financial transaction data
+      allow get: if isOwner(existing().userId);
+      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
+      allow create: if isSignedIn() && isOwner(incoming().userId);
+      allow update: if isOwner(existing().userId) || isAdmin();
+      allow delete: if isOwner(existing().userId) || isAdmin();
+    }
+
     match /auditLogs/{logId} {
       // SECURITY: Audit entries are server-generated. The Firebase Admin SDK
       // (service account) bypasses rules entirely, so allow create only for


### PR DESCRIPTION
## Problem

The `transactions` collection has no `match` block in `firestore.rules`, so the default-deny rule rejects every transaction read/write. All transaction features (trends, reports, currency conversion, bills, anomalies, subscription detection) fail at the security layer.

## Fix

Add an owner-scoped `match /transactions/{txnId}` block gating read/write on `request.auth.uid == txn.userId` (or `isAdmin()`), matching the canonical `userId` field used to write and filter transactions everywhere in the app (`where('userId', '==', user.uid)`).

## Files changed

- `firestore.rules`

## Testing

- `npm run typecheck` passes (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- Rule follows the same owner-scoped pattern as the existing `subscriptions`/`goals` blocks and the app's canonical `userId` field.

Closes #318
