### PR TITLE
fix(subscriptions): query transactions by userId

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -25,7 +25,7 @@ import {
 
 export interface Transaction {
   id: string;
-  ownerId: string;
+  userId: string;
   amount: number;
   category: string;
   description: string;
@@ -137,7 +137,7 @@ export async function fetchUserTransactions(
   try {
     const q = query(
       collection(db, "transactions"),
-      where("ownerId", "==", userId),
+      where("userId", "==", userId),
       where("date", ">=", Timestamp.fromDate(subDays(new Date(), daysBack))),
     );
     const snapshot = await getDocs(q);
@@ -145,7 +145,7 @@ export async function fetchUserTransactions(
       const data = doc.data();
       return {
         id: doc.id,
-        ownerId: data.ownerId || "",
+        userId: data.userId || "",
         amount: data.amount || 0,
         category: data.category || "Other",
         description: data.description || "",


### PR DESCRIPTION
## Problem

`fetchUserTransactions` in `subscriptionUtils.ts` queried the `transactions` collection with `where('ownerId', '==', userId)`, but transactions are stored and filtered with `userId` everywhere else in the app (billUtils, trendsUtils, reportUtils, portfolioUtils). The mismatch meant subscription detection never saw any transactions.

## Fix

Use the canonical `userId` field for the query filter and for the mapped `Transaction` interface in `subscriptionUtils.ts`.

## Files changed

- `src/lib/subscriptionUtils.ts`

## Testing

- `npm run typecheck` passes for the changed file (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).

Closes #324
