### PR TITLE
fix: use leave-one-out baseline for large-transaction anomaly detection

### DIFF
--- a/src/lib/anomalyStats.ts
+++ b/src/lib/anomalyStats.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { format } from "date-fns";
+
+export interface Transaction {
+  id: string;
+  userId: string;
+  amount: number;
+  category: string;
+  date: Date;
+  description?: string;
+  type?: "expense" | "income";
+}
+
+export interface CategoryBaseline {
+  mean: number;
+  stdDev: number;
+  monthlyTotals: number[];
+}
+
+// Minimum number of observations per category before large-transaction
+// anomalies are flagged. Below this the leave-one-out baseline has too few
+// comparison points to be statistically meaningful.
+export const MIN_LARGE_TRANSACTION_SAMPLES = 4;
+
+export function calculateCategoryBaseline(
+  transactions: Transaction[],
+): Map<string, CategoryBaseline> {
+  const grouped = new Map<string, Transaction[]>();
+
+  transactions.forEach((transaction) => {
+    const category = transaction.category || "Other";
+    grouped.set(category, [...(grouped.get(category) || []), transaction]);
+  });
+
+  const baseline = new Map<string, CategoryBaseline>();
+  grouped.forEach((items, category) => {
+    const amounts = items.map((item) => Math.abs(item.amount));
+    const mean =
+      amounts.length > 0
+        ? amounts.reduce((sum, amount) => sum + amount, 0) / amounts.length
+        : 0;
+    const variance =
+      amounts.length > 0
+        ? amounts.reduce((sum, amount) => sum + Math.pow(amount - mean, 2), 0) /
+          amounts.length
+        : 0;
+    const monthlyTotals = new Map<string, number>();
+    items.forEach((item) => {
+      const date = item.date instanceof Date ? item.date : new Date(item.date);
+      const key = format(date, "yyyy-MM");
+      monthlyTotals.set(key, (monthlyTotals.get(key) || 0) + Math.abs(item.amount));
+    });
+
+    baseline.set(category, {
+      mean,
+      stdDev: Math.sqrt(variance),
+      monthlyTotals: Array.from(monthlyTotals.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([, total]) => total),
+    });
+  });
+
+  return baseline;
+}
+
+export function detectLargeTransactions(
+  transactions: Transaction[],
+  baseline: Map<string, CategoryBaseline>,
+): Transaction[] {
+  const byCategory = new Map<string, Transaction[]>();
+  transactions.forEach((transaction) => {
+    const category = transaction.category || "Other";
+    byCategory.set(category, [
+      ...(byCategory.get(category) || []),
+      transaction,
+    ]);
+  });
+
+  return transactions.filter((transaction) => {
+    const category = transaction.category || "Other";
+    if (!baseline.has(category)) return false;
+
+    const items = byCategory.get(category);
+    if (!items || items.length < MIN_LARGE_TRANSACTION_SAMPLES) return false;
+
+    // Leave-one-out baseline: the candidate is excluded from the mean/stdDev
+    // it is compared against. A large amount must not be able to inflate its
+    // own threshold (a single dominant expense previously never got flagged).
+    const amounts = items.map((item) => Math.abs(item.amount));
+    const candidateIndex = items.indexOf(transaction);
+    const others = amounts.filter((_, index) => index !== candidateIndex);
+
+    const mean =
+      others.reduce((sum, amount) => sum + amount, 0) / others.length;
+    const variance =
+      others.reduce(
+        (sum, amount) => sum + Math.pow(amount - mean, 2),
+        0,
+      ) / others.length;
+    const threshold = mean + Math.sqrt(variance) * 2;
+
+    return Math.abs(transaction.amount) > Math.max(threshold, 1000);
+  });
+}

--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -16,16 +16,21 @@ import {
 import { db, handleFirestoreError, OperationType } from "./firebase";
 import { formatCurrency } from "./utils";
 import { format, subMonths, startOfMonth } from "date-fns";
+import {
+  calculateCategoryBaseline,
+  detectLargeTransactions,
+  type Transaction,
+  type CategoryBaseline,
+} from "./anomalyStats";
 
-export interface Transaction {
-  id: string;
-  userId: string;
-  amount: number;
-  category: string;
-  date: Date;
-  description?: string;
-  type?: "expense" | "income";
-}
+export {
+  calculateCategoryBaseline,
+  detectLargeTransactions,
+};
+export type {
+  Transaction,
+  CategoryBaseline,
+};
 
 export interface Anomaly {
   id: string;
@@ -57,12 +62,6 @@ export interface AnomalySummary {
   lowCount: number;
   byCategory: Record<string, number>;
   weeklyData: { week: string; count: number }[];
-}
-
-export interface CategoryBaseline {
-  mean: number;
-  stdDev: number;
-  monthlyTotals: number[];
 }
 
 export async function fetchAnomalies(
@@ -146,59 +145,6 @@ export async function fetchTransactions(
 }
 
 export const fetchUserTransactions = fetchTransactions;
-
-export function calculateCategoryBaseline(
-  transactions: Transaction[],
-): Map<string, CategoryBaseline> {
-  const grouped = new Map<string, Transaction[]>();
-
-  transactions.forEach((transaction) => {
-    const category = transaction.category || "Other";
-    grouped.set(category, [...(grouped.get(category) || []), transaction]);
-  });
-
-  const baseline = new Map<string, CategoryBaseline>();
-  grouped.forEach((items, category) => {
-    const amounts = items.map((item) => Math.abs(item.amount));
-    const mean =
-      amounts.length > 0
-        ? amounts.reduce((sum, amount) => sum + amount, 0) / amounts.length
-        : 0;
-    const variance =
-      amounts.length > 0
-        ? amounts.reduce((sum, amount) => sum + Math.pow(amount - mean, 2), 0) /
-          amounts.length
-        : 0;
-    const monthlyTotals = new Map<string, number>();
-    items.forEach((item) => {
-      const date = item.date instanceof Date ? item.date : new Date(item.date);
-      const key = format(date, "yyyy-MM");
-      monthlyTotals.set(key, (monthlyTotals.get(key) || 0) + Math.abs(item.amount));
-    });
-
-    baseline.set(category, {
-      mean,
-      stdDev: Math.sqrt(variance),
-      monthlyTotals: Array.from(monthlyTotals.entries())
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([, total]) => total),
-    });
-  });
-
-  return baseline;
-}
-
-export function detectLargeTransactions(
-  transactions: Transaction[],
-  baseline: Map<string, CategoryBaseline>,
-): Transaction[] {
-  return transactions.filter((transaction) => {
-    const categoryBaseline = baseline.get(transaction.category || "Other");
-    if (!categoryBaseline) return false;
-    const threshold = categoryBaseline.mean + categoryBaseline.stdDev * 2;
-    return Math.abs(transaction.amount) > Math.max(threshold, 1000);
-  });
-}
 
 export function detectCategorySpikes(
   transactions: Transaction[],

--- a/tests/anomaly-leave-one-out.test.mjs
+++ b/tests/anomaly-leave-one-out.test.mjs
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { calculateCategoryBaseline, detectLargeTransactions } = await import(
+  "../src/lib/anomalyStats.ts"
+);
+
+function tx(id, amount, category) {
+  return {
+    id,
+    userId: "u1",
+    amount,
+    category,
+    date: new Date("2026-07-15"),
+  };
+}
+
+test("calculateCategoryBaseline aggregates mean, stdDev and monthly totals", () => {
+  const baseline = calculateCategoryBaseline([
+    tx("a", 100, "Food"),
+    tx("b", 100, "Food"),
+    tx("c", 10000, "Food"),
+  ]);
+  const food = baseline.get("Food");
+  assert.ok(food, "baseline should contain the Food category");
+  assert.equal(food.mean, 3400);
+  assert.equal(food.monthlyTotals.length, 1);
+  assert.equal(food.monthlyTotals[0], 10200);
+});
+
+test("detectLargeTransactions flags a dominant amount via leave-one-out baseline", () => {
+  const transactions = [
+    tx("a", 100, "Food"),
+    tx("b", 100, "Food"),
+    tx("c", 100, "Food"),
+    tx("d", 10000, "Food"),
+  ];
+  const baseline = calculateCategoryBaseline(transactions);
+  const detected = detectLargeTransactions(transactions, baseline).map(
+    (t) => t.id,
+  );
+  assert.deepEqual(detected, ["d"]);
+});
+
+test("detectLargeTransactions does not flag categories below the minimum sample size", () => {
+  const transactions = [
+    tx("a", 100, "Food"),
+    tx("b", 100, "Food"),
+    tx("c", 10000, "Food"),
+  ];
+  const baseline = calculateCategoryBaseline(transactions);
+  const detected = detectLargeTransactions(transactions, baseline);
+  assert.equal(detected.length, 0);
+});


### PR DESCRIPTION
## Problem

`detectLargeTransactions` compared every amount against `mean + 2*stdDev`, where `mean`/`stdDev` were computed over the full category set including the very amount being tested. Large transactions pulled their own baseline up, so in small categories they rarely exceeded the threshold and the engine missed the biggest anomalies it exists to find.

## Fix

- `detectLargeTransactions` now tests each candidate against a leave-one-out baseline: `mean`/`stdDev` are recomputed over the other transactions in the same category, so a large amount cannot inflate its own threshold.
- Enforced a minimum sample size of 4 observations per category before flagging, documented via `MIN_LARGE_TRANSACTION_SAMPLES`.
- Extracted the pure statistics (`calculateCategoryBaseline`, `detectLargeTransactions`, and their types) into `src/lib/anomalyStats.ts`, which has no firebase dependency and can be unit tested under Node. `anomalyUtils.ts` re-exports the same API, so no call sites change.

## Files changed

- `src/lib/anomalyStats.ts` (new)
- `src/lib/anomalyUtils.ts`
- `tests/anomaly-leave-one-out.test.mjs` (new)

## Testing

- New unit tests cover `calculateCategoryBaseline` aggregation and the single-dominant-transaction case, and verify categories below the minimum sample size are not flagged.
- `npm test` passes; no new typecheck errors versus `origin/main`.

Closes #391
