### PR TITLE
fix: sells reduce holding quantity atomically and reject oversells

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -229,7 +229,9 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
       }
     } catch (error) {
       handleFirestoreError(error, OperationType.CREATE, 'portfolioTransactions');
-      toast.error('Failed to add transaction');
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to add transaction',
+      );
     }
   };
 

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -15,6 +15,7 @@ import {
   addDoc,
   orderBy,
   deleteDoc,
+  runTransaction,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
 
@@ -226,6 +227,75 @@ export async function addTransaction(userId: string, input: TransactionInput): P
       createdAt: new Date().toISOString(),
     };
 
+    // Buy and sell must reconcile the holding quantity atomically so
+    // concurrent writes cannot clobber each other, and a sell can never push
+    // the quantity below zero. dividend/deposit/withdrawal are cash events
+    // and intentionally leave the share quantity and cost basis untouched.
+    if (input.type === 'buy' || input.type === 'sell') {
+      const holdingSnap = await getDocs(
+        query(
+          collection(db, 'portfolioHoldings'),
+          where('userId', '==', userId),
+          where('symbol', '==', input.symbol),
+        ),
+      );
+
+      if (holdingSnap.empty) {
+        if (input.type === 'sell') {
+          throw new Error(
+            `Cannot sell ${input.quantity} shares: no holding exists for ${input.symbol}`,
+          );
+        }
+      } else {
+        const holdingRef = holdingSnap.docs[0].ref;
+        const currentHolding = holdingSnap.docs[0].data();
+        if (
+          input.type === 'sell' &&
+          input.quantity > (currentHolding.quantity || 0)
+        ) {
+          throw new Error(
+            `Cannot sell ${input.quantity} shares: only ${currentHolding.quantity || 0} are held for ${input.symbol}`,
+          );
+        }
+
+        await runTransaction(db, async (tx) => {
+          const snap = await tx.get(holdingRef);
+          const data = snap.data();
+          if (!data) return;
+
+          const currentQty = data.quantity || 0;
+          if (
+            input.type === 'sell' &&
+            input.quantity > currentQty
+          ) {
+            throw new Error(
+              `Cannot sell ${input.quantity} shares: only ${currentQty} are held for ${input.symbol}`,
+            );
+          }
+
+          const totalShares =
+            input.type === 'buy'
+              ? currentQty + input.quantity
+              : currentQty - input.quantity;
+
+          // Average-cost method: buys raise the per-share basis, sells leave
+          // the remaining shares' basis unchanged.
+          let avgCost = data.avgCost || 0;
+          if (input.type === 'buy') {
+            const totalCost =
+              currentQty * avgCost + input.quantity * input.price;
+            avgCost = totalShares > 0 ? totalCost / totalShares : input.price;
+          }
+
+          await tx.update(holdingRef, {
+            quantity: totalShares,
+            avgCost,
+            updatedAt: serverTimestamp(),
+          });
+        });
+      }
+    }
+
     if (input.type === 'buy') {
       await addDoc(collection(db, 'portfolioTransactions'), {
         ...transaction,
@@ -236,23 +306,6 @@ export async function addTransaction(userId: string, input: TransactionInput): P
         ...transaction,
         createdAt: serverTimestamp(),
       });
-    }
-
-    if (input.type === 'buy') {
-      const holdingRef = doc(db, 'portfolioHoldings', input.holdingId);
-      const holdingSnap = await getDocs(query(collection(db, 'portfolioHoldings'), where('userId', '==', userId), where('symbol', '==', input.symbol)));
-      if (!holdingSnap.empty) {
-        const holdingDoc = holdingSnap.docs[0];
-        const data = holdingDoc.data();
-        const totalShares = (data.quantity || 0) + input.quantity;
-        const totalCost = (data.quantity || 0) * (data.avgCost || 0) + input.quantity * input.price;
-        const newAvg = totalShares > 0 ? totalCost / totalShares : input.price;
-        await updateDoc(holdingDoc.ref, {
-          quantity: totalShares,
-          avgCost: newAvg,
-          updatedAt: serverTimestamp(),
-        });
-      }
     }
 
     return { ...transaction, id: id || '' };


### PR DESCRIPTION
## Problem

Selling a holding never reduced the held quantity: `addTransaction` only handled `buy`, and there was no guard against selling more than you hold.

## Fix

- `portfolioUtils.addTransaction` now handles both `buy` and `sell`.
- A sell with no existing holding, or a sell exceeding the held quantity, is rejected with an error.
- A Firestore transaction re-validates the holding inside `runTransaction`, so an oversell cannot race a concurrent update.
- `avgCost` is only recalculated on buys; sells reduce `quantity` and keep the cost basis.
- `PortfolioTracker` surfaces the rejection reason in the error toast instead of a generic message.

## Files changed

- `src/lib/portfolioUtils.ts`
- `src/components/portfolio/PortfolioTracker.tsx`

## Testing

- `npm test` passes.
- Scoped `tsc` typecheck of the changed files passes.

Closes #386
