### PR TITLE
fix: wire budget recommendations Discard button to revert local edits

### DIFF
--- a/src/components/budget/BudgetDashboard.tsx
+++ b/src/components/budget/BudgetDashboard.tsx
@@ -375,7 +375,6 @@ export function BudgetDashboard({ user }: { user: any }) {
             totalBudget={totalBudget}
             confidenceScore={confidenceScore}
             onSave={handleSaveBudget}
-            onDiscard={() => setSuggestions(suggestions)}
             isLoading={loading}
           />
         </div>

--- a/src/components/budget/BudgetRecommendations.tsx
+++ b/src/components/budget/BudgetRecommendations.tsx
@@ -29,7 +29,6 @@ interface BudgetRecommendationsProps {
   totalBudget: number;
   confidenceScore: number;
   onSave: (suggestions: CategoryBudgetSuggestion[]) => void;
-  onDiscard: () => void;
   isLoading?: boolean;
 }
 
@@ -38,7 +37,6 @@ export function BudgetRecommendations({
   totalBudget,
   confidenceScore,
   onSave,
-  onDiscard,
   isLoading = false,
 }: BudgetRecommendationsProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -345,7 +343,7 @@ export function BudgetRecommendations({
               <Button
                 variant="outline"
                 className="border-slate-700 text-slate-300 hover:bg-slate-800 h-9 px-4 text-xs font-bold uppercase tracking-wider"
-                onClick={onDiscard}
+                onClick={handleReset}
               >
                 Discard
               </Button>


### PR DESCRIPTION
## Problem

The 'Discard' button in Budget Recommendations was a no-op: `BudgetDashboard` wired `onDiscard={() => setSuggestions(suggestions)}`, which sets state to the same array reference, so local edits were never reverted. The component's own `handleReset` (which restores `localSuggestions` from the `suggestions` prop) was bound to a different, separate button.

## Fix

- The Discard button now calls the component's `handleReset`, reverting local edits back to the last saved/accepted values.
- Removed the now-dead `onDiscard` prop and its no-op wiring in `BudgetDashboard`.

## Files changed

- `src/components/budget/BudgetRecommendations.tsx`
- `src/components/budget/BudgetDashboard.tsx`

## Testing

- Edit a suggestion then click Discard: values revert to the last saved/accepted values.
- `npx eslint` on both files — same problem count as main.

Closes #470
