### PR TITLE
fix(chat): update title only on first message, always update lastMessageAt

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -311,7 +311,10 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
     setSuggestions(response.suggestions || []);
 
     const conversation = conversations.find((c) => c.id === currentConversationId);
-    const derivedTitle = content.trim().slice(0, 50) + (content.trim().length > 50 ? '...' : '');
+    const isDefaultTitle = !conversation?.title || conversation.title === 'New Chat';
+    const derivedTitle = isDefaultTitle
+      ? content.trim().slice(0, 50) + (content.trim().length > 50 ? '...' : '')
+      : conversation.title;
     if (conversation) {
       setConversations((prev) =>
         prev.map((c) =>
@@ -325,10 +328,9 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
             : c
         )
       );
-      await updateConversation(currentConversationId, {
-        title: derivedTitle,
-        lastMessageAt: new Date().toISOString(),
-      });
+      const patch = { lastMessageAt: new Date().toISOString() };
+      if (isDefaultTitle) patch.title = derivedTitle;
+      await updateConversation(currentConversationId, patch);
     }
   };
 


### PR DESCRIPTION
## Summary of What Has Been Done
Modified `handleSendMessage` in ChatAssistant.tsx to only update the conversation title on the first user message, not on every subsequent message.

## Changes Made
- `src/components/chat/ChatAssistant.tsx`: Added `isDefaultTitle` check before updating title
- `lastMessageAt` is still updated on every message (correct behavior)

## Impact it Made
- Reduces unnecessary Firestore writes on every chat message
- Preserves the original conversation title instead of overwriting with later messages

Closes #408

Note: Please assign this PR to the `tmdeveloper007` account.