### PR TITLE
fix: apply goal contributions atomically with server-side increment

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -23,7 +23,7 @@ import {
 
 interface GoalCardProps {
   goal: Goal;
-  onUpdateAmount: (goalId: string, amount: number) => void;
+  onUpdateAmount: (goalId: string, amount: number) => Promise<void> | void;
   onViewDetails: (goal: Goal) => void;
   onStatusChange: (goalId: string, status: Goal['status']) => void;
   onDelete: (goalId: string) => void;
@@ -37,6 +37,7 @@ export function GoalCard({
   onDelete,
 }: GoalCardProps) {
   const [amountInput, setAmountInput] = useState('');
+  const [adding, setAdding] = useState(false);
   const daysRemaining = calculateDaysRemaining(goal.deadline);
   const progress = getProgressPercentage(goal.currentAmount, goal.targetAmount);
   const monthlyContribution = calculateMonthlyContribution(
@@ -46,11 +47,16 @@ export function GoalCard({
   );
   const status = getGoalStatus(goal);
 
-  const handleAddContribution = () => {
+  const handleAddContribution = async () => {
     const amount = parseFloat(amountInput);
     if (isNaN(amount) || amount <= 0) return;
-    onUpdateAmount(goal.id, amount);
-    setAmountInput('');
+    setAdding(true);
+    try {
+      await onUpdateAmount(goal.id, amount);
+      setAmountInput('');
+    } finally {
+      setAdding(false);
+    }
   };
 
   return (
@@ -160,12 +166,14 @@ export function GoalCard({
             className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500 h-9 rounded-lg text-xs"
             min="0"
             step="0.01"
+            disabled={adding}
           />
           <Button
             onClick={handleAddContribution}
+            disabled={adding}
             className="bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-semibold h-9 px-3 rounded-lg"
           >
-            Add
+            {adding ? 'Adding...' : 'Add'}
           </Button>
         </div>
       </CardContent>

--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { GoalCard } from './GoalCard';
 import { auth, db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import {
   doc,
@@ -11,6 +10,7 @@ import {
   where,
   onSnapshot,
   serverTimestamp,
+  increment,
 } from 'firebase/firestore';
 import {
   Target,
@@ -216,16 +216,22 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
     const goal = goals.find((g) => g.id === goalId);
     if (!goal) return;
 
+    // Guard against the auto-complete effect writing a stale snapshot while a
+    // contribution is in flight: it skips goals present in updatingGoalIds.
+    updatingGoalIds.current.add(goalId);
     try {
-      const newAmount = goal.currentAmount + addedAmount;
+      // Apply the contribution atomically on the server so two rapid adds (or
+      // an add racing the auto-complete write) can never overwrite each other.
       await updateDoc(doc(db, 'goals', goalId), {
-        currentAmount: newAmount,
+        currentAmount: increment(addedAmount),
       });
       toast.success(`Added ${formatCurrency(addedAmount)} to ${goal.name}`);
     } catch (error) {
       console.error('Error updating goal:', error);
       handleFirestoreError(error, OperationType.UPDATE, `goals/${goalId}`);
       toast.error('Failed to update goal');
+    } finally {
+      updatingGoalIds.current.delete(goalId);
     }
   };
 


### PR DESCRIPTION
## Problem

Goal contributions used a stale read-then-write: `GoalPlanner` read `currentAmount` from React state and wrote back an absolute new amount. Two rapid "Add" clicks, or an add racing the auto-complete write, both computed from the same old value, so the second write overwrote the first and a real contribution was silently lost.

## Fix

- `updateGoalAmount` now applies `currentAmount: increment(addedAmount)` atomically on the server, so rapid or concurrent adds can never overwrite each other.
- The goal is added to `updatingGoalIds` while the write is in flight so the auto-complete effect cannot write a stale snapshot amount on top of it.
- `GoalCard` disables the input and button while a contribution write is pending and only clears the input on success.
- Removed a duplicate `GoalCard` import in `GoalPlanner`.

## Files changed

- `src/components/goals/GoalPlanner.tsx`
- `src/components/goals/GoalCard.tsx`

## Testing

- `npm test` passes.
- Scoped `tsc` typecheck of the changed files passes.

Closes #390
