### PR TITLE
fix: persist transaction dates as Timestamps and parse them consistently

### DIFF
--- a/src/components/currency/CurrencyManager.tsx
+++ b/src/components/currency/CurrencyManager.tsx
@@ -33,6 +33,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { motion } from 'motion/react';
+import { toDate } from '@/src/lib/utils';
 import {
   MAJOR_CURRENCIES,
   fetchExchangeRates,
@@ -64,7 +65,7 @@ interface Transaction {
   amount: number;
   currency: string;
   category: string;
-  date: string;
+  date: any;
   createdAt: any;
 }
 
@@ -198,7 +199,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: parseFloat(newTx.amount),
         currency: newTx.currency,
         category: newTx.category,
-        date: newTx.date,
+        date: new Date(newTx.date),
         createdAt: serverTimestamp(),
       });
       toast.success('Transaction added');
@@ -226,7 +227,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: parseFloat(editForm.amount),
         currency: editForm.currency,
         category: editForm.category,
-        date: editForm.date,
+        date: new Date(editForm.date),
       });
       toast.success('Transaction updated');
       setEditingTx(null);
@@ -664,7 +665,9 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
                                   amount: tx.amount.toString(),
                                   currency: tx.currency,
                                   category: tx.category,
-                                  date: tx.date,
+                                  date: toDate(tx.date)
+                                    ? toDate(tx.date)!.toISOString().split('T')[0]
+                                    : '',
                                 });
                               }}
                               className="p-2 rounded-lg text-slate-500 hover:text-indigo-400 hover:bg-slate-800 transition-colors"

--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -14,7 +14,7 @@ import {
   serverTimestamp,
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "./firebase";
-import { formatCurrency } from "./utils";
+import { formatCurrency, toDate } from "./utils";
 import { format, subMonths, startOfMonth } from "date-fns";
 
 export interface Transaction {
@@ -133,10 +133,7 @@ export async function fetchTransactions(
           return { ...data, id: d.id } as Transaction;
         })
         .filter((t) => {
-          const time =
-            t.date instanceof Date
-              ? t.date.getTime()
-              : new Date(t.date as any).getTime();
+          const time = toDate(t.date)?.getTime() ?? 0;
           return time >= startDate.getTime();
         });
     }
@@ -171,7 +168,7 @@ export function calculateCategoryBaseline(
         : 0;
     const monthlyTotals = new Map<string, number>();
     items.forEach((item) => {
-      const date = item.date instanceof Date ? item.date : new Date(item.date);
+      const date = toDate(item.date) || new Date();
       const key = format(date, "yyyy-MM");
       monthlyTotals.set(key, (monthlyTotals.get(key) || 0) + Math.abs(item.amount));
     });
@@ -213,7 +210,7 @@ export function detectCategorySpikes(
   const byCategory = new Map<string, Transaction[]>();
 
   transactions.forEach((transaction) => {
-    const date = transaction.date instanceof Date ? transaction.date : new Date(transaction.date);
+    const date = toDate(transaction.date) || new Date();
     if (format(date, "yyyy-MM") !== currentMonth) return;
     const category = transaction.category || "Other";
     byCategory.set(category, [...(byCategory.get(category) || []), transaction]);
@@ -328,7 +325,7 @@ export function detectAnomalies(
   const monthlySpend = new Map<string, Map<string, number>>();
   transactions.forEach((t) => {
     const monthKey = format(
-      t.date instanceof Date ? t.date : new Date(t.date as any),
+      toDate(t.date) || new Date(),
       "yyyy-MM",
     );
     const cat = t.category || "Other";

--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -8,6 +8,7 @@ import {
   Timestamp,
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
+import { toDate } from "@/src/lib/utils";
 
 export interface Transaction {
   id: string;
@@ -71,26 +72,13 @@ export async function fetchUserTransactions(
     const snapshot = await getDocs(q);
     return snapshot.docs.map((doc) => {
       const data = doc.data();
-      let date: Date;
-      if (data.date instanceof Timestamp) {
-        date = data.date.toDate();
-      } else if (data.date instanceof Date) {
-        date = data.date;
-      } else if (
-        typeof data.date === "string" ||
-        typeof data.date === "number"
-      ) {
-        date = new Date(data.date);
-      } else {
-        date = new Date();
-      }
       return {
         id: doc.id,
         userId: data.userId || "",
         amount: Number(data.amount) || 0,
         category: data.category || "Other",
         type: data.type === "income" ? "income" : "expense",
-        date,
+        date: toDate(data.date) || new Date(),
         description: data.description,
       };
     });

--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -17,7 +17,7 @@ import {
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import { format, subMonths, startOfMonth, endOfMonth } from 'date-fns';
-import { formatCurrency } from '@/src/lib/utils';
+import { formatCurrency, toDate } from '@/src/lib/utils';
 import type { Transaction } from '@/src/lib/trendsUtils';
 
 export interface ChatMessage {
@@ -105,7 +105,7 @@ export async function loadConversations(userId: string): Promise<Conversation[]>
     snapshot.forEach((docSnap) => {
       const data = docSnap.data();
       const toIso = (val: any) =>
-        val && typeof val.toDate === 'function' ? val.toDate().toISOString() : (val || new Date().toISOString());
+        toDate(val) ? toDate(val)!.toISOString() : new Date().toISOString();
       conversations.push({
         id: docSnap.id,
         userId: data.userId || '',
@@ -173,7 +173,7 @@ export async function loadMessages(conversationId: string, userId: string): Prom
         content: data.content || '',
         timestamp: (() => {
           const t = data.timestamp;
-          return t && typeof t.toDate === 'function' ? t.toDate().toISOString() : (t || new Date().toISOString());
+          return toDate(t) ? toDate(t)!.toISOString() : new Date().toISOString();
         })(),
         metadata: data.metadata,
       });

--- a/src/lib/reportUtils.ts
+++ b/src/lib/reportUtils.ts
@@ -12,6 +12,7 @@ import {
   Timestamp,
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
+import { toDate } from "@/src/lib/utils";
 import { format, subDays, startOfDay, endOfDay } from "date-fns";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
@@ -92,17 +93,7 @@ export async function fetchTransactionsForDateRange(
     const snap = await getDocs(q);
     return snap.docs.map((d) => {
       const data = d.data() as any;
-      const dateVal = data.date;
-      let date: Date;
-      if (dateVal instanceof Date) {
-        date = dateVal;
-      } else if (typeof dateVal?.toDate === "function") {
-        date = dateVal.toDate();
-      } else if (typeof dateVal?.seconds === "number") {
-        date = new Date(dateVal.seconds * 1000);
-      } else {
-        date = new Date(dateVal as any);
-      }
+      const date = toDate(data.date) || new Date();
       return { ...data, id: d.id, date } as ReportTransaction;
     });
   } catch (error) {
@@ -118,17 +109,7 @@ export async function fetchTransactionsForDateRange(
       return snap.docs
         .map((d) => {
           const data = d.data() as any;
-          const dateVal = data.date;
-          let date: Date;
-          if (dateVal instanceof Date) {
-            date = dateVal;
-          } else if (typeof dateVal?.toDate === "function") {
-            date = dateVal.toDate();
-          } else if (typeof dateVal?.seconds === "number") {
-            date = new Date(dateVal.seconds * 1000);
-          } else {
-            date = new Date(dateVal as any);
-          }
+          const date = toDate(data.date) || new Date();
           return { ...data, id: d.id, date } as ReportTransaction;
         })
         .filter((t) => {

--- a/src/lib/trendsUtils.ts
+++ b/src/lib/trendsUtils.ts
@@ -16,6 +16,7 @@ import {
 } from 'firebase/firestore';
 import { db } from './firebase';
 import { OperationType, handleFirestoreError } from './firebase';
+import { toDate } from './utils';
 import {
   format,
   startOfWeek,
@@ -132,7 +133,7 @@ async function fetchTransactions(
         return snap.docs
           .map((d) => ({ ...(d.data() as Omit<Transaction, 'id'>), id: d.id } as Transaction))
           .filter((t) => {
-            const time = t.date instanceof Date ? t.date.getTime() : new Date(t.date as any).getTime();
+            const time = (toDate(t.date)?.getTime() ?? 0);
             return time >= startDate.getTime() && time <= endDate.getTime();
           });
       } catch (e) {
@@ -171,7 +172,7 @@ export function groupByCategoryAndPeriod(
   const totals: Record<string, number> = {};
 
   transactions.forEach((t) => {
-    const tDate = t.date instanceof Date ? t.date : new Date(t.date as any);
+    const tDate = toDate(t.date) || new Date();
     const key = isMonth ? formatMonthKey(tDate) : formatWeekKey(tDate);
     if (!byCategory.has(t.category)) {
       const base: CategoryPeriodDatum = { category: t.category };
@@ -201,7 +202,7 @@ export function generateMonthlyComparison(
 
   const map = new Map<string, CategoryPeriodDatum>();
   transactions.forEach((t) => {
-    const tDate = t.date instanceof Date ? t.date : new Date(t.date as any);
+    const tDate = toDate(t.date) || new Date();
     const key = formatMonthKey(tDate);
     if (!key.match(/^\d{4}-\d{2}$/)) return;
     if (!map.has(t.category)) {
@@ -232,7 +233,7 @@ export function generateWeeklyComparison(
 
   const map = new Map<string, CategoryPeriodDatum>();
   transactions.forEach((t) => {
-    const tDate = t.date instanceof Date ? t.date : new Date(t.date as any);
+    const tDate = toDate(t.date) || new Date();
     const key = formatWeekKey(tDate);
     if (!map.has(t.category)) {
       const base: CategoryPeriodDatum = { category: t.category };
@@ -293,7 +294,7 @@ export function generateTrendLines(
   periods.forEach((p) => matrix.set(p.key, new Map()));
   transactions.forEach((t) => {
     if (filterCategory && t.category !== filterCategory) return;
-    const tDate = t.date instanceof Date ? t.date : new Date(t.date as any);
+    const tDate = toDate(t.date) || new Date();
     const key = formatMonthKey(tDate);
     if (matrix.has(key)) {
       const monthMap = matrix.get(key)!;


### PR DESCRIPTION
## Problem

`CurrencyManager` wrote `date` as an ISO string while `billUtils` wrote a Firestore `Timestamp`. Each reader edge-parsed date shapes partially (some accepted strings, some only `Timestamp`/`Date`), so dates could be mis-read or silently fall back to "now".

## Fix

- `CurrencyManager` now persists `date: new Date(...)` on add and update, so manual transactions store a `Timestamp` just like bill transactions.
- Added a shared `toDate()` helper in `src/lib/utils.ts` that coerces `Timestamp` / `Date` / string / number consistently.
- Readers (`cashflowUtils`, `anomalyUtils`, `trendsUtils`, `reportUtils`, `chatUtils`) now parse dates through `toDate`, including both normal and `failed-precondition` fallback paths.

## Files changed

- `src/components/currency/CurrencyManager.tsx`
- `src/lib/utils.ts`
- `src/lib/cashflowUtils.ts`
- `src/lib/anomalyUtils.ts`
- `src/lib/trendsUtils.ts`
- `src/lib/reportUtils.ts`
- `src/lib/chatUtils.ts`

## Testing

- `npm test` passes.
- Scoped `tsc` typechecks pass; no new typecheck errors versus `origin/main`.

Closes #385
