### PR TITLE
fix(health): update currentScore state after recalculation to show refreshed component scores

### DIFF
--- a/src/components/health/HealthScoreDashboard.tsx
+++ b/src/components/health/HealthScoreDashboard.tsx
@@ -277,9 +277,11 @@ export function HealthScoreDashboard({ user }: HealthScoreDashboardProps) {
           budgetAdherenceScore: budget,
           metrics: metricsPayload,
         });
+        const updatedScore = { ...existing, ...metricsPayload, overallScore: overall, spendingScore: spending, savingsScore: savings, budgetAdherenceScore: budget };
         setHistoricalScores((prev) =>
-          prev.map((s) => (s.id === existing.id ? { ...s, ...metricsPayload, overallScore: overall } : s))
+          prev.map((s) => (s.id === existing.id ? updatedScore : s))
         );
+        setCurrentScore(updatedScore);
         toast.success('Health score recalculated');
       } else {
         const created = await createHealthScore({
@@ -298,19 +300,6 @@ export function HealthScoreDashboard({ user }: HealthScoreDashboardProps) {
           toast.error('Failed to save health score');
         }
       }
-
-      setCurrentScore({
-        id: existing?.id || '',
-        userId: user.uid,
-        overallScore: overall,
-        spendingScore: spending,
-        savingsScore: savings,
-        budgetAdherenceScore: budget,
-        metrics: metricsPayload,
-        month: monthKey,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
     } catch (error) {
       console.error('Error calculating health score:', error);
       handleFirestoreError(error, OperationType.WRITE, 'health_scores');


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed `handleCalculate` in HealthScoreDashboard.tsx to call `setCurrentScore(updatedScore)` when recalculating an existing health score. Previously, only `historicalScores` was updated, leaving `currentScore` stale with outdated component subscores.

## Changes Made
- `src/components/health/HealthScoreDashboard.tsx`: Added `setCurrentScore(updatedScore)` in the `if (existing)` block
- Removed duplicate `setCurrentScore` at function end

## Impact it Made
- Users see accurate sub-scores immediately after recalculation
- Prevents confusing display where overall score changes but sub-scores appear frozen

Closes #411

Note: Please assign this PR to the `tmdeveloper007` account.