### PR TITLE
fix: update existing emergency fund on Save Changes instead of creating a duplicate

### DIFF
--- a/src/components/emergency/EmergencyFundPlanner.tsx
+++ b/src/components/emergency/EmergencyFundPlanner.tsx
@@ -143,26 +143,49 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
       toast.error('Enter your monthly expenses to calculate a target');
       return;
     }
-    const monthly = parseFloat(monthlyContribution) || calculateMonthlySavings(targetAmount, 0, targetMonths);
-    const created = await createEmergencyFund({
-      userId: user.uid,
-      targetAmount,
-      currentAmount: 0,
-      monthlyContribution: monthly,
-      monthsCovered: targetMonths,
-      estimatedCompletionDate: estimateCompletionDate(targetAmount, 0, monthly),
-      reminderEnabled: false,
-      reminderDayOfMonth: 1,
-    });
-    if (created) {
-      setFund(created);
-      toast.success('Emergency fund plan created');
-      setSetupOpen(false);
-      setMonthlyExpenses('');
-      setMonthlyContribution('');
+    const monthly = parseFloat(monthlyContribution) || (fund ? fund.monthlyContribution : calculateMonthlySavings(targetAmount, 0, targetMonths));
+
+    if (fund) {
+      const ok = await updateEmergencyFund(fund.id, {
+        targetAmount,
+        currentAmount: fund.currentAmount,
+        monthlyContribution: monthly,
+        monthsCovered: targetMonths,
+        estimatedCompletionDate: estimateCompletionDate(targetAmount, fund.currentAmount, monthly),
+      });
+      if (ok) {
+        setFund({
+          ...fund,
+          targetAmount,
+          monthlyContribution: monthly,
+          monthsCovered: targetMonths,
+          estimatedCompletionDate: estimateCompletionDate(targetAmount, fund.currentAmount, monthly),
+        });
+        toast.success('Emergency fund plan updated');
+      } else {
+        toast.error('Failed to update emergency fund');
+      }
     } else {
-      toast.error('Failed to create emergency fund');
+      const created = await createEmergencyFund({
+        userId: user.uid,
+        targetAmount,
+        currentAmount: 0,
+        monthlyContribution: monthly,
+        monthsCovered: targetMonths,
+        estimatedCompletionDate: estimateCompletionDate(targetAmount, 0, monthly),
+        reminderEnabled: false,
+        reminderDayOfMonth: 1,
+      });
+      if (created) {
+        setFund(created);
+        toast.success('Emergency fund plan created');
+      } else {
+        toast.error('Failed to create emergency fund');
+      }
     }
+    setSetupOpen(false);
+    setMonthlyExpenses('');
+    setMonthlyContribution('');
   };
 
   const updateGoal = async (patch: Partial<EmergencyFund>) => {


### PR DESCRIPTION
## Problem

'Adjust Plan' / 'Save Changes' on an existing emergency fund always called `createEmergencyFund`, which inserted a new document. Because `getEmergencyFund` only ever reads `snapshot.docs[0]`, the duplicate silently masked the original fund.

## Fix

`handleSetup` now checks whether a fund already exists. If it does, it calls `updateEmergencyFund(fund.id, ...)` preserving the existing `id` and `currentAmount`, and only creates a new document when no fund exists.

## Files changed

- `src/components/emergency/EmergencyFundPlanner.tsx`

## Testing

- Verified Save Changes on an existing fund updates the existing document instead of inserting a duplicate.
- `npx eslint src/components/emergency/EmergencyFundPlanner.tsx` — no new problems vs main.

Closes #465
