### PR TITLE
fix: added unused CheckCircle2Icon removal from AnalysisList.tsx

### DIFF
--- a/src/components/AnalysisList.tsx
+++ b/src/components/AnalysisList.tsx
@@ -334,22 +334,4 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function CheckCircle2Icon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z" />
-      <path d="m9 12 2 2 4-4" />
-    </svg>
-  );
-}
+


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the unused `CheckCircle2Icon` function from `src/components/AnalysisList.tsx`. The function was defined but never referenced anywhere in the component. The `CheckCircle2` icon from lucide-react is already imported and used directly, making this custom component redundant dead code.

## Changes Made

- Removed `CheckCircle2Icon` function (lines 337-355) from `src/components/AnalysisList.tsx`

## Impact it Made

- Eliminates dead code from the codebase
- Reduces confusion for future maintainers
- Clean lint output for the unused function

Closes #366

## Note: Please assign this PR to the `tmdeveloper007` account.