### PR TITLE
fix: use latest snapshot for portfolio All-Time Return card

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -666,16 +666,16 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
                     <p className="text-xs text-slate-500 mb-1">All-Time Return</p>
                     <p className={cn(
                       'text-2xl font-bold tabular-nums',
-                      (performanceHistory[performanceHistory.length - 1]?.profitLoss ?? 0) >= 0 ? 'text-emerald-400' : 'text-red-400'
+                      (performanceHistory[0]?.profitLoss ?? 0) >= 0 ? 'text-emerald-400' : 'text-red-400'
                     )}>
-                      {formatCurrencyDisplay((performanceHistory[performanceHistory.length - 1]?.profitLoss ?? 0), 'USD')}
+                      {formatCurrencyDisplay((performanceHistory[0]?.profitLoss ?? 0), 'USD')}
                     </p>
                     <p className={cn(
                       'text-xs mt-1',
-                      (performanceHistory[performanceHistory.length - 1]?.profitLossPercent ?? 0) >= 0 ? 'text-emerald-400' : 'text-red-400'
+                      (performanceHistory[0]?.profitLossPercent ?? 0) >= 0 ? 'text-emerald-400' : 'text-red-400'
                     )}>
-                      {((performanceHistory[performanceHistory.length - 1]?.profitLossPercent ?? 0) >= 0 ? '+' : '')}
-                      {(performanceHistory[performanceHistory.length - 1]?.profitLossPercent ?? 0).toFixed(2)}%
+                      {((performanceHistory[0]?.profitLossPercent ?? 0) >= 0 ? '+' : '')}
+                      {(performanceHistory[0]?.profitLossPercent ?? 0).toFixed(2)}%
                     </p>
                   </CardContent>
                 </Card>


### PR DESCRIPTION
## Problem

The portfolio "All-Time Return" card displays the P/L of the OLDEST portfolio snapshot instead of the latest one:

- `fetchPortfolioHistory` (`src/lib/portfolioUtils.ts`) orders by `orderBy('snapshotDate', 'desc')`, so index `0` is the newest snapshot and `[length - 1]` is the oldest.
- `PortfolioTracker.tsx` read `performanceHistory[performanceHistory.length - 1]` (oldest) for the "All-Time Return" `profitLoss` / `profitLossPercent`, while the adjacent "Latest Total Value" card correctly reads `performanceHistory[0]` (newest).

The result: "All-Time Return" is frozen at the earliest snapshot's P/L, ignores later price changes, and can disagree with the current header P/L and the "Latest Total Value" card in the same row.

## Fix

- "All-Time Return" now reads `performanceHistory[0]` for both the dollar amount and the percentage, matching the "Latest Total Value" card, so both cards reflect the same latest snapshot.
- The line chart's ascending reversal (`[...performanceHistory].reverse()`) is kept as-is.

## Files changed

- `src/components/portfolio/PortfolioTracker.tsx` — All-Time Return card now indexes `performanceHistory[0]` (latest snapshot) instead of `[length - 1]` (oldest).

## Testing

- `npx tsc --noEmit` reports no new errors for `PortfolioTracker.tsx` (remaining errors are pre-existing on `main`).
- Both the "All-Time Return" and "Latest Total Value" cards now read from the same newest snapshot, so they can no longer drift apart.

Closes #430
