### PR TITLE
feat: Add system theme option to comprehensive theme switcher

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,23 +1,42 @@
-import { Sun, Moon } from "lucide-react";
+import { Sun, Moon, Monitor } from "lucide-react";
 import { useTheme } from "@/src/lib/themeContext";
 import { Button } from "@/src/components/ui/button";
 
+type ThemeOption = "dark" | "light" | "system";
+
 export function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
+
+  // Cycle through themes: dark -> light -> system -> dark
+  const cycleTheme = () => {
+    const themes: ThemeOption[] = ["dark", "light", "system"];
+    const currentIndex = themes.indexOf(theme as ThemeOption);
+    const nextTheme = themes[(currentIndex + 1) % themes.length];
+    setTheme(nextTheme);
+  };
+
+  const getIcon = () => {
+    if (theme === "system") {
+      return <Monitor className="h-4 w-4" />;
+    }
+    return theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />;
+  };
+
+  const getLabel = () => {
+    if (theme === "system") return "Switch to dark mode";
+    return theme === "dark" ? "Switch to light mode" : "Switch to system mode";
+  };
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={toggleTheme}
+      onClick={cycleTheme}
       className="h-9 w-9 rounded-lg text-slate-400 hover:text-white hover:bg-slate-800"
-      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      aria-label={getLabel()}
+      title={getLabel()}
     >
-      {theme === "dark" ? (
-        <Sun className="h-4 w-4" />
-      ) : (
-        <Moon className="h-4 w-4" />
-      )}
+      {getIcon()}
     </Button>
   );
 }

--- a/src/lib/themeContext.tsx
+++ b/src/lib/themeContext.tsx
@@ -1,38 +1,67 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 
-type Theme = "dark" | "light";
+type Theme = "dark" | "light" | "system";
 
 interface ThemeContextValue {
   theme: Theme;
   toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: "dark" | "light";
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
+function getSystemTheme(): "dark" | "light" {
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
+  const [theme, setThemeState] = useState<Theme>(() => {
     if (typeof window === "undefined") return "dark";
     const stored = localStorage.getItem("theme");
-    if (stored === "light" || stored === "dark") return stored;
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    if (stored === "light" || stored === "dark" || stored === "system") return stored;
+    return "system";
   });
+
+  const [systemTheme, setSystemTheme] = useState<"dark" | "light">(getSystemTheme);
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) => {
+      setSystemTheme(e.matches ? "dark" : "light");
+    };
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, []);
+
+  const resolvedTheme = theme === "system" ? systemTheme : theme;
 
   useEffect(() => {
     const root = document.documentElement;
-    if (theme === "dark") {
+    if (resolvedTheme === "dark") {
       root.classList.add("dark");
     } else {
       root.classList.remove("dark");
     }
     localStorage.setItem("theme", theme);
-  }, [theme]);
+  }, [theme, resolvedTheme]);
 
   const toggleTheme = () => {
-    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+    setThemeState((prev) => {
+      if (prev === "dark") return "light";
+      if (prev === "light") return "system";
+      return "dark";
+    });
+  };
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
   };
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme, resolvedTheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary

Enhances the theme switcher with a system theme option that follows OS preferences.

## What Changed

**ThemeToggle Component:**
- Cycles through themes: Dark → Light → System → Dark
- Added Monitor icon for system theme option
- Shows appropriate icon based on current theme

**ThemeContext:**
- Added "system" theme option
- Listens for system preference changes in real-time
- Added `setTheme()` function for direct theme control
- Added `resolvedTheme` computed property for actual applied theme
- Persists theme preference to localStorage

## Why

Users should have three theme options:
1. **Dark mode** - For night use
2. **Light mode** - For day use
3. **System** - Automatically follows OS preference, updates when system preference changes

## How to Test

1. Click the theme toggle button in the app
2. Observe cycling through: Moon (dark) → Sun (light) → Monitor (system)
3. Change OS dark/light mode setting
4. Verify "system" mode automatically follows

Closes #356