### PR TITLE
Fix: storage.rules admin checks silently break with non-default Firestore database

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -52,7 +52,23 @@ const firebaseProjectId = String(process.env.FIREBASE_PROJECT_ID || "").trim();
 const firestoreDatabaseId =
   String(process.env.FIREBASE_FIRESTORE_DATABASE_ID || "(default)").trim() ||
   "(default)";
-
+// storage.rules hardcodes isAdmin() to check the "(default)" Firestore
+// database — Cloud Storage Security Rules cannot read env vars or accept a
+// runtime database id, so that path is a literal string baked into the
+// rules file. If this server is configured to use a *named* Firestore
+// database instead, storage.rules' admin checks will silently evaluate to
+// false (no error, no log) and admins will quietly lose the ability to
+// read/delete other users' files in Storage. Fail loudly here instead of
+// letting that ship unnoticed.
+if (firestoreDatabaseId !== "(default)") {
+  console.warn(
+    `FIRESTORE_DATABASE_MISMATCH_WARNING: FIREBASE_FIRESTORE_DATABASE_ID is ` +
+      `set to "${firestoreDatabaseId}", but storage.rules' isAdmin() check is ` +
+      `hardcoded to the "(default)" database. Admin access to Firebase ` +
+      `Storage will not work correctly until storage.rules is updated to ` +
+      `match, or FIREBASE_FIRESTORE_DATABASE_ID is reverted to "(default)".`,
+  );
+}
 // Explicit CORS allowlist. In production, only APP_URL (the deployed
 // frontend origin) may call this API with credentials. Local Vite dev
 // ports are allowed so `npm run dev` keeps working out of the box.

--- a/storage.rules
+++ b/storage.rules
@@ -55,10 +55,30 @@ service firebase.storage {
     }
   }
 
-  // Helper function to check if user is admin (cached in Firestore)
-  function isAdmin(uid) {
-    return request.auth != null &&
-      firestore.exists(/databases/(default)/documents/users/$(uid)) &&
-      firestore.get(/databases/(default)/documents/users/$(uid)).data.role == 'admin';
-  }
+// Helper function to check if user is admin (cached in Firestore)
+//
+// IMPORTANT — DATABASE ID IS HARDCODED, NOT CONFIGURABLE:
+// Cloud Storage Security Rules cannot read environment variables or accept
+// a runtime parameter for which Firestore database to query — the path
+// segment after /databases/ must be a literal string. This project's
+// server.ts supports a configurable FIREBASE_FIRESTORE_DATABASE_ID
+// (see .env.example), but that setting has NO EFFECT here: these rules
+// will always check the "(default)" database for the admin role.
+//
+// If you ever deploy this app against a named (non-default) Firestore
+// database, every isAdmin() check below will silently evaluate to false
+// (not error) — admins will quietly lose the ability to read/delete other
+// users' files in Storage. There is no warning anywhere else in the app
+// for this. Two safe options:
+//   1. Keep FIREBASE_FIRESTORE_DATABASE_ID as "(default)" (the default),
+//      which is required for these rules to work as written, OR
+//   2. If you must use a named database, update the literal string below
+//      to match it, AND remove/replace this comment accordingly. Storage
+//      rules and your Firestore database id must always be kept in sync
+//      by hand — nothing enforces this automatically.
+function isAdmin(uid) {
+  return request.auth != null &&
+    firestore.exists(/databases/(default)/documents/users/$(uid)) &&
+    firestore.get(/databases/(default)/documents/users/$(uid)).data.role == 'admin';
+}
 }


### PR DESCRIPTION
## Problem

`storage.rules` hardcodes the Firestore database path in `isAdmin()`:

```js
function isAdmin(uid) {
  return request.auth != null &&
    firestore.exists(/databases/(default)/documents/users/$(uid)) &&
    firestore.get(/databases/(default)/documents/users/$(uid)).data.role == 'admin';
}
```

The app supports a configurable `FIREBASE_FIRESTORE_DATABASE_ID` env var
(see `.env.example`, used in `server.ts` via `getFirestore(firestoreDatabaseId)`),
but Cloud Storage Security Rules can't read env vars or accept a runtime
database id — the path after `/databases/` has to be a literal string.

**Impact:** if this app is ever deployed against a named (non-default)
Firestore database, every `isAdmin()` check in `storage.rules` silently
evaluates to `false` — no error, no log. Admins quietly lose the ability
to read/delete other users' files in Firebase Storage. Nothing in the app
currently warns about this mismatch.

## Fix

This isn't fixable by making the rule "dynamic" — that's a hard limitation
of the Storage Rules language, not a bug in the logic itself. Instead:

1. **`storage.rules`** — added an explicit comment on `isAdmin()` documenting
   that `(default)` is a hardcoded literal, why it can't be dynamic, and what
   silently breaks if `FIREBASE_FIRESTORE_DATABASE_ID` is changed.
2. **`server.ts`** — added a startup check right after `firestoreDatabaseId`
   is resolved that logs a loud `console.warn` if the configured database
   isn't `(default)`, so this failure mode shows up in server logs instead
   of degrading admin permissions with no trace.

## Changes

- `storage.rules`: comment-only change, no behavior change.
- `server.ts`: adds a non-blocking startup warning, no behavior change for
  the default (and currently only supported) configuration.

## Testing

- Confirmed rules file still deploys cleanly (no duplicate `isAdmin`
  definitions, brace structure unchanged).
- Confirmed the warning only fires when `FIREBASE_FIRESTORE_DATABASE_ID` is
  set to something other than `(default)` — default setup is unaffected.

## Why this matters

This is the kind of failure that's easy to miss in review and expensive to
debug in production: an admin dashboard/tool quietly stops being able to
manage user files, with no exception thrown anywhere. Making the constraint
visible in code (not just tribal knowledge) prevents that.