### PR TITLE
fix(tax): compare against same-jurisdiction history instead of different jurisdiction

### DIFF
--- a/src/components/tax/TaxEstimation.tsx
+++ b/src/components/tax/TaxEstimation.tsx
@@ -89,10 +89,13 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
           orderBy('createdAt', 'desc')
         );
         const snapshot = await getDocs(q);
-        // Pick the latest record that differs from the current selection
-        const prev = snapshot.docs
-          .map((d) => ({ id: d.id, ...(d.data() as Omit<TaxEstimateRecord, 'id'>) }))
-          .find((r) => r.country !== country?.name || r.region !== regions.find((x) => x.code === regionCode)?.name);
+        // Pick the latest record that matches the current jurisdiction
+        const currentRegionName = regions.find((x) => x.code === regionCode)?.name;
+        const records = snapshot.docs
+          .map((d) => ({ id: d.id, ...(d.data() as Omit<TaxEstimateRecord, 'id'>) }));
+        const prev = records.find(
+          (r) => r.country === country?.name && r.region === currentRegionName
+        );
         if (prev) {
           setPreviousYear({
             ...prev,


### PR DESCRIPTION
The tax comparison predicate at lines 92-95 was selecting the first historical record where country or region *differed* from the current selection, then labelling it as the previous estimate for that jurisdiction. Inverted the filter to match the same country and region so the comparison card shows the actual prior estimate for the selected jurisdiction.

Fixes #245