### PR TITLE
fix(rules): add owner-scoped anomalies collection rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -79,6 +79,16 @@ service cloud.firestore {
       allow delete: if isOwner(existing().ownerId) || isAdmin();
     }
 
+    match /anomalies/{anomalyId} {
+      // SECURITY: Per-user RLS for the anomalies collection
+      // Prevents cross-user access to anomaly detection data
+      allow get: if isOwner(existing().userId);
+      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
+      allow create: if isSignedIn() && isOwner(incoming().userId);
+      allow update: if isOwner(existing().userId) || isAdmin();
+      allow delete: if isOwner(existing().userId) || isAdmin();
+    }
+
     match /subscriptions/{subId} {
       allow read: if isOwner(existing().userId) || isAdmin();
       allow create: if isSignedIn() && isOwner(incoming().userId);


### PR DESCRIPTION
## Problem

The `anomalies` collection is created and read client-side (`runAnomalyDetection`, `fetchAnomalies`), but has no `match` block in `firestore.rules`. The default-deny rule silently fails every anomaly read/write, so anomaly detection data never persists and never renders.

## Fix

Add an owner-scoped `match /anomalies/{anomalyId}` block gating read/write on `request.auth.uid == anomaly.userId` (or `isAdmin()`), matching how anomalies are written and filtered (`where('userId', '==', userId)`).

## Files changed

- `firestore.rules`

## Testing

- `npm run typecheck` passes (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- Rule uses the same owner-scoped pattern as the existing blocks.

Closes #319
