### PR TITLE
fix: prevent repeated goal-completion notifications in GoalPlanner.tsx

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -71,6 +71,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
   const notifiedGoalIds = useRef(new Set<string>());
+  const updatingGoalIds = useRef(new Set<string>());
 
   const [formName, setFormName] = useState('');
   const [formTarget, setFormTarget] = useState('');
@@ -133,14 +134,18 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
     goals.forEach((goal) => {
       if (goal.status === 'completed') return;
       if (notifiedGoalIds.current.has(goal.id)) return;
+      if (updatingGoalIds.current.has(goal.id)) return;
       const isComplete = goal.currentAmount >= goal.targetAmount;
       if (isComplete) {
         notifiedGoalIds.current.add(goal.id);
+        updatingGoalIds.current.add(goal.id);
         toast.success(`Goal reached: ${goal.name}!`, {
           description: `You've reached ${formatCurrency(goal.targetAmount)}.`,
           duration: 5000,
         });
-        updateGoalStatus(goal.id, 'completed', goal.currentAmount);
+        updateGoalStatus(goal.id, 'completed', goal.currentAmount).finally(() => {
+          updatingGoalIds.current.delete(goal.id);
+        });
       }
     });
   }, [goals, user]);


### PR DESCRIPTION
## Description

Prevented repeated toast notifications and Firestore writes for goal completion in `src/components/goals/GoalPlanner.tsx`. The existing `notifiedGoalIds` Set prevented duplicate toasts, but the async `updateGoalStatus` call could still fire multiple times before the Firestore write completed and triggered a re-render.

## Changes Made

- Added `updatingGoalIds` Set ref to track goals currently being written to Firestore
- Added check `if (updatingGoalIds.current.has(goal.id)) return;` before processing a goal
- Wrapped `updateGoalStatus` call with `.finally()` to remove the goal ID from `updatingGoalIds` after the write completes

## Impact

Eliminates duplicate toast notifications and redundant Firestore writes when a goal reaches its target amount.

## Checklist

- [x] Added deduplication for Firestore writes
- [x] Toast deduplication preserved
- [x] No other changes
