### PR TITLE
fix: hold concurrency slot for the full analysis pipeline lifetime

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -564,8 +564,16 @@ async function startServer() {
       else inFlightAnalyzeByUser.set(key, updated);
     };
 
+    // The slot must be held for the full lifetime of the analysis pipeline.
+    // Binding cleanup to `res.once("close")` would refund it as soon as the
+    // client disconnects, even though the pipeline keeps running afterwards,
+    // letting clients escape the "max 2 concurrent analyses" guard. The
+    // handler releases the slot in its `finally` once the pipeline settles;
+    // the `finish` binding below is only a safety net for requests that never
+    // reach the handler body (e.g. an oversized upload rejected by
+    // `upload.single`), which fires after the (error) response is sent.
+    res.locals.releaseAnalyzeSlot = cleanup;
     res.once("finish", cleanup);
-    res.once("close", cleanup);
     next();
   };
 
@@ -1028,6 +1036,11 @@ CRITICAL RULES:
         }
 
         return res.status(500).json(errorResponse);
+      } finally {
+        // Release the concurrency slot only once the pipeline has settled.
+        // It must not be freed while the pipeline continues to run, e.g. after
+        // a client disconnects mid-analysis.
+        res.locals?.releaseAnalyzeSlot?.();
       }
     },
   );


### PR DESCRIPTION
## Problem

The in-flight analysis concurrency limiter released a user's slot via `res.once("close")`. `close` fires on a client disconnect while the analysis pipeline (PDF parsing -> inference -> Storage upload -> Firestore writes) keeps running, so the freed slot no longer matched the work actually in progress. Clients could abort requests to escape the "max 2 concurrent analyses" guard while the server continued running expensive pipelines.

## Fix

- `concurrentAnalyzeLimiter` no longer binds cleanup to the `close` event.
- The release function is exposed via `res.locals.releaseAnalyzeSlot` and called from the analyze handler's `finally`, so the slot is held for the full pipeline lifetime and only released once the pipeline settles.
- `res.once("finish")` is kept as a safety net only for requests rejected before the handler body runs (e.g. an oversized upload rejected by `upload.single`), which fires after the response is actually sent.

## Files changed

- `server.ts`

## Testing

- `npm test` passes.
- Scoped `tsc` typecheck of `server.ts` passes.

Closes #388
