### PR TITLE
fix: added unused import cleanup in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,20 +26,12 @@ import {
   LayoutDashboard,
   FileText,
   ShieldCheck,
-  Settings,
   LogOut,
   Upload,
   Search,
   Clock,
   Briefcase,
   AlertTriangle,
-  History,
-  FileSearch,
-  Filter,
-  Lock,
-  Zap,
-  Activity,
-  Target,
   Bell,
   Trophy,
   Wallet,
@@ -66,7 +58,6 @@ import {
 } from "@/src/components/ui/card";
 import {
   Tabs,
-  TabsContent,
   TabsList,
   TabsTrigger,
 } from "@/src/components/ui/tabs";


### PR DESCRIPTION
## Summary of What Has Been Done

Removed all unused imports from `src/App.tsx`:
- Lucide-react icon imports: `Settings`, `History`, `FileSearch`, `Filter`, `Lock`, `Zap`, `Activity`, `Target`
- `TabsContent` from `@/src/components/ui/tabs`

## Changes Made

- Removed 8 unused lucide-react icon imports from `src/App.tsx`
- Removed unused `TabsContent` import from `src/App.tsx`

## Impact it Made

- Clean lint output for removed unused imports
- Improved code readability and maintainability
- Reduced import clutter

Closes #367
Closes #368

## Note: Please assign this PR to the `tmdeveloper007` account.