### PR TITLE
fix: restore rejected budget categories and their status after reload

### DIFF
--- a/src/components/budget/BudgetDashboard.tsx
+++ b/src/components/budget/BudgetDashboard.tsx
@@ -123,14 +123,22 @@ export function BudgetDashboard({ user }: { user: any }) {
       let finalConfidence = confidence;
 
       if (savedBudget && savedBudget.categoryBudgets) {
-        finalSuggestions = generatedSuggestions.map((s) => ({
-          ...s,
-          suggestedAmount:
-            savedBudget.categoryBudgets[s.category] || s.suggestedAmount,
-          modifiedAmount:
-            savedBudget.categoryBudgets[s.category] || s.suggestedAmount,
-          status: "accepted" as const,
-        }));
+        finalSuggestions = generatedSuggestions.map((s) => {
+          const hasSaved = Object.prototype.hasOwnProperty.call(
+            savedBudget.categoryBudgets,
+            s.category,
+          );
+          const savedAmount = hasSaved
+            ? savedBudget.categoryBudgets[s.category]
+            : s.suggestedAmount;
+          const savedStatus = savedBudget.categoryStatuses?.[s.category];
+          return {
+            ...s,
+            suggestedAmount: savedAmount,
+            modifiedAmount: savedAmount,
+            status: savedStatus || (hasSaved ? "accepted" : s.status),
+          };
+        });
         finalTotal = savedBudget.totalBudget;
         finalConfidence = savedBudget.confidenceScore;
         setSaved(true);
@@ -156,10 +164,12 @@ export function BudgetDashboard({ user }: { user: any }) {
     if (!user) return;
 
     const categoryBudgets: Record<string, number> = {};
+    const categoryStatuses: Record<string, string> = {};
     newSuggestions.forEach((s) => {
       const amount =
         s.status === "rejected" ? 0 : (s.modifiedAmount ?? s.suggestedAmount);
       categoryBudgets[s.category] = amount;
+      categoryStatuses[s.category] = s.status || "accepted";
     });
 
     const budgetData = {
@@ -167,6 +177,7 @@ export function BudgetDashboard({ user }: { user: any }) {
       month: currentMonth,
       totalBudget: calculateTotalBudget(newSuggestions),
       categoryBudgets,
+      categoryStatuses,
       confidenceScore,
       createdAt: new Date(),
       updatedAt: new Date(),


### PR DESCRIPTION
## Problem

Rejected budget categories silently reappear as "accepted" after a reload because a saved amount of `0` is treated as falsy by the budget restore logic:

- `handleSaveBudget` persists a rejected category as `categoryBudgets[cat] = 0`.
- On load, the saved value is read back with a `||` fallback (`savedBudget.categoryBudgets[s.category] || s.suggestedAmount`) and the status is hardcoded to `accepted`.

Because `0` is falsy, the saved `0` is discarded and a freshly generated suggestion is substituted, and the category is forced to `status: "accepted"`. The user's explicit rejection is silently undone, and the per-category amounts disagree with the loaded `totalBudget`.

## Fix

- **Restore path:** checks key presence with `Object.prototype.hasOwnProperty` instead of truthiness, so a saved `0` is used. The per-category `status` is now restored instead of being hardcoded to `accepted`, so rejected categories remain rejected.
- **Save path:** persists the per-category `status` alongside the amounts via a new `categoryStatuses` field on the budget document, so the restore logic has the actual status to work with.

With rejected categories restored as rejected, `calculateTotalBudget`-based `totalBudget` (which excludes rejected categories) reconciles with the visible category list again.

## Files changed

- `src/components/budget/BudgetDashboard.tsx` — key-presence check in the restore path, restore the saved per-category status, and persist `categoryStatuses` on save.

## Testing

- `npx tsc --noEmit` reports no new errors for `BudgetDashboard.tsx` (remaining errors are pre-existing on `main`).
- Verified the restore logic keeps a saved `0` (rejected) category and its `rejected` status after reload instead of substituting a new suggestion.

Closes #429
