### PR TITLE
fix(server): honor abort signal on AI analysis timeout

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -771,7 +771,7 @@ CRITICAL RULES:
                 messages,
                 max_tokens: 5000,
                 temperature: 0.2,
-              });
+              }, { signal: controller.signal });
               console.log(
                 "AI_REQUEST_COMPLETE: received response from Llama-3.3-70B-Instruct",
               );


### PR DESCRIPTION
## Problem

The 30s analysis timeout in `server.ts` was a no-op. `controller.abort()` never cancelled the request because `hfClient.chatCompletion()` was called with a single arguments object, while the `@huggingface/inference` SDK types put `signal` on the second `Options` argument. Aborted jobs kept running to completion and stored misleading `"timeout"`-style outcomes.

## Fix

Pass `{ signal: controller.signal }` as the second argument to `hfClient.chatCompletion()`, so the timeout actually aborts the underlying HTTP request.

## Files changed

- `server.ts`

## Testing

- `npm run typecheck` passes for `server.ts` (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- Signature verified against `node_modules/@huggingface/inference` types.

Closes #321
