### PR TITLE
fix(goals): render paused goals in their own section so they remain visible and resumable

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -160,6 +160,11 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
     [goals]
   );
 
+  const pausedGoals = useMemo(
+    () => goals.filter((g) => g.status === 'paused'),
+    [goals]
+  );
+
   const createGoal = async () => {
     if (!user) return;
     if (!formName.trim()) {
@@ -477,6 +482,35 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {completedGoals.map((goal) => (
+                  <motion.div
+                    key={goal.id}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <GoalCard
+                      goal={goal}
+                      onUpdateAmount={updateGoalAmount}
+                      onViewDetails={setSelectedGoal}
+                      onStatusChange={(id, status) => updateGoalStatus(id, status)}
+                      onDelete={deleteGoal}
+                    />
+                  </motion.div>
+                ))}
+              </div>
+            </div>
+          )}
+          {pausedGoals.length > 0 && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Pause className="h-4 w-4 text-amber-400" />
+                <h2 className="text-lg font-semibold text-white">Paused Goals</h2>
+                <Badge variant="outline" className="bg-amber-500/10 text-amber-400 border-amber-500/30 text-[10px] uppercase tracking-wider">
+                  {pausedGoals.length}
+                </Badge>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {pausedGoals.map((goal) => (
                   <motion.div
                     key={goal.id}
                     initial={{ opacity: 0, y: 10 }}


### PR DESCRIPTION
GoalPlanner only filtered for `active` and `completed` statuses, so paused goals dropped out of the view entirely. Added a `pausedGoals` memo and a dedicated Paused Goals section (with amber-colored Pause icon and count badge) rendered between the completed goals and the empty state. GoalCard already has the Resume action when `status === 'paused'`, so no card-level changes were needed.

Fixes #246