### PR TITLE
fix: subscribe users once and fetch docs stats once in AdminPanel

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -49,7 +49,7 @@ export function AdminPanel() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Real-time listener for users
+    // Real-time listener for users (subscribed once)
     const usersQuery = query(
       collection(db, "users"),
       orderBy("createdAt", "desc"),
@@ -57,13 +57,23 @@ export function AdminPanel() {
     const unsubscribeUsers = onSnapshot(
       usersQuery,
       (snapshot) => {
-        setUsers(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+        const nextUsers = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+        setUsers(nextUsers);
+        setSystemStats((prev) => ({ ...prev, totalUsers: nextUsers.length }));
       },
       (error) => {
         handleFirestoreError(error, OperationType.LIST, "users");
       },
     );
+    return () => unsubscribeUsers();
+  }, []);
 
+  useEffect(() => {
+    // Documents stats are fetched once; totalUsers is derived from the live
+    // users snapshot, not from a stale closure.
     const fetchStats = async () => {
       try {
         const allDocs = await getDocs(collection(db, "documents"));
@@ -76,12 +86,12 @@ export function AdminPanel() {
           0,
         );
 
-        setSystemStats({
-          totalUsers: users.length,
+        setSystemStats((prev) => ({
+          ...prev,
           totalDocs,
           analysisCompleted: completed,
           storageUsed: (totalSize / 1024 / 1024 / 1024).toFixed(2) + " GB",
-        });
+        }));
       } catch (error) {
         handleFirestoreError(error, OperationType.GET, "documents");
       }
@@ -89,8 +99,7 @@ export function AdminPanel() {
     };
 
     fetchStats();
-    return () => unsubscribeUsers();
-  }, [users.length]);
+  }, []);
 
   return (
     <div className="space-y-8 pb-12">


### PR DESCRIPTION
## Problem

`AdminPanel` runs a single effect that depends on `users.length`, causing the users listener to be torn down and re-subscribed, and the entire `documents` collection to be re-read from scratch, on every change to the user count:

- Every new user (or any `users.length` change) unmounts/remounts the effect: the `onSnapshot` listener is unsubscribed and re-created and a fresh `getDocs` over the whole `documents` collection fires again.
- On first mount the effect runs at least twice (length `0`, then `N`), and the first pass captures the stale `users.length` in the `fetchStats` closure, so `systemStats.totalUsers` can disagree with the live "Active Operatives" stat.
- With growth, this produces unbounded duplicate Firestore reads for a read-only stats panel.

## Fix

Split the two concerns into two effects, both with `[]` deps:

- **Users listener** — subscribes via `onSnapshot` exactly once. The snapshot handler updates `users` and derives `totalUsers` from the current snapshot length (`nextUsers.length`) instead of a stale closure.
- **Documents stats** — `getDocs` over `documents` runs exactly once and updates only the document-derived stats (`totalDocs`, `analysisCompleted`, `storageUsed`), merging into the existing stats state.

The "Active Operatives" stat continues to render the live `users.length`, and `systemStats.totalUsers` now always reflects the current users snapshot.

## Files changed

- `src/components/AdminPanel.tsx` — split the effect, removed the `[users.length]` dependency, and derive `totalUsers` from the users snapshot instead of a closure.

## Testing

- `npx tsc --noEmit` reports no new errors for `AdminPanel.tsx` (remaining errors are pre-existing on `main`).
- The users listener now subscribes once and the `documents` collection is fetched once, regardless of user count changes.

Closes #432
