### PR TITLE
fix(reports): format currency using user's base currency

### DIFF
--- a/src/components/reports/ReportExport.tsx
+++ b/src/components/reports/ReportExport.tsx
@@ -4,7 +4,8 @@
  */
 
 import { useState, useEffect, useRef, useMemo } from "react";
-import { auth } from "@/src/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { auth, db } from "@/src/lib/firebase";
 import { Button } from "@/src/components/ui/button";
 import {
   Card,
@@ -120,6 +121,7 @@ export function ReportExport() {
   const [transactions, setTransactions] = useState<ReportTransaction[]>([]);
   const [reportData, setReportData] = useState<ReportData | null>(null);
   const [showPreview, setShowPreview] = useState(false);
+  const [baseCurrency, setBaseCurrency] = useState("INR");
 
   const expenseChartRef = useRef<HTMLDivElement>(null);
   const incomeChartRef = useRef<HTMLDivElement>(null);
@@ -150,6 +152,22 @@ export function ReportExport() {
   );
 
   useEffect(() => {
+    const loadCurrency = async () => {
+      if (!auth.currentUser) return;
+      try {
+        const snap = await getDoc(doc(db, "currencies", auth.currentUser.uid));
+        if (snap.exists()) {
+          const data = snap.data() as { baseCurrency?: string };
+          if (data.baseCurrency) setBaseCurrency(data.baseCurrency);
+        }
+      } catch (e) {
+        console.error("Failed to load currency settings:", e);
+      }
+    };
+    loadCurrency();
+  }, []);
+
+  useEffect(() => {
     const fetchData = async () => {
       if (!auth.currentUser) return;
       setLoading(true);
@@ -178,6 +196,7 @@ export function ReportExport() {
       transactions,
       expenseSummary,
       incomeSummary,
+      baseCurrency,
     );
     setReportData(data);
     setShowPreview(true);
@@ -436,7 +455,7 @@ export function ReportExport() {
                       {loading ? (
                         <Skeleton className="h-8 w-20 bg-slate-700" />
                       ) : (
-                        formatCurrency(totalIncome - totalExpenses)
+                        formatCurrency(totalIncome - totalExpenses, baseCurrency)
                       )}
                     </p>
                   </div>
@@ -510,7 +529,7 @@ export function ReportExport() {
                             fontSize={12}
                             tickLine={false}
                             axisLine={false}
-                            tickFormatter={(val) => `₹${val}`}
+                            tickFormatter={(val) => formatCurrency(val, baseCurrency)}
                           />
                           <Tooltip
                             contentStyle={{
@@ -520,7 +539,7 @@ export function ReportExport() {
                             }}
                             itemStyle={{ color: "#f8fafc" }}
                             formatter={(value: any) => [
-                              formatCurrency(value),
+                              formatCurrency(value, baseCurrency),
                               "Total",
                             ]}
                           />
@@ -584,7 +603,7 @@ export function ReportExport() {
                             }}
                             itemStyle={{ color: "#f8fafc" }}
                             formatter={(value: any) => [
-                              formatCurrency(value),
+                              formatCurrency(value, baseCurrency),
                               "Total",
                             ]}
                           />

--- a/src/components/reports/ReportPreview.tsx
+++ b/src/components/reports/ReportPreview.tsx
@@ -39,7 +39,9 @@ export function ReportPreview({ reportData }: ReportPreviewProps) {
     totalIncome,
     totalExpenses,
     transactions,
+    currency,
   } = reportData;
+  const reportCurrency = currency || "INR";
 
   return (
     <div className="space-y-6">
@@ -61,7 +63,7 @@ export function ReportPreview({ reportData }: ReportPreviewProps) {
                   Total Income
                 </p>
                 <p className="text-lg font-bold text-emerald-400 tabular-nums">
-                  {formatCurrency(totalIncome)}
+                  {formatCurrency(totalIncome, reportCurrency)}
                 </p>
               </div>
               <div className="w-px bg-slate-800" />
@@ -70,7 +72,7 @@ export function ReportPreview({ reportData }: ReportPreviewProps) {
                   Total Expenses
                 </p>
                 <p className="text-lg font-bold text-red-400 tabular-nums">
-                  {formatCurrency(totalExpenses)}
+                  {formatCurrency(totalExpenses, reportCurrency)}
                 </p>
               </div>
             </div>
@@ -115,7 +117,7 @@ export function ReportPreview({ reportData }: ReportPreviewProps) {
                             {item.count}
                           </TableCell>
                           <TableCell className="text-right text-slate-300 text-sm font-semibold tabular-nums">
-                            {formatCurrency(item.total)}
+                            {formatCurrency(item.total, reportCurrency)}
                           </TableCell>
                         </TableRow>
                       ))}
@@ -162,7 +164,7 @@ export function ReportPreview({ reportData }: ReportPreviewProps) {
                             {item.count}
                           </TableCell>
                           <TableCell className="text-right text-slate-300 text-sm font-semibold tabular-nums">
-                            {formatCurrency(item.total)}
+                            {formatCurrency(item.total, reportCurrency)}
                           </TableCell>
                         </TableRow>
                       ))}

--- a/src/lib/reportUtils.ts
+++ b/src/lib/reportUtils.ts
@@ -47,13 +47,17 @@ export interface ReportData {
   incomeSummary: IncomeSummaryItem[];
   totalIncome: number;
   totalExpenses: number;
+  currency?: string;
   createdAt: Date;
 }
 
-export function formatCurrency(amount: number): string {
+export function formatCurrency(
+  amount: number,
+  currencyCode: string = "INR",
+): string {
   return new Intl.NumberFormat("en-IN", {
     style: "currency",
-    currency: "INR",
+    currency: currencyCode,
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
   }).format(amount);
@@ -265,16 +269,18 @@ export async function generatePDF(
   pdf.text("Summary", margin, y);
   y += 6;
 
+  const currency = reportData.currency || "INR";
+
   pdf.setFontSize(10);
   pdf.setTextColor(51, 65, 85);
   pdf.text(
-    `Total Income: ${formatCurrency(reportData.totalIncome)}`,
+    `Total Income: ${formatCurrency(reportData.totalIncome, currency)}`,
     margin,
     y,
   );
   y += 6;
   pdf.text(
-    `Total Expenses: ${formatCurrency(reportData.totalExpenses)}`,
+    `Total Expenses: ${formatCurrency(reportData.totalExpenses, currency)}`,
     margin,
     y,
   );
@@ -293,7 +299,7 @@ export async function generatePDF(
       y = margin;
     }
     pdf.text(
-      `${item.category}: ${formatCurrency(item.total)} (${item.count} transactions)`,
+      `${item.category}: ${formatCurrency(item.total, currency)} (${item.count} transactions)`,
       margin + 4,
       y,
     );
@@ -319,7 +325,7 @@ export async function generatePDF(
       y = margin;
     }
     pdf.text(
-      `${item.source}: ${formatCurrency(item.total)} (${item.count} transactions)`,
+      `${item.source}: ${formatCurrency(item.total, currency)} (${item.count} transactions)`,
       margin + 4,
       y,
     );
@@ -367,6 +373,7 @@ export function buildReportData(
   transactions: ReportTransaction[],
   expenseSummary: ExpenseSummaryItem[],
   incomeSummary: IncomeSummaryItem[],
+  currency: string = "INR",
 ): ReportData {
   const totalIncome = incomeSummary.reduce((sum, item) => sum + item.total, 0);
   const totalExpenses = expenseSummary.reduce(
@@ -382,6 +389,7 @@ export function buildReportData(
     incomeSummary,
     totalIncome,
     totalExpenses,
+    currency,
     createdAt: new Date(),
   };
 }
@@ -406,6 +414,7 @@ export async function saveReportToFirestore(
       },
       totalIncome: reportData.totalIncome,
       totalExpenses: reportData.totalExpenses,
+      currency: reportData.currency || "INR",
       createdAt: new Date().toISOString(),
     };
     await setDoc(newDocRef, payload);


### PR DESCRIPTION
## Problem

`formatCurrency` in `reportUtils.ts` hardcoded `en-IN` / `INR`, so PDF, CSV, and preview reports always displayed amounts in Indian Rupees regardless of the user's configured base currency. The report charts also hardcoded the `₹` symbol in the Y-axis tick formatter.

## Fix

- `src/lib/reportUtils.ts`: `formatCurrency(amount, currencyCode = "INR")` now formats with the given currency; `ReportData` gains an optional `currency` field; `buildReportData` accepts and stores it; `saveReportToFirestore` persists it; `generatePDF` formats totals and category lines with it.
- `src/components/reports/ReportExport.tsx`: loads the user's `baseCurrency` from the `currencies/{uid}` doc and uses it for the net-balance, chart tooltips, and Y-axis tick formatter (replacing the hardcoded `₹`).
- `src/components/reports/ReportPreview.tsx`: formats totals and per-category amounts using `reportData.currency`.

## Files changed

- `src/lib/reportUtils.ts`
- `src/components/reports/ReportExport.tsx`
- `src/components/reports/ReportPreview.tsx`

## Testing

- `npm run typecheck` passes for the changed files (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- Existing callers that don't pass a currency keep the previous INR default.

Closes #325
