### PR TITLE
fix: persist failed analysis records that match Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -38,6 +38,12 @@ service cloud.firestore {
              data.riskLevel in ['low', 'medium', 'high'];
     }
 
+    function isValidFailedAnalysis(data) {
+      return data.keys().hasAll(['status', 'ownerId']) &&
+             data.status == 'failed' &&
+             data.ownerId == request.auth.uid;
+    }
+
     // ----------------------------------------------------
     // COLLECTION MATCHES
     // ----------------------------------------------------
@@ -98,7 +104,7 @@ service cloud.firestore {
       // SECURITY: Per-user RLS for any top-level analyses collection
       // Prevents unauthorized access to sensitive financial analysis data
       allow read: if isOwner(existing().ownerId) || isAdmin();
-      allow create: if isSignedIn() && isValidAnalysis(incoming());
+      allow create: if isSignedIn() && (isValidAnalysis(incoming()) || isValidFailedAnalysis(incoming()));
       allow update: if isAdmin();
       allow delete: if isOwner(existing().ownerId) || isAdmin();
     }

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -184,6 +184,7 @@ export function FileUpload({ user, onComplete, onCancel }: any) {
       toast.error(userMsg);
 
       try {
+        if (!user?.uid) return;
         const { db } = await import("@/src/lib/firebase");
         const { collection, addDoc, serverTimestamp } =
           await import("firebase/firestore");
@@ -195,7 +196,7 @@ export function FileUpload({ user, onComplete, onCancel }: any) {
           errorKind: kind,
           uploadedAt: serverTimestamp(),
           failedAt: serverTimestamp(),
-          ownerId: user?.uid || null,
+          ownerId: user.uid,
         });
       } catch (firestoreErr) {
         console.error("Could not persist failed record:", firestoreErr);


### PR DESCRIPTION
## Problem

When an AI analysis pipeline run fails, `FileUpload.tsx` tries to persist a `status: "failed"` record to the top-level `analyses` collection, but the write is always rejected by the Firestore security rules, so failed runs are never recorded:

- The failure record omits `documentId` and `riskLevel` (fields required by `isValidAnalysis`), and falls back to `ownerId: null` when signed out.
- The `create` rule on `/analyses/{analysisId}` gates every write behind `isValidAnalysis(incoming())`, so the record never matches and the client gets `permission-denied`.
- The resulting error is swallowed, so the error-persistence feature is effectively dead code.

## Fix

Made the write contract and the Firestore rules agree on the shape of a failed-analysis record:

- `src/components/FileUpload.tsx` — bail out of persisting when there is no signed-in user (a record without an owner can never be stored), and always write a non-null `ownerId: user.uid`.
- `firestore.rules` — added `isValidFailedAnalysis()` which validates the actual failed-record shape (`status == 'failed'` owned by the requester), and allowed `create` on `/analyses/{analysisId}` for either a valid analysis or a valid failed analysis.

Failed records remain scoped per-user: they are only writable by the signed-in owner and readable by the owner (or an admin).

## Files changed

- `src/components/FileUpload.tsx` — non-null `ownerId`, skip persistence when signed out.
- `firestore.rules` — new `isValidFailedAnalysis` helper and updated `create` rule for `/analyses/{analysisId}`.

## Testing

- `npx tsc --noEmit` reports no new errors for `FileUpload.tsx` (remaining errors are pre-existing on `main` in `RolloverManager.tsx`).
- Rules now match the exact document shape written by the failure handler, so the write passes the `create` gate when the user is signed in and email-verified.

Closes #427
