### PR TITLE
fix: dedupe generated challenges by title and type to prevent duplicates

### DIFF
--- a/src/components/challenges/ChallengesDashboard.tsx
+++ b/src/components/challenges/ChallengesDashboard.tsx
@@ -209,19 +209,30 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
       const monthly = generateMonthlyChallenges(spending);
       const all = [...weekly, ...monthly];
 
+      const existingKeys = new Set(
+        challenges.map((c) => `${c.title}::${c.type}`)
+      );
+      const newChallenges = all.filter(
+        (data) => !existingKeys.has(`${data.title}::${data.type}`)
+      );
+
       let created = 0;
-      for (const data of all) {
+      for (const data of newChallenges) {
         await createChallenge(user.uid, { ...data, difficulty });
         created++;
       }
-      toast.success(`Generated ${created} personalized challenges (${difficulty} difficulty)`);
+      if (created > 0) {
+        toast.success(`Generated ${created} personalized challenges (${difficulty} difficulty)`);
+      } else {
+        toast.info('You already have these challenges');
+      }
     } catch (error) {
       handleFirestoreError(error, OperationType.CREATE, 'challenges');
       toast.error('Failed to generate challenges');
     } finally {
       setGenerating(false);
     }
-  }, [user, spending]);
+  }, [user, spending, challenges]);
 
   const renderGrid = (items: Challenge[]) => (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Problem

Clicking 'Generate Challenges' duplicates every existing challenge each time, because new challenges were created without checking for already-existing ones.

## Fix

`generateChallenges` now dedupes generated challenges by title + type against the challenges already in the store before creating them, and shows an info toast when nothing new was generated.

## Files changed

- `src/components/challenges/ChallengesDashboard.tsx`

## Testing

- Clicking Generate repeatedly no longer creates duplicates.
- `npx eslint src/components/challenges/ChallengesDashboard.tsx` — no new problems vs main.

Closes #468
