### PR TITLE
fix: normalize transaction type at write and read

### DIFF
--- a/src/components/currency/CurrencyManager.tsx
+++ b/src/components/currency/CurrencyManager.tsx
@@ -64,6 +64,7 @@ interface Transaction {
   amount: number;
   currency: string;
   category: string;
+  type: 'income' | 'expense';
   date: string;
   createdAt: any;
 }
@@ -86,6 +87,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
     amount: '',
     currency: 'USD',
     category: 'General',
+    type: 'expense' as 'income' | 'expense',
     date: new Date().toISOString().split('T')[0],
   });
   const [editingTx, setEditingTx] = useState<string | null>(null);
@@ -94,6 +96,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
     amount: '',
     currency: 'USD',
     category: 'General',
+    type: 'expense' as 'income' | 'expense',
     date: '',
   });
 
@@ -198,6 +201,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: parseFloat(newTx.amount),
         currency: newTx.currency,
         category: newTx.category,
+        type: newTx.type,
         date: newTx.date,
         createdAt: serverTimestamp(),
       });
@@ -207,6 +211,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: '',
         currency: settings?.baseCurrency || 'USD',
         category: 'General',
+        type: 'expense',
         date: new Date().toISOString().split('T')[0],
       });
     } catch (error) {
@@ -226,6 +231,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: parseFloat(editForm.amount),
         currency: editForm.currency,
         category: editForm.category,
+        type: editForm.type,
         date: editForm.date,
       });
       toast.success('Transaction updated');
@@ -499,7 +505,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
               </CardTitle>
             </CardHeader>
             <CardContent className="p-6">
-              <div className="grid gap-4 md:grid-cols-[2fr_1fr_1fr_1fr_auto]">
+              <div className="grid gap-4 md:grid-cols-[2fr_1fr_1fr_1fr_1fr_auto]">
                 <Input
                   placeholder="Description"
                   value={newTx.description}
@@ -515,6 +521,18 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
                   min="0"
                   step="0.01"
                 />
+                <Select
+                  value={newTx.type}
+                  onValueChange={(val) => setNewTx({ ...newTx, type: val as 'income' | 'expense' })}
+                >
+                  <SelectTrigger className="bg-slate-800 border-slate-700 text-white h-10">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="bg-slate-900 border-slate-800 text-slate-300">
+                    <SelectItem value="expense" className="cursor-pointer">Expense</SelectItem>
+                    <SelectItem value="income" className="cursor-pointer">Income</SelectItem>
+                  </SelectContent>
+                </Select>
                 <Select
                   value={newTx.currency}
                   onValueChange={(val) => setNewTx({ ...newTx, currency: val })}
@@ -614,6 +632,18 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
                               ))}
                             </SelectContent>
                           </Select>
+                          <Select
+                            value={editForm.type}
+                            onValueChange={(val) => setEditForm({ ...editForm, type: val as 'income' | 'expense' })}
+                          >
+                            <SelectTrigger className="bg-slate-800 border-slate-700 text-white h-8 w-24 text-xs">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent className="bg-slate-900 border-slate-800 text-slate-300">
+                              <SelectItem value="expense" className="cursor-pointer text-xs">Expense</SelectItem>
+                              <SelectItem value="income" className="cursor-pointer text-xs">Income</SelectItem>
+                            </SelectContent>
+                          </Select>
                           <Input
                             type="date"
                             value={editForm.date}
@@ -664,6 +694,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
                                   amount: tx.amount.toString(),
                                   currency: tx.currency,
                                   category: tx.category,
+                                  type: tx.type === 'income' ? 'income' : 'expense',
                                   date: tx.date,
                                 });
                               }}

--- a/src/lib/budgetUtils.ts
+++ b/src/lib/budgetUtils.ts
@@ -19,6 +19,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
+import { normalizeTransactionType } from './utils';
 import { toDate } from './utils';
 
 export interface BudgetCategory {
@@ -345,7 +346,7 @@ async function fetchUserTransactionsInRange(
         category: data.category || 'Other',
         date: dateVal.toISOString(),
         description: data.description || '',
-        type: data.type || (data.amount < 0 ? 'expense' : 'income'),
+        type: normalizeTransactionType(data.type),
       });
     });
     transactions.sort((a, b) => b.date.localeCompare(a.date));

--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -8,6 +8,7 @@ import {
   Timestamp,
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
+import { normalizeTransactionType } from "@/src/lib/utils";
 
 export interface Transaction {
   id: string;
@@ -122,7 +123,7 @@ export async function fetchUserTransactions(
           userId: data.userId || "",
           amount: Number(data.amount) || 0,
           category: data.category || "Other",
-          type: data.type === "income" ? "income" : "expense",
+        type: normalizeTransactionType(data.type),
           date,
           description: data.description,
         };

--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -17,7 +17,7 @@ import {
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import { format, subMonths, startOfMonth, endOfMonth } from 'date-fns';
-import { formatCurrency } from '@/src/lib/utils';
+import { formatCurrency, normalizeTransactionType } from '@/src/lib/utils';
 import type { Transaction } from '@/src/lib/trendsUtils';
 
 export interface ChatMessage {
@@ -191,8 +191,12 @@ export function buildFinancialContext(
   transactions: Transaction[],
   budgetCategories: { name: string; monthlyLimit: number }[]
 ): FinancialContext {
-  const expenses = transactions.filter((t) => t.type === 'expense' || !t.type);
-  const income = transactions.filter((t) => t.type === 'income');
+  const expenses = transactions.filter(
+    (t) => normalizeTransactionType(t.type) === 'expense',
+  );
+  const income = transactions.filter(
+    (t) => normalizeTransactionType(t.type) === 'income',
+  );
 
   const totalSpending = expenses.reduce((sum, t) => sum + t.amount, 0);
   const totalIncome = income.reduce((sum, t) => sum + t.amount, 0);

--- a/src/lib/healthUtils.ts
+++ b/src/lib/healthUtils.ts
@@ -16,6 +16,7 @@ import {
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
 import { Transaction } from './anomalyUtils';
+import { normalizeTransactionType } from './utils';
 
 export interface HealthMetric {
   name: string;
@@ -66,7 +67,9 @@ export function getScoreColor(score: number): string {
 }
 
 export function calculateSpendingScore(transactions: Transaction[]): number {
-  const expenses = transactions.filter((t) => t.type === 'expense');
+  const expenses = transactions.filter(
+    (t) => normalizeTransactionType(t.type) === 'expense',
+  );
   if (expenses.length === 0) return 100;
 
   const totalSpent = expenses.reduce((sum, t) => sum + t.amount, 0);
@@ -92,7 +95,9 @@ export function calculateSpendingScore(transactions: Transaction[]): number {
 }
 
 export function calculateSavingsScore(transactions: Transaction[]): number {
-  const expenses = transactions.filter((t) => t.type === 'expense');
+  const expenses = transactions.filter(
+    (t) => normalizeTransactionType(t.type) === 'expense',
+  );
   const income = transactions.filter((t) => t.type === 'income');
 
   const totalExpenses = expenses.reduce((sum, t) => sum + t.amount, 0);
@@ -116,7 +121,9 @@ export function calculateBudgetAdherence(
 ): number {
   if (budgetCategories.length === 0) return 70;
 
-  const expenses = transactions.filter((t) => t.type === 'expense');
+  const expenses = transactions.filter(
+    (t) => normalizeTransactionType(t.type) === 'expense',
+  );
   const categorySpend = new Map<string, number>();
   expenses.forEach((t) => {
     categorySpend.set(t.category, (categorySpend.get(t.category) || 0) + t.amount);

--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -11,6 +11,7 @@ import {
   Timestamp,
 } from "firebase/firestore";
 import { db } from "./firebase";
+import { normalizeTransactionType } from "./utils";
 import {
   subDays,
   addMonths,
@@ -150,7 +151,7 @@ export async function fetchUserTransactions(
         category: data.category || "Other",
         description: data.description || "",
         date: toDate(data.date) || new Date(),
-        type: data.type || "expense",
+        type: normalizeTransactionType(data.type),
       } as Transaction;
     });
   } catch (error) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,6 +27,15 @@ export function formatCurrency(amount: number): string {
   }).format(amount);
 }
 
+// Canonical transaction type shared by every reader. Transactions written
+// without a `type` field (legacy manual entries) default to "expense" so all
+// dashboards classify them identically instead of inferring divergent types.
+export function normalizeTransactionType(
+  value: unknown,
+): "income" | "expense" {
+  return value === "income" ? "income" : "expense";
+}
+
 export function toDate(value: any): Date | null {
   if (!value) return null;
 


### PR DESCRIPTION
## Problem

Manual transactions written by `CurrencyManager` never persisted a `type` field, so each reader inferred it differently: `budgetUtils` used the amount sign, `subscriptionUtils` defaulted to `"expense"`, and `cashflowUtils` / `healthUtils` / `chatUtils` each had their own rule. The same transaction could be classified inconsistently across views.

## Fix

- Added `normalizeTransactionType(value)` to `src/lib/utils.ts`: anything other than exactly `"income"` is treated as `"expense"`.
- `CurrencyManager` now persists `type` on add and edit, with a type select in both the add form and the inline edit form.
- All readers (`budgetUtils`, `subscriptionUtils`, `cashflowUtils`, `healthUtils`, `chatUtils`) now use the shared `normalizeTransactionType` instead of bespoke inference.

## Files changed

- `src/lib/utils.ts`
- `src/components/currency/CurrencyManager.tsx`
- `src/lib/budgetUtils.ts`
- `src/lib/subscriptionUtils.ts`
- `src/lib/cashflowUtils.ts`
- `src/lib/healthUtils.ts`
- `src/lib/chatUtils.ts`

## Testing

- `npm test` passes.
- Scoped `tsc` typechecks pass; no new typecheck errors versus `origin/main`.

Closes #384
