### PR TITLE
fix: remove sensitive Firebase configs and temp files from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,14 @@ coverage/
 *.log
 .env*
 !.env.example
+
+# Firebase sensitive configs
 firebase-applet-config.json
+firebase-blueprint.json
+temp_*.txt
+*.local.json
+
+# Sensitive environment files
+.env.local
+.env.development.local
+.env.production.local


### PR DESCRIPTION
Closes #188

- Add firebase-blueprint.json to .gitignore
- Add temp_*.txt patterns to .gitignore
- Add *.local.json pattern to .gitignore
- Add explicit .env.local and .env.*.local entries
- Document security concerns in .gitignore comments

These changes prevent accidental commits of sensitive configuration files and temporary development files that may contain API keys or other credentials.