### PR TITLE
fix: added unused formatDateSafe removal from BillCard.tsx

### DIFF
--- a/src/components/bills/BillCard.tsx
+++ b/src/components/bills/BillCard.tsx
@@ -8,7 +8,7 @@ import { Calendar, CreditCard, Tag, AlertTriangle, Clock, CheckCircle2 } from 'l
 import { Card, CardContent, CardHeader, CardTitle } from '@/src/components/ui/card';
 import { Badge } from '@/src/components/ui/badge';
 import { Button } from '@/src/components/ui/button';
-import { cn, formatCurrency, formatDateSafe, toDate } from '@/src/lib/utils';
+import { cn, formatCurrency, toDate } from '@/src/lib/utils';
 import { type Bill, getDaysUntilDue, isOverdue } from '@/src/lib/billUtils';
 
 interface BillCardProps {


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the unused `formatDateSafe` import from `src/components/bills/BillCard.tsx`. The function was imported but never used in the component.

## Changes Made

- Removed `formatDateSafe` from the utils import in `src/components/bills/BillCard.tsx`

## Impact it Made

- Clean lint output
- Reduced import clutter

Closes #369

## Note: Please assign this PR to the `tmdeveloper007` account.