### PR TITLE
fix: re-add Lock and Activity icons used by the sign-in card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
 } from "firebase/auth";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import {
+  Activity,
   TrendingUp,
   LayoutDashboard,
   FileText,
@@ -41,6 +42,7 @@ import {
   MessageSquare,
   LineChart,
   Globe,
+  Lock,
   Shield
 } from 'lucide-react';
 import { Toaster, toast } from 'sonner';


### PR DESCRIPTION
## Problem

Commit `1b0ebe6` ("fix: remove unused icon imports and TabsContent from App.tsx (#372)") removed the `Lock` and `Activity` icons from the lucide-react import in `src/App.tsx`, but both identifiers are still referenced in the JSX at `src/App.tsx:861`:

```tsx
{[ShieldCheck, Lock, Activity].map((Icon, i) => (
```

This decorative row renders inside the login/sign-up card shown for every unauthenticated visitor. `Lock` and `Activity` are undeclared identifiers, so evaluating the array literal throws `ReferenceError: Lock is not defined` during render, leaving unauthenticated users with a blank screen. `npm run typecheck` also fails with "Cannot find name 'Lock'" / "Cannot find name 'Activity'".

## Fix

Re-added `Lock` and `Activity` to the lucide-react import block in `src/App.tsx`, restoring the icons referenced by the sign-in card.

The CI workflow already runs `npx tsc --noEmit` (`.github/workflows/ci.yml`), which now passes again for these identifiers, so no CI change was needed.

## Files changed

- `src/App.tsx` — added `Lock` and `Activity` to the lucide-react import.

## Testing

- `npm run typecheck` no longer reports `Cannot find name 'Lock'` / `Cannot find name 'Activity'`.
- The remaining typecheck failures (in `src/components/rollover/RolloverManager.tsx`) are pre-existing on `main` and unrelated to this issue.

Closes #425
