### PR TITLE
fix: tombstone erased accounts so they are not resurrected on reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   sendEmailVerification,
+  deleteUser,
 } from "firebase/auth";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import {
@@ -331,6 +332,22 @@ export default function App() {
           const userRef = doc(db, "users", currentUser.uid);
           try {
             const userSnap = await getDoc(userRef);
+
+            if (userSnap.exists() && userSnap.data().deletedAt) {
+              // Erased account: the profile must stay deleted. Terminate the
+              // session instead of auto-recreating a fresh profile.
+              setUserProfile(null);
+              setShowVerificationScreen(false);
+              try {
+                await deleteUser(currentUser);
+              } catch (authError) {
+                console.error("Could not remove auth account:", authError);
+              }
+              await signOut(auth);
+              toast.info("This account has been deleted.");
+              setLoading(false);
+              return;
+            }
 
             if (!userSnap.exists()) {
               const profile = getDefaultProfile(currentUser);

--- a/src/components/privacy/PrivacyDashboard.tsx
+++ b/src/components/privacy/PrivacyDashboard.tsx
@@ -31,6 +31,8 @@ import {
   ActivityLogEntry,
 } from "@/src/lib/privacyUtils";
 import { toast } from "sonner";
+import { auth } from "@/src/lib/firebase";
+import { deleteUser, signOut } from "firebase/auth";
 
 export function PrivacyDashboard({ user }: { user: any }) {
   const [loading, setLoading] = useState(true);
@@ -101,6 +103,13 @@ export function PrivacyDashboard({ user }: { user: any }) {
     try {
       await deleteUserData(user.uid);
       toast.success("All data deleted successfully");
+      // Terminate the Auth identity so the erased account cannot come back.
+      try {
+        if (auth.currentUser) await deleteUser(auth.currentUser);
+      } catch (authError) {
+        console.error("Auth account deletion failed:", authError);
+      }
+      await signOut(auth);
     } catch (error) {
       console.error("Delete failed:", error);
       toast.error("Failed to delete data");

--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -11,8 +11,9 @@ import {
   writeBatch,
   getDoc,
   setDoc,
+  deleteDoc,
 } from "firebase/firestore";
-import { db, handleFirestoreError, OperationType } from "./firebase";
+import { db, auth, handleFirestoreError, OperationType } from "./firebase";
 import { format } from "date-fns";
 
 export interface PrivacySettings {
@@ -111,6 +112,29 @@ export async function exportUserData(
 }
 
 export async function deleteUserData(userId: string): Promise<void> {
+  // Write the deletion tombstone (users/<uid>.deletedAt) first so that
+  // onAuthStateChanged cannot resurrect the profile even if a later step fails.
+  const userRef = doc(db, "users", userId);
+  try {
+    const existing = await getDoc(userRef);
+    const profile = existing.exists() ? existing.data() : {};
+    await deleteDoc(userRef);
+    await setDoc(userRef, {
+      uid: userId,
+      email: profile.email ?? auth.currentUser?.email ?? "",
+      role:
+        profile.role && profile.role !== "admin"
+          ? profile.role
+          : "junior_analyst",
+      username: profile.username ?? "",
+      deletedAt: new Date().toISOString(),
+      deleted: true,
+    });
+  } catch (error) {
+    handleFirestoreError(error, OperationType.DELETE, "users");
+    throw error;
+  }
+
   const batch = writeBatch(db);
   for (const colName of [
     "transactions",
@@ -131,12 +155,12 @@ export async function deleteUserData(userId: string): Promise<void> {
     }
   }
   try {
-    batch.delete(doc(db, "users", userId));
     batch.delete(doc(db, "privacy_settings", userId));
     batch.delete(doc(db, "currencies", userId));
     await batch.commit();
   } catch (error) {
     handleFirestoreError(error, OperationType.DELETE, "userData");
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Problem

A successful right-to-erasure is not final:

- `deleteUserData` removes `users/<uid>` along with the data collections.
- `onAuthStateChanged` (in `src/App.tsx`) treats a missing `users/<uid>` doc as a brand-new user and auto-creates a fresh `junior_analyst` profile, so the "deleted" account is silently resurrected on the next page load.
- The Firebase Auth account itself is never removed (no `deleteUser` call exists anywhere in `src/`).

## Fix

- **Tombstone before erasure** — `deleteUserData` now writes `users/<uid>` with `deletedAt` + `deleted: true` (replacing the plain delete of the profile) *before* erasing the data collections, so the tombstone survives even if a later step fails. The tombstone keeps `email`/`role` so it still satisfies the `isValidUser` create rule.
- **Stop auto-creating erased profiles** — the `onAuthStateChanged` sync path now checks `userSnap.data().deletedAt` and, when present, skips profile creation, attempts `deleteUser(auth.currentUser)` to remove the Auth identity, signs the session out, and shows an "account deleted" notice instead of logging the user in.
- **Terminate the Auth identity on erasure** — `PrivacyDashboard.handleDeleteData` now best-effort calls `deleteUser(auth.currentUser)` and then `signOut(auth)` after the data erasure succeeds, so the account cannot come back.

## Files changed

- `src/lib/privacyUtils.ts` — write the deletion tombstone first; stop deleting the profile doc outright.
- `src/App.tsx` — detect the tombstone in `onAuthStateChanged` and terminate the session instead of recreating the profile.
- `src/components/privacy/PrivacyDashboard.tsx` — remove the Auth account and sign out after a successful erasure.

## Testing

- `npx tsc --noEmit` reports no new errors for the changed files (remaining errors are pre-existing on `main`).
- Flow: delete data → tombstone written → Auth account removed (best effort) → signed out. On any later sign-in attempt the tombstone is detected and the session is terminated rather than the profile being recreated.

Closes #434
