### PR TITLE
fix: add validation for storage rules Firestore database mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "validate-env": "node scripts/validate-storage-rules.js"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/scripts/validate-storage-rules.js
+++ b/scripts/validate-storage-rules.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Validates that Firebase Storage rules are compatible with server configuration.
+ * Run this before deploying to catch configuration mismatches.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const RULES_FILE = path.join(__dirname, '..', 'storage.rules');
+const DEFAULT_DB = '(default)';
+
+function checkStorageRules() {
+  console.log('Validating Firebase Storage Rules...\n');
+
+  const rules = fs.readFileSync(RULES_FILE, 'utf8');
+  const issues = [];
+
+  if (rules.includes('/databases/(default)/documents/')) {
+    console.log('Storage rules use hardcoded "(default)" database');
+    
+    if (process.env.FIREBASE_FIRESTORE_DATABASE_ID && 
+        process.env.FIREBASE_FIRESTORE_DATABASE_ID !== DEFAULT_DB) {
+      issues.push({
+        severity: 'ERROR',
+        message: `FIREBASE_FIRESTORE_DATABASE_ID is set to "${process.env.FIREBASE_FIRESTORE_DATABASE_ID}" but storage.rules expects "${DEFAULT_DB}". Admin access will FAIL!`
+      });
+    }
+  }
+
+  if (issues.length > 0) {
+    console.log('\nISSUES FOUND:\n');
+    issues.forEach(issue => {
+      console.log(`[${issue.severity}] ${issue.message}`);
+    });
+    console.log('\nFix the issues above before deploying.');
+    process.exit(1);
+  } else {
+    console.log('\nNo issues found. Storage rules are properly configured.');
+    process.exit(0);
+  }
+}
+
+checkStorageRules();

--- a/storage.rules
+++ b/storage.rules
@@ -1,4 +1,8 @@
 rules_version = '2';
+// ⚠️ IMPORTANT: This file hardcodes the Firestore database as "(default)"
+// See the isAdmin() function below for details. If FIREBASE_FIRESTORE_DATABASE_ID
+// is not "(default)", admin access will silently fail.
+// Run `npm run validate-env` to check for this mismatch.
 service firebase.storage {
   match /b/{bucket}/o {
     // Default deny all access


### PR DESCRIPTION
## Description

Add validation and documentation for the Firestore database mismatch issue in Firebase Storage rules.

### Changes:

1. **Added prominent warning header** to `storage.rules` explaining the hardcoded database limitation

2. **Created validation script** `scripts/validate-storage-rules.js` that:
   - Checks if FIREBASE_FIRESTORE_DATABASE_ID matches storage.rules
   - Exits with error code if mismatch detected
   - Provides clear error message explaining the issue

3. **Added npm script** `npm run validate-env` to run validation

### Usage:

```bash
# Validate configuration before deploying
npm run validate-env
```

If FIREBASE_FIRESTORE_DATABASE_ID is not "(default)", the script will fail with:
```
[ERROR] FIREBASE_FIRESTORE_DATABASE_ID is set to "production" but storage.rules expects "(default)". Admin access will FAIL!
```

### Why This Fix?

Cloud Storage Security Rules cannot read environment variables. The `isAdmin()` function in storage.rules always checks the "(default)" database. If a different database is configured:
- Admins will silently fail to access storage
- No error is thrown
- Storage access just returns false

This validation prevents silent failures in production.

Closes #475