### PR TITLE
fix(chat): persist conversation title and last-message time on first message only

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -311,6 +311,7 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
     setSuggestions(response.suggestions || []);
 
     const conversation = conversations.find((c) => c.id === currentConversationId);
+    const isDefaultTitle = !conversation || conversation.title === 'New Chat';
     const derivedTitle = content.trim().slice(0, 50) + (content.trim().length > 50 ? '...' : '');
     if (conversation) {
       setConversations((prev) =>
@@ -318,7 +319,7 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
           c.id === currentConversationId
             ? {
                 ...c,
-                title: derivedTitle,
+                ...(isDefaultTitle ? { title: derivedTitle } : {}),
                 updatedAt: new Date().toISOString(),
                 lastMessageAt: new Date().toISOString(),
               }
@@ -326,7 +327,7 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
         )
       );
       await updateConversation(currentConversationId, {
-        title: derivedTitle,
+        ...(isDefaultTitle ? { title: derivedTitle } : {}),
         lastMessageAt: new Date().toISOString(),
       });
     }


### PR DESCRIPTION
Each `handleSendMessage` call overwrote the conversation title with the current message text. On any reload, Firestore returns the title from the *last* message, not the meaningful one the user would expect. The same per-message overwrite also means the title changes unexpectedly mid-session.

Fixed by only updating `title` when the conversation still has the default `'New Chat'` label. Subsequent messages continue to update `lastMessageAt` for correct sidebar ordering but leave the title stable.

Fixes #249