### PR TITLE
fix: generate savings challenges from real transaction data instead of hardcoded placeholder

### DIFF
--- a/src/components/challenges/ChallengesDashboard.tsx
+++ b/src/components/challenges/ChallengesDashboard.tsx
@@ -32,6 +32,7 @@ import {
   type BadgeTier,
   BADGE_META,
   DIFFICULTY_REWARDS,
+  deriveSpendingPattern,
   generateWeeklyChallenges,
   generateMonthlyChallenges,
   generateRecommendations,
@@ -43,31 +44,19 @@ import {
   completeChallenge,
   deleteChallenge,
 } from '@/src/lib/challengeUtils';
+import { fetchUserTransactions } from '@/src/lib/cashflowUtils';
 import { ChallengeCard } from './ChallengeCard';
 
 interface ChallengesDashboardProps {
   user: import('firebase/auth').User | null;
 }
 
-function getEmptySpending(): SpendingPattern {
-  return {
-    totalMonthlySpend: 2000,
-    coffeeSpend: 40,
-    diningSpend: 220,
-    subscriptionsSpend: 45,
-    entertainmentSpend: 120,
-    topCategory: 'Dining',
-    discretionarySpend: 425,
-    savingsRate: 0.08,
-  };
-}
-
 export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
   const [challenges, setChallenges] = useState<Challenge[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
-
-  const spending = useMemo<SpendingPattern>(() => getEmptySpending(), []);
+  const [spending, setSpending] = useState<SpendingPattern | null>(null);
+  const [spendingLoading, setSpendingLoading] = useState(true);
 
   useEffect(() => {
     if (!user) {
@@ -116,6 +105,33 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
     return () => unsubscribe();
   }, [user]);
 
+  useEffect(() => {
+    if (!user) {
+      setSpending(null);
+      setSpendingLoading(false);
+      return;
+    }
+    let active = true;
+    fetchUserTransactions(user.uid, 6)
+      .then((transactions) => {
+        if (!active) return;
+        if (transactions.length === 0) {
+          setSpending(null);
+        } else {
+          setSpending(deriveSpendingPattern(transactions));
+        }
+      })
+      .catch(() => {
+        if (active) setSpending(null);
+      })
+      .finally(() => {
+        if (active) setSpendingLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
   const weeklyChallenges = useMemo(
     () => challenges.filter((c) => c.type === 'weekly'),
     [challenges]
@@ -133,7 +149,10 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
     [challenges]
   );
 
-  const recommendations = useMemo(() => generateRecommendations(spending), [spending]);
+  const recommendations = useMemo(
+    () => (spending ? generateRecommendations(spending) : []),
+    [spending]
+  );
 
   const stats = useMemo(() => {
     const totalPoints = challenges.reduce(
@@ -202,6 +221,10 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
 
   const generateChallenges = useCallback(async () => {
     if (!user) return;
+    if (!spending) {
+      toast.error('Add a few transactions first so we can personalize your challenges');
+      return;
+    }
     setGenerating(true);
     try {
       const difficulty: Difficulty = calculateDifficulty(spending);
@@ -333,23 +356,37 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {recommendations.map((rec, i) => (
-                <div key={i} className="rounded-xl bg-slate-800/50 border border-slate-700/50 p-3 space-y-1">
-                  <div className="flex items-center justify-between">
-                    <p className="text-sm font-semibold text-white">{rec.title}</p>
-                    <Badge variant="outline" className={cn(
-                      'text-[10px] uppercase tracking-wider',
-                      rec.difficulty === 'easy' ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
-                        : rec.difficulty === 'medium' ? 'bg-amber-500/10 text-amber-400 border-amber-500/30'
-                        : 'bg-red-500/10 text-red-400 border-red-500/30'
-                    )}>
-                      {rec.difficulty}
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-slate-400">{rec.description}</p>
-                  <p className="text-[10px] text-yellow-500/80 uppercase tracking-wider">{rec.reason}</p>
+              {spendingLoading ? (
+                <div className="space-y-2">
+                  {[1, 2, 3].map((i) => (
+                    <div key={i} className="h-16 rounded-xl bg-slate-800/50 border border-slate-700/50 animate-pulse" />
+                  ))}
                 </div>
-              ))}
+              ) : !spending ? (
+                <div className="rounded-xl bg-slate-800/30 border border-slate-700/50 p-4 text-center">
+                  <p className="text-xs text-slate-400">
+                    Add a few transactions so we can analyze your spending and suggest personalized challenges.
+                  </p>
+                </div>
+              ) : (
+                recommendations.map((rec, i) => (
+                  <div key={i} className="rounded-xl bg-slate-800/50 border border-slate-700/50 p-3 space-y-1">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-white">{rec.title}</p>
+                      <Badge variant="outline" className={cn(
+                        'text-[10px] uppercase tracking-wider',
+                        rec.difficulty === 'easy' ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
+                          : rec.difficulty === 'medium' ? 'bg-amber-500/10 text-amber-400 border-amber-500/30'
+                          : 'bg-red-500/10 text-red-400 border-red-500/30'
+                      )}>
+                        {rec.difficulty}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-slate-400">{rec.description}</p>
+                    <p className="text-[10px] text-yellow-500/80 uppercase tracking-wider">{rec.reason}</p>
+                  </div>
+                ))
+              )}
             </CardContent>
           </Card>
 

--- a/src/lib/challengeUtils.ts
+++ b/src/lib/challengeUtils.ts
@@ -12,7 +12,7 @@ import {
   serverTimestamp,
 } from 'firebase/firestore';
 import { db } from '@/src/lib/firebase';
-import { formatCurrency } from '@/src/lib/utils';
+import { formatCurrency, normalizeTransactionType, toDate } from '@/src/lib/utils';
 
 export type ChallengeType = 'weekly' | 'monthly';
 export type Difficulty = 'easy' | 'medium' | 'hard';
@@ -60,6 +60,72 @@ export const BADGE_META: Record<BadgeTier, { label: string; color: string; point
 export function getProgressPercentage(currentProgress: number, targetAmount: number): number {
   if (targetAmount <= 0) return 0;
   return Math.min(100, Math.round((currentProgress / targetAmount) * 100));
+}
+
+export interface SpendingTransaction {
+  amount: number;
+  category: string;
+  type?: string;
+  date?: unknown;
+}
+
+export function deriveSpendingPattern(
+  transactions: SpendingTransaction[],
+): SpendingPattern {
+  const expenses = transactions.filter(
+    (t) => normalizeTransactionType(t.type) === 'expense',
+  );
+  const income = transactions.filter((t) => t.type === 'income');
+  const totalIncome = income.reduce((sum, t) => sum + (Number(t.amount) || 0), 0);
+  const totalExpenses = expenses.reduce((sum, t) => sum + (Number(t.amount) || 0), 0);
+
+  const months = new Set(
+    expenses
+      .map((t) => {
+        const d = toDate(t.date);
+        return d ? `${d.getFullYear()}-${d.getMonth()}` : null;
+      })
+      .filter((m): m is string => Boolean(m)),
+  ).size || 1;
+  const totalMonthlySpend = totalExpenses / months;
+
+  const spendIn = (predicate: (category: string) => boolean): number =>
+    expenses
+      .filter((t) => predicate(t.category || ''))
+      .reduce((sum, t) => sum + (Number(t.amount) || 0), 0) / months;
+
+  const coffeeSpend = spendIn((c) => /coffee|caf[eé]/i.test(c));
+  const diningSpend = spendIn((c) => /dining|food|restaurant/i.test(c));
+  const subscriptionsSpend = spendIn((c) => /subscription|streaming|membership/i.test(c));
+  const entertainmentSpend = spendIn((c) => /entertainment|movie|game/i.test(c));
+  const discretionarySpend = coffeeSpend + diningSpend + subscriptionsSpend + entertainmentSpend;
+
+  const byCategory = new Map<string, number>();
+  expenses.forEach((t) => {
+    const cat = t.category || 'Other';
+    byCategory.set(cat, (byCategory.get(cat) || 0) + (Number(t.amount) || 0));
+  });
+  let topCategory = 'Other';
+  let topAmount = 0;
+  byCategory.forEach((amount, cat) => {
+    if (amount > topAmount) {
+      topAmount = amount;
+      topCategory = cat;
+    }
+  });
+
+  const savingsRate = totalIncome > 0 ? (totalIncome - totalExpenses) / totalIncome : 0;
+
+  return {
+    totalMonthlySpend,
+    coffeeSpend,
+    diningSpend,
+    subscriptionsSpend,
+    entertainmentSpend,
+    topCategory,
+    discretionarySpend,
+    savingsRate,
+  };
 }
 
 export function calculateDifficulty(spending: SpendingPattern): Difficulty {


### PR DESCRIPTION
## Problem

Savings Challenges were generated from a hardcoded placeholder spending pattern (`getEmptySpending`), so every user got the same generic challenges regardless of their actual transactions.

## Fix

- Added `deriveSpendingPattern(transactions)` to `challengeUtils.ts`, which computes real metrics (coffee/dining/subscriptions/entertainment spend, top category, discretionary spend, savings rate) from the user's actual transactions.
- `ChallengesDashboard.tsx` now loads the user's transactions via `fetchUserTransactions(user.uid, 6)` and derives the spending pattern from them; `getEmptySpending()` is removed.
- Generate is blocked with a toast when no transaction data is available, and the recommendations card shows loading/empty states.

## Files changed

- `src/lib/challengeUtils.ts`
- `src/components/challenges/ChallengesDashboard.tsx`

## Testing

- Verified challenges and recommendations are derived from real transaction data.
- `npx eslint` on both files — no new problems vs main.

Closes #467
