### PR TITLE
fix: wire privacy dashboard to real settings and app navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,7 @@ import { AnalysisList } from './components/AnalysisList';
 import { FileUpload } from './components/FileUpload';
 import { AnalysisDetail } from './components/AnalysisDetail';
 import { AdminPanel } from './components/AdminPanel';
+import { PrivacyDashboard } from './components/privacy/PrivacyDashboard';
 import { AnomalyDashboard } from './components/anomaly/AnomalyDashboard';
 import { BudgetDashboard } from './components/budget/BudgetDashboard';
 import { CommandPalette } from './components/dashboard/CommandPalette';
@@ -990,6 +991,12 @@ export default function App() {
             active={activeTab === 'portfolio'}
             onClick={() => setActiveTab('portfolio')}
           />
+          <NavItem
+            icon={<Shield size={20} />}
+            label="Privacy & Security"
+            active={activeTab === 'privacy'}
+            onClick={() => setActiveTab('privacy')}
+          />
           {userProfile?.role === "admin" && (
             <NavItem
               icon={<ShieldCheck size={20} />}
@@ -1339,6 +1346,17 @@ export default function App() {
                 exit={{ opacity: 0, x: -10 }}
               >
                 <AdminPanel />
+              </motion.div>
+            )}
+
+            {activeTab === 'privacy' && user && (
+              <motion.div 
+                key="privacy"
+                initial={false}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+              >
+                <PrivacyDashboard user={user} />
               </motion.div>
             )}
 

--- a/src/components/privacy/PrivacyDashboard.tsx
+++ b/src/components/privacy/PrivacyDashboard.tsx
@@ -6,29 +6,18 @@ import {
   CardTitle,
   CardDescription,
 } from "@/src/components/ui/card";
-import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
-import { Progress } from "@/src/components/ui/progress";
-import { Input } from "@/src/components/ui/input";
 import {
-  ShieldCheck,
   Loader2,
   Download,
   Trash2,
-  LogOut,
-  Globe,
-  Lock,
-  Eye,
-  Activity,
 } from "lucide-react";
-import SessionManager from "@/src/components/privacy/SessionManager";
 import {
   exportUserData,
   deleteUserData,
-  fetchActivityLog,
-  revokeUserSessions,
+  getPrivacySettings,
+  updatePrivacySettings,
   PrivacySettings,
-  ActivityLogEntry,
 } from "@/src/lib/privacyUtils";
 import { toast } from "sonner";
 
@@ -36,7 +25,6 @@ export function PrivacyDashboard({ user }: { user: any }) {
   const [loading, setLoading] = useState(true);
   const [privacySettings, setPrivacySettings] =
     useState<PrivacySettings | null>(null);
-  const [activityLog, setActivityLog] = useState<ActivityLogEntry[]>([]);
   const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -48,22 +36,18 @@ export function PrivacyDashboard({ user }: { user: any }) {
     if (!user) return;
     setLoading(true);
     try {
-      const logs = await fetchActivityLog(user.uid);
-      setActivityLog(logs);
-      setPrivacySettings({
-        userId: user.uid,
-        dataRetentionEnabled: true,
-        analyticsEnabled: true,
-        sharingEnabled: false,
-        exportRequestedAt: "",
-        deletionRequestedAt: "",
-        updatedAt: new Date().toISOString(),
-      });
+      const settings = await getPrivacySettings(user.uid);
+      setPrivacySettings(settings);
     } catch (error) {
       console.error("Failed to load privacy data:", error);
     } finally {
       setLoading(false);
     }
+  }
+
+  function handleSettingUpdate(updates: Partial<PrivacySettings>) {
+    setPrivacySettings((prev) => (prev ? { ...prev, ...updates } : prev));
+    updatePrivacySettings(user.uid, updates);
   }
 
   async function handleExport() {
@@ -147,8 +131,8 @@ export function PrivacyDashboard({ user }: { user: any }) {
         </div>
       </section>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2 space-y-6">
+      <div className="space-y-6">
+        <div className="space-y-6">
           <Card className="bg-slate-900 border-slate-800 rounded-2xl">
             <CardHeader className="p-5 border-b border-slate-800">
               <CardTitle className="text-sm font-bold uppercase tracking-wider text-white">
@@ -224,10 +208,7 @@ export function PrivacyDashboard({ user }: { user: any }) {
                     description="Keep transaction history and analysis data"
                     enabled={privacySettings.dataRetentionEnabled}
                     onChange={(enabled) =>
-                      setPrivacySettings({
-                        ...privacySettings,
-                        dataRetentionEnabled: enabled,
-                      })
+                      handleSettingUpdate({ dataRetentionEnabled: enabled })
                     }
                   />
                   <PrivacyToggle
@@ -235,10 +216,7 @@ export function PrivacyDashboard({ user }: { user: any }) {
                     description="Allow anonymous usage analytics to improve the service"
                     enabled={privacySettings.analyticsEnabled}
                     onChange={(enabled) =>
-                      setPrivacySettings({
-                        ...privacySettings,
-                        analyticsEnabled: enabled,
-                      })
+                      handleSettingUpdate({ analyticsEnabled: enabled })
                     }
                   />
                   <PrivacyToggle
@@ -246,10 +224,7 @@ export function PrivacyDashboard({ user }: { user: any }) {
                     description="Share anonymized data for research purposes"
                     enabled={privacySettings.sharingEnabled}
                     onChange={(enabled) =>
-                      setPrivacySettings({
-                        ...privacySettings,
-                        sharingEnabled: enabled,
-                      })
+                      handleSettingUpdate({ sharingEnabled: enabled })
                     }
                   />
                   <PrivacyToggle
@@ -257,64 +232,13 @@ export function PrivacyDashboard({ user }: { user: any }) {
                     description="Require an extra security step when logging in"
                     enabled={privacySettings.mfaEnabled}
                     onChange={(enabled) =>
-                      setPrivacySettings({
-                        ...privacySettings,
-                        mfaEnabled: enabled,
-                      })
+                      handleSettingUpdate({ mfaEnabled: enabled })
                     }
                   />
                 </>
               )}
             </CardContent>
           </Card>
-
-          <Card className="bg-slate-900 border-slate-800 rounded-2xl">
-            <CardHeader className="p-5 border-b border-slate-800">
-              <CardTitle className="text-sm font-bold uppercase tracking-wider text-white">
-                Activity Log
-              </CardTitle>
-              <CardDescription className="text-slate-500 text-xs">
-                Recent account activity
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="p-5">
-              {activityLog.length === 0 ? (
-                <p className="text-xs text-slate-500 text-center py-4">
-                  No activity recorded yet
-                </p>
-              ) : (
-                <div className="space-y-3">
-                  {activityLog.slice(0, 10).map((log, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center justify-between py-2 border-b border-slate-800 last:border-0"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="h-8 w-8 rounded-lg bg-slate-800 flex items-center justify-center text-slate-400">
-                          <Activity size={14} />
-                        </div>
-                        <div>
-                          <p className="text-xs font-medium text-slate-200">
-                            {log.action}
-                          </p>
-                          <p className="text-[10px] text-slate-500">
-                            {log.details}
-                          </p>
-                        </div>
-                      </div>
-                      <span className="text-[10px] text-slate-500 font-mono">
-                        {log.timestamp}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="space-y-6">
-          <SessionManager user={user} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem

`src/components/privacy/PrivacyDashboard.tsx` is dead code that breaks the build:

- It imports `SessionManager` from `@/src/components/privacy/SessionManager`, which does not exist in the repo.
- It imports `fetchActivityLog` and `revokeUserSessions` from `@/src/lib/privacyUtils`, which do not exist (only `getPrivacySettings`, `updatePrivacySettings`, `exportUserData`, `deleteUserData`, `downloadJSON`, `formatDate` are exported).
- `loadPrivacyData` never calls `getPrivacySettings`; it hardcodes a mock settings object.
- The toggle handlers only mutate local state — `updatePrivacySettings` is never called, so settings are never persisted.
- The component is never mounted anywhere, so no user can reach the privacy UI.

## Fix

- Removed the non-existent `SessionManager` import/usage and the `fetchActivityLog`/`revokeUserSessions` imports and the never-populated "Activity Log" section (there is no client-readable activity-log source; `auditLogs` is admin-only server-generated).
- `loadPrivacyData` now loads the user's real `privacy_settings` document via `getPrivacySettings`.
- Added a `handleSettingUpdate` helper that persists toggle changes to Firestore via `updatePrivacySettings`, so Data Retention / Usage Analytics / Data Sharing / 2FA preferences are actually saved.
- Removed the unused `SessionManager`, `Activity Log`, and unrelated unused imports.
- Mounted `PrivacyDashboard` in the app sidebar navigation ("Privacy & Security") and wired the `privacy` view, available to all signed-in users (not only admins).

## Files changed

- `src/components/privacy/PrivacyDashboard.tsx` — real settings load/persist, removed dead imports and dead UI sections.
- `src/App.tsx` — imported `PrivacyDashboard`, added a "Privacy & Security" nav item and the corresponding view.

## Testing

- `npx tsc --noEmit` introduces no new errors; the errors that remain (e.g. `App.tsx` `Activity` icon, `RolloverManager.tsx`, `AnalysisList.tsx`, `budgetUtils.ts`, etc.) are pre-existing on `main` and unrelated to this change.
- The dashboard is now reachable for every authenticated user and reads/writes the real `privacy_settings/<uid>` document.

Closes #428
