### PR TITLE
fix(chat): normalize Firestore Timestamp to ISO string when loading messages

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -201,7 +201,12 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
             userId: data.userId || '',
             role: data.role || 'user',
             content: data.content || '',
-            timestamp: data.timestamp || new Date().toISOString(),
+            timestamp: (() => {
+              const ts = data.timestamp;
+              if (!ts) return new Date().toISOString();
+              if (typeof ts.toDate === 'function') return ts.toDate().toISOString();
+              return String(ts);
+            })(),
             metadata: data.metadata,
           });
         });
@@ -423,7 +428,8 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
   };
 
   const formatMessageTime = (timestamp: string) => {
-    const date = new Date(timestamp);
+    const ts = timestamp as any;
+    const date = typeof ts?.toDate === 'function' ? ts.toDate() : new Date(timestamp);
     return format(date, 'h:mm a');
   };
 


### PR DESCRIPTION
When messages are loaded from Firestore, `data.timestamp` is a `Timestamp` object, not a string. Passing it directly to `new Date()` or string-based date formatters produces invalid dates after reload.

Fixed by:
1. Normalizing `data.timestamp` in the message mapping: if it has a `toDate()` method (Firestore Timestamp), call it and return an ISO string; otherwise coerce to string.
2. Making `formatMessageTime` resilient as a secondary safeguard — if a Timestamp leaks through, it calls `toDate()` before constructing the Date.

Fixes #248