### PR TITLE
fix(privacy): allow right-to-erasure batch deletes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -51,6 +51,29 @@ service cloud.firestore {
       allow read: if isOwner(userId) || isAdmin();
       allow create: if isAuthenticatedOwner(userId) && isValidUser(incoming()) && incoming().role != 'admin';
       allow update: if (isOwner(userId) && incoming().diff(existing()).affectedKeys().hasOnly(['displayName', 'photoURL'])) || isAdmin();
+      allow delete: if isOwner(userId) || isAdmin();
+    }
+
+    match /privacy_settings/{userId} {
+      allow read: if isOwner(userId) || isAdmin();
+      allow create: if isSignedIn() && isOwner(userId);
+      allow update: if isOwner(userId) || isAdmin();
+      allow delete: if isOwner(userId) || isAdmin();
+    }
+
+    match /currencies/{userId} {
+      allow read: if isOwner(userId) || isAdmin();
+      allow create: if isSignedIn() && isOwner(userId);
+      allow update: if isOwner(userId) || isAdmin();
+      allow delete: if isOwner(userId) || isAdmin();
+    }
+
+    match /reports/{reportId} {
+      allow get: if isOwner(existing().userId) || isAdmin();
+      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
+      allow create: if isSignedIn() && isOwner(incoming().userId);
+      allow update: if isOwner(existing().userId) || isAdmin();
+      allow delete: if isOwner(existing().userId) || isAdmin();
     }
 
     match /documents/{docId} {


### PR DESCRIPTION
## Problem

`deleteUserData` in `src/lib/privacyUtils.ts` never erases anything. The atomic `writeBatch` deletes the `users/{uid}`, `privacy_settings/{uid}`, and `currencies/{uid}` documents, but:

- `users` has no `allow delete`, and
- `privacy_settings`, `currencies`, and `reports` have no `match` block at all,

so the default-deny rule rejects the whole commit and the right-to-erasure flow silently no-ops. (The `transactions` and `anomalies` collection rules are covered by #318 and #319 respectively.)

## Fix

- Add `allow delete: if isOwner(userId) || isAdmin()` to the `users` match block.
- Add owner-scoped match blocks for `privacy_settings`, `currencies` (doc id = uid) and `reports` (owner field `userId`, with `get`/`list`/`create`/`update`/`delete`).
- The delete confirmation dialog in `PrivacyDashboard` already acts as the user-confirmation guard; audit logging stays server-side since `auditLogs` only accepts Admin SDK tokens.

## Files changed

- `firestore.rules`

## Testing

- `npm run typecheck` passes (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- New rules match the app's canonical `userId` field and the doc-id = uid pattern used for per-user settings.

Closes #323
