### PR TITLE
fix(auth): remove hardcoded admin email

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,10 +234,7 @@ export default function App() {
     username: currentUser.displayName || "",
     email: currentUser.email,
     emailVerified: currentUser.emailVerified,
-    role:
-      currentUser.email === "aakash.ra613@gmail.com"
-        ? "admin"
-        : "junior_analyst",
+    role: "junior_analyst",
     createdAt: new Date().toISOString(),
   });
 


### PR DESCRIPTION
## Problem

`getDefaultProfile` in `src/App.tsx` granted the `admin` role to a single hardcoded email (`aakash.ra613@gmail.com`). Role assignment depended on a magic constant embedded in client code, and the privileged account was exposed in the source.

## Fix

Default the role to `junior_analyst` for all new users. Admin promotion is left to the server-side `users/{uid}` document, which the Firestore rules already protect (create requires `role != 'admin'`; update only allows `displayName`/`photoURL`), so no client can self-promote.

## Files changed

- `src/App.tsx`

## Testing

- `npm run typecheck` passes for the changed file (only the pre-existing `RolloverManager.tsx:530` error on `main` remains, unrelated).
- No other email-based admin checks remain in `src/`.

Closes #326
