### PR TITLE
fix: corrected spending pattern average calculation in chatUtils.ts

### DIFF
--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -327,7 +327,7 @@ export function generateBudgetAdvice(context: FinancialContext): ChatResponse {
 }
 
 export function analyzeSpendingPatterns(context: FinancialContext): ChatResponse {
-  const { monthlySpending, spendingByMonth, totalSpending } = context;
+  const { monthlySpending, spendingByMonth } = context;
   const months = Object.keys(monthlySpending).sort((a, b) => a - b);
   let response = '';
 
@@ -349,7 +349,7 @@ export function analyzeSpendingPatterns(context: FinancialContext): ChatResponse
     response += `Spending increased by ${formatCurrency(maxIncrease.amount)} in ${maxIncrease.month}. `;
   }
 
-  const avg = totalSpending / Math.max(spendingByMonth.length, 1);
+  const avg = spendingByMonth.reduce((sum, m) => sum + m.amount, 0) / spendingByMonth.length;
   response += `Your average monthly spending is ${formatCurrency(Math.round(avg))}.`;
 
   return {


### PR DESCRIPTION
## Description

Corrected the average monthly spending calculation in the `analyzeSpendingPatterns` function in `src/lib/chatUtils.ts`. The previous calculation used `totalSpending / spendingByMonth.length` which incorrectly divided all-time spending by the count of months in the filtered 6-month window, producing inflated averages.

## Changes Made

- Changed the average calculation to use `spendingByMonth.reduce((sum, m) => sum + m.amount, 0) / spendingByMonth.length`, summing only the amounts from the actual months in the filtered window
- Removed unused `totalSpending` from destructuring

## Impact

Spending pattern analysis now reports accurate average monthly spending based only on the months included in the analysis window.

## Checklist

- [x] Corrected calculation
- [x] Removed unused variable
- [x] No functional changes to other functions
