### PR TITLE
fix: concurrency rejections no longer consume daily analysis quota

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -570,10 +570,13 @@ async function startServer() {
   };
 
   // AI Analysis Endpoint
+  // `concurrentAnalyzeLimiter` must run BEFORE `analyzeRateLimiter`: the rate
+  // limiter counts every request that reaches it, so a request rejected at the
+  // concurrency gate (429 CONCURRENT_LIMIT) must never consume daily quota.
   app.post(
     "/api/analyze",
-    analyzeRateLimiter,
     concurrentAnalyzeLimiter,
+    analyzeRateLimiter,
     upload.single("file"),
     async (req: any, res) => {
       try {

--- a/tests/analyze-quota-guard.test.mjs
+++ b/tests/analyze-quota-guard.test.mjs
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const server = readFileSync(path.join(repoRoot, "server.ts"), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+
+// /api/analyze middleware must reject at the concurrency gate before the
+// daily-quota counter is ever touched. express-rate-limit counts every request
+// that reaches it, so a 429 CONCURRENT_LIMIT must not burn one of the 5/day.
+const routeStart = server.indexOf('app.post(\n    "/api/analyze",');
+assert.ok(routeStart !== -1, 'app.post("/api/analyze", not found in server.ts');
+
+const bodyStart = server.indexOf("{", routeStart);
+const routeEnd = server.indexOf("\n  );", bodyStart);
+const route = server.slice(routeStart, routeEnd + 1);
+
+function position(name) {
+  const idx = route.indexOf(name);
+  return idx === -1 ? null : idx;
+}
+
+test("concurrency limiter runs before the daily quota limiter on /api/analyze", () => {
+  const concurrency = position("concurrentAnalyzeLimiter");
+  const quota = position("analyzeRateLimiter");
+  assert.ok(
+    concurrency !== null,
+    "concurrentAnalyzeLimiter must be registered on /api/analyze",
+  );
+  assert.ok(
+    quota !== null,
+    "analyzeRateLimiter must be registered on /api/analyze",
+  );
+  assert.ok(
+    concurrency < quota,
+    "concurrentAnalyzeLimiter must run before analyzeRateLimiter so a " +
+      "429 CONCURRENT_LIMIT rejection does not consume daily quota",
+  );
+});


### PR DESCRIPTION
## Problem

`analyzeRateLimiter` (5/day quota) ran before `concurrentAnalyzeLimiter`, and `express-rate-limit` counts every request that reaches it. Every extra request rejected with `429 CONCURRENT_LIMIT` still consumed one of the 5 daily attempts, so a free user whose first analysis was slow could burn the whole daily budget on rejected requests and be locked out for 24 hours.

## Fix

- Reversed the middleware order on `POST /api/analyze`: `concurrentAnalyzeLimiter` now runs before `analyzeRateLimiter`, so requests rejected at the concurrency gate never reach the quota counter.
- Added a guard test asserting the ordering so it cannot silently regress.

## Files changed

- `server.ts`
- `tests/analyze-quota-guard.test.mjs` (new)

## Testing

- New test verifies the concurrency limiter is registered before the quota limiter on `/api/analyze`.

Closes #389
