### PR TITLE
fix: show true cross rate in currency converter badge for non-USD from currencies

### DIFF
--- a/src/components/currency/CurrencyConverter.tsx
+++ b/src/components/currency/CurrencyConverter.tsx
@@ -68,6 +68,10 @@ export function CurrencyConverter({
     setToCurrency(fromCurrency);
   };
 
+  const fromRate = rates?.rates[fromCurrency] || 1;
+  const toRate = rates?.rates[toCurrency];
+  const badgeRate = toRate != null && fromRate > 0 ? toRate / fromRate : null;
+
   return (
     <Card className="border-slate-800 bg-slate-900 shadow-2xl rounded-2xl overflow-hidden">
       <CardHeader className="p-6 border-b border-slate-800 bg-slate-900/50">
@@ -136,7 +140,11 @@ export function CurrencyConverter({
               </p>
             </div>
             <Badge className="bg-indigo-500/10 text-indigo-400 border-indigo-500/20 font-bold text-xs">
-              {rates ? `1 ${fromCurrency} = ${rates.rates[toCurrency]?.toFixed(4) || '---'} ${toCurrency}` : 'Loading rates...'}
+              {badgeRate != null
+                ? `1 ${fromCurrency} = ${badgeRate.toFixed(4)} ${toCurrency}`
+                : rates
+                  ? `1 ${fromCurrency} = --- ${toCurrency}`
+                  : 'Loading rates...'}
             </Badge>
           </div>
           {rates && (


### PR DESCRIPTION
## Problem

The rate badge under the Currency Converter claimed to show the rate between the selected currencies, but it always displayed the USD-denominated rate from the exchange API. When converting from a non-USD currency (e.g. EUR to JPY), the badge showed an incorrect rate even though the actual conversion math was right.

## Fix

Compute a true cross rate from the API's USD-denominated rates: `badgeRate = toRate / fromRate`, and label the badge `1 {from} = {badgeRate} {to}`. The conversion itself was already correct; only the badge was wrong.

## Files changed

- `src/components/currency/CurrencyConverter.tsx`

## Testing

- Verified the badge rate now equals `toRate / fromRate` for non-USD base currencies (e.g. EUR to JPY, GBP to USD).
- `npx eslint src/components/currency/CurrencyConverter.tsx` — no new problems vs main.
- `npx tsc --noEmit` — no new errors (RolloverManager.tsx error is pre-existing on main).

Closes #464
