### PR TITLE
fix: added missing getDocs import in CurrencyManager.tsx

### DIFF
--- a/src/components/currency/CurrencyManager.tsx
+++ b/src/components/currency/CurrencyManager.tsx
@@ -5,6 +5,7 @@ import {
   doc,
   setDoc,
   getDoc,
+  getDocs,
   onSnapshot,
   addDoc,
   updateDoc,


### PR DESCRIPTION
## Description

Added the missing `getDocs` import from `firebase/firestore` in `src/components/currency/CurrencyManager.tsx`. The `getDocs` function was used on line 153 to query Firestore transactions but was not imported, causing a TypeScript error.

## Changes Made

- Added `getDocs` to the existing `firebase/firestore` import block in `CurrencyManager.tsx`

## Impact

Fixes TypeScript compilation error: `Cannot find name 'getDocs'. Did you mean 'getDoc'?`. The currency transaction listing feature will now compile correctly.

## Checklist

- [x] Added missing import
- [x] No functional changes
- [x] TypeScript compiles
