### PR TITLE
fix: wire up working source-file download in analysis list

### DIFF
--- a/src/components/AnalysisList.tsx
+++ b/src/components/AnalysisList.tsx
@@ -14,7 +14,7 @@ import {
   MoreVertical,
   Trash2,
   Eye,
-  ExternalLink,
+  Download,
   Search,
   Filter,
   FileSearch,
@@ -42,12 +42,14 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { toast } from "sonner";
-import { formatDateSafe, isSafeExternalUrl } from "@/src/lib/utils";
+import { apiFetch } from "@/src/lib/api";
+import { formatDateSafe } from "@/src/lib/utils";
 
 export function AnalysisList({ type, user, onSelect }: any) {
   const [documents, setDocuments] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!user) return;
@@ -98,6 +100,65 @@ export function AnalysisList({ type, user, onSelect }: any) {
     } catch (error) {
       handleFirestoreError(error, OperationType.DELETE, `documents/${id}`);
       toast.error("Failed to delete document");
+    }
+  };
+
+  const handleDownload = async (
+    id: string,
+    storagePath: string,
+    fileName: string,
+  ) => {
+    if (!storagePath) {
+      toast.error("Source file is not available for this record");
+      return;
+    }
+
+    setDownloadingId(id);
+    try {
+      let headers: Record<string, string> = {};
+      try {
+        const idToken = await (user as any)?.getIdToken?.();
+        if (idToken) headers["Authorization"] = `Bearer ${idToken}`;
+      } catch (tErr) {
+        console.warn("Could not fetch ID token for document download", tErr);
+      }
+
+      const res = await apiFetch(
+        "/api/document-download-url",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...headers,
+          },
+          body: JSON.stringify({ storagePath }),
+        },
+        { timeout: 30000 },
+      );
+
+      if (!res.ok) {
+        let errorText = "";
+        try {
+          const errorBody = await res.json();
+          errorText = String(errorBody?.error || "");
+        } catch {
+          errorText = await res.text().catch(() => "");
+        }
+        throw new Error(
+          errorText || `Failed to generate download URL (${res.status})`,
+        );
+      }
+
+      const data = await res.json();
+      if (!data?.signedUrl) {
+        throw new Error("Download URL generation returned no URL");
+      }
+      window.open(data.signedUrl, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      handleFirestoreError(error, OperationType.GET, `documents/${id}`);
+      toast.error(`Failed to download ${fileName}`);
+    } finally {
+      setDownloadingId(null);
     }
   };
 
@@ -262,21 +323,17 @@ export function AnalysisList({ type, user, onSelect }: any) {
                         >
                           <Eye size={16} /> View Intelligence Report
                         </DropdownMenuItem>
-                        <DropdownMenuItem className="gap-3 py-2.5 focus:bg-slate-800 focus:text-white rounded-lg p-0">
-                          {isSafeExternalUrl(doc.fileUrl) ? (
-                            <a
-                              href={doc.fileUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="flex items-center gap-3 w-full h-full px-2 py-1"
-                            >
-                              <ExternalLink size={16} /> Open Source File
-                            </a>
-                          ) : (
-                            <span className="flex items-center gap-3 w-full h-full px-2 py-1 text-slate-500 cursor-not-allowed">
-                              <ExternalLink size={16} /> Source file unavailable
-                            </span>
-                          )}
+                        <DropdownMenuItem
+                          onClick={() =>
+                            handleDownload(doc.id, doc.storagePath, doc.fileName)
+                          }
+                          disabled={downloadingId === doc.id}
+                          className="gap-3 py-2.5 focus:bg-slate-800 focus:text-white rounded-lg"
+                        >
+                          <Download size={16} />{" "}
+                          {downloadingId === doc.id
+                            ? "Preparing download..."
+                            : "Download Source File"}
                         </DropdownMenuItem>
                         <DropdownMenuSeparator className="bg-slate-800" />
                         <DropdownMenuItem


### PR DESCRIPTION
## Problem

The "Open Source File" menu item in the analysis list was a disabled placeholder, so there was no working way to download an analysed PDF. The client never called the existing `POST /api/document-download-url` endpoint.

## Fix

- `AnalysisList.tsx`: replaced the dead menu item with a working "Download Source File" action.
- Added `handleDownload`, which POSTs `{ storagePath }` to `/api/document-download-url` with the user's token and opens the returned short-lived signed URL.
- Swapped the placeholder icon for a `Download` icon and added a per-row spinner while the signed URL is being fetched.

## Files changed

- `src/components/AnalysisList.tsx`

## Testing

- Scoped `tsc` typecheck of the changed file passes.

Closes #383
