### PR TITLE
fix: use suggestions prop for empty-state check in BudgetRecommendations.tsx

### DIFF
--- a/src/components/budget/BudgetRecommendations.tsx
+++ b/src/components/budget/BudgetRecommendations.tsx
@@ -127,7 +127,7 @@ export function BudgetRecommendations({
     );
   }
 
-  if (!localSuggestions || localSuggestions.length === 0) {
+  if (!suggestions || suggestions.length === 0) {
     return (
       <Card className="bg-slate-900 border-slate-800 rounded-2xl">
         <CardContent className="p-8 flex flex-col items-center justify-center min-h-[300px]">


### PR DESCRIPTION
## Description

Fixed the empty-state conditional in `src/components/budget/BudgetRecommendations.tsx` to check the `suggestions` prop instead of the `localSuggestions` state. When the parent component clears all suggestions (e.g., after the user rejects all), the empty state UI now correctly displays instead of rendering an empty list from stale local state.

## Changes Made

- Changed `if (!localSuggestions || localSuggestions.length === 0)` to `if (!suggestions || suggestions.length === 0)` on line 130

## Impact

Users will now see the empty-state prompt when all budget suggestions have been rejected, rather than a blank content area.

## Checklist

- [x] Empty-state check now uses prop
- [x] No other changes
