### PR TITLE
fix: Docker build copies /app/dist and runs dist/server.cjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,9 @@ ENV NODE_ENV=production
 COPY --from=builder --chown=node:node /app/package*.json ./
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/dist ./dist
-COPY --from=builder --chown=node:node /app/build ./build
 
 USER node
 
 EXPOSE 3001
 
-CMD ["node", "build/server.cjs"]
+CMD ["node", "dist/server.cjs"]


### PR DESCRIPTION
## Problem

The Dockerfile references a build artifact that `npm run build` never produces:

- `Dockerfile` — `COPY --from=builder --chown=node:node /app/build ./build`
- `Dockerfile` — `CMD ["node", "build/server.cjs"]`
- `package.json` — `"build": "vite build && esbuild server.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=dist/server.cjs"`

The build script emits the server bundle to `dist/server.cjs` (and `vite build` writes to `dist/`). Neither step ever creates a `build/` directory, so `docker build` aborts at the `COPY /app/build` step, and even if it got past that, the container would crash on boot because `build/server.cjs` does not exist.

## Fix

- Removed the invalid `COPY --from=builder --chown=node:node /app/build ./build` line (the `/app/dist` copy was already present and correct).
- Changed the runtime `CMD` to `node dist/server.cjs`, matching the repo's own `start` script (`node dist/server.cjs`).

## Files changed

- `Dockerfile` — removed the stale `/app/build` copy and pointed `CMD` at `dist/server.cjs`.

## Testing

- The two referenced paths now match what `npm run build` emits (`dist/server.cjs`), so the builder stage always contains the copied artifact and the container starts the API server (port `3001`, matching `server.ts`).

Closes #426
