### PR TITLE
fix(analyses): allow owner-scoped list queries on document analyses

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -64,7 +64,8 @@ service cloud.firestore {
     match /documents/{docId}/analyses/{analysisId} {
       // SECURITY: Only allow reading own analyses or if admin
       // Prevents cross-user data leakage of financial AI analysis results
-      allow read: if isOwner(existing().ownerId) || isAdmin();
+      allow get: if isOwner(existing().ownerId) || isAdmin();
+      allow list: if request.auth != null && (request.query.ownerId == request.auth.uid || isAdmin());
       allow create: if isSignedIn() && isValidAnalysis(incoming());
       allow update: if isAdmin();
       allow delete: if isOwner(existing().ownerId) || isAdmin();

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -114,6 +114,7 @@ export function Dashboard({ user, userProfile, onAction, onDocSelect }: any) {
             if (!analysisData) {
               const analysesQuery = query(
                 collection(db, "documents", doc.id, "analyses"),
+                where("ownerId", "==", user.uid),
                 orderBy("processedAt", "desc"),
                 limit(1),
               );


### PR DESCRIPTION
## Problem

The `documents/{docId}/analyses` subcollection only declared `allow read`, which permits `get` but not `list`. The dashboard and analysis list query the subcollection with `getDocs(... where('ownerId', '==', user.uid))`, so list requests are denied by the rules.

## Fix

- In `firestore.rules`, split `allow read` into `allow get` (owner/admin) and `allow list` requiring `request.query.ownerId == request.auth.uid || isAdmin()`.
- In `Dashboard.tsx`, add the `ownerId` filter to the analyses query so the list request matches the rule (it already orders by `processedAt` and limits to 1).

## Files changed

- `firestore.rules`
- `src/components/Dashboard.tsx`

## Testing

- `npm run typecheck` passes (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- The dashboard analyses query now filters by `ownerId`, consistent with the `request.query.ownerId` rule.

Closes #320
