### PR TITLE
fix: dedup anomalies by stable key and keep dismissed anomalies dismissed

### DIFF
--- a/src/components/anomaly/AnomalyDashboard.tsx
+++ b/src/components/anomaly/AnomalyDashboard.tsx
@@ -409,14 +409,19 @@ async function runDetection(userId: string) {
     });
   });
 
+  const now = new Date();
+  const currentMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+
   for (const anomaly of newAnomalies) {
     try {
+      const dedupKey =
+        anomaly.type === "category_spike"
+          ? `${anomaly.category}_category_spike_${currentMonthKey}`
+          : `transaction_${anomaly.transactionId}`;
       const existingQuery = query(
         collection(db, "anomalies"),
         where("userId", "==", userId),
-        where("transactionId", "==", anomaly.transactionId),
-        where("type", "==", anomaly.type),
-        where("dismissed", "==", false),
+        where("dedupKey", "==", dedupKey),
       );
       const existingSnap = await getDocs(existingQuery);
       if (existingSnap.empty) {
@@ -428,6 +433,7 @@ async function runDetection(userId: string) {
         );
         await addDoc(collection(db, "anomalies"), {
           ...anomaly,
+          dedupKey,
           historicalCount: historical.count,
           historicalLabel: historical.label,
           createdAt: anomaly.createdAt || serverTimestamp(),


### PR DESCRIPTION
## Problem

Anomaly de-duplication is broken in two ways, so duplicate anomaly documents accumulate and dismissed anomalies keep coming back:

1. **Dismissed anomalies are re-created.** The dedup query in `runDetection` (`AnomalyDashboard.tsx`) filtered `dismissed == false`. When a user dismisses an anomaly (flips `dismissed` to `true`), the next scan no longer matches it and writes a brand-new non-dismissed anomaly with the same detection — dismissal is effectively meaningless.

2. **`category_spike` anomalies have an unstable dedup key.** The dedup key was `transactionId`, set to the id of the *last current-month transaction in the category*. `detectCategorySpikes` recomputes the spike from the current month's transactions, so as soon as a new transaction lands in that category the "last transaction" id changes, the dedup query misses, and another identical `category_spike` document is written.

## Fix

- Added a stable per-anomaly `dedupKey` stored on the document:
  - `category_spike`: `{category}_category_spike_{yyyy-MM}` — stable per category and month.
  - other types: `transaction_{transactionId}` — stable per originating transaction.
- The dedup query now checks `userId` + `dedupKey` only, and no longer filters `dismissed`, so an existing document (dismissed or not) suppresses re-creation. Dismissal is treated as a state transition on the existing document.

Result: each distinct anomaly is persisted once; dismissing it keeps it dismissed until the underlying condition genuinely changes (a new transaction, or a new month's spike), and the anomalies grid / historical-count stats no longer accumulate duplicates.

## Files changed

- `src/components/anomaly/AnomalyDashboard.tsx` — `runDetection` now writes and checks a stable `dedupKey` and drops the `dismissed == false` filter.

## Testing

- `npx tsc --noEmit` reports no new errors for `AnomalyDashboard.tsx` (remaining errors are pre-existing on `main`).
- Re-running detection now skips anomalies whose `dedupKey` already exists, including previously dismissed ones.

> Note: the dedup query now requires a composite index on `anomalies` for `userId` + `dedupKey` (same class of index the previous `userId` + `transactionId` + `type` + `dismissed` query already required).

Closes #431
