### PR TITLE
fix: include all user collections in privacy data export and erasure

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -82,17 +82,31 @@ export async function updatePrivacySettings(
   }
 }
 
+const USER_COLLECTIONS = [
+  "transactions",
+  "subscriptions",
+  "anomalies",
+  "reports",
+  "trend_analysis",
+  "goals",
+  "challenges",
+  "emergency_funds",
+  "health_scores",
+  "chat_conversations",
+  "chat_messages",
+  "budget_categories",
+  "budget_rollovers",
+  "portfolioHoldings",
+  "portfolioTransactions",
+  "portfolios",
+  "tax_estimates",
+];
+
 export async function exportUserData(
   userId: string,
 ): Promise<Record<string, any>> {
   const data: Record<string, any> = {};
-  for (const colName of [
-    "transactions",
-    "subscriptions",
-    "anomalies",
-    "reports",
-    "trend_analysis",
-  ]) {
+  for (const colName of USER_COLLECTIONS) {
     try {
       const snap = await getDocs(
         query(collection(db, colName), where("userId", "==", userId)),
@@ -102,6 +116,36 @@ export async function exportUserData(
       console.error('exportUserData: failed to fetch', colName, error);
       data[colName] = [];
     }
+  }
+  // documents are keyed by ownerId and keep their analyses as subcollections
+  try {
+    const docsSnap = await getDocs(
+      query(collection(db, "documents"), where("ownerId", "==", userId)),
+    );
+    const documents: Record<string, unknown>[] = [];
+    for (const d of docsSnap.docs) {
+      const entry: Record<string, unknown> = { id: d.id, ...d.data() };
+      try {
+        const analysesSnap = await getDocs(
+          query(
+            collection(db, "documents", d.id, "analyses"),
+            where("ownerId", "==", userId),
+          ),
+        );
+        entry.analyses = analysesSnap.docs.map((a) => ({
+          id: a.id,
+          ...a.data(),
+        }));
+      } catch (error) {
+        console.error('exportUserData: failed to fetch document analyses', error);
+        entry.analyses = [];
+      }
+      documents.push(entry);
+    }
+    data.documents = documents;
+  } catch (error) {
+    console.error('exportUserData: failed to fetch documents', error);
+    data.documents = [];
   }
   try {
     data.profile = (await getDoc(doc(db, "users", userId))).data();
@@ -153,15 +197,8 @@ export async function deleteUserData(userId: string): Promise<void> {
     throw error;
   }
 
-  const batch = writeBatch(db);
-  for (const colName of [
-    "transactions",
-    "subscriptions",
-    "anomalies",
-    "reports",
-    "trend_analysis",
-    "goals",
-  ]) {
+  const docRefs: DocumentReference[] = [];
+  for (const colName of USER_COLLECTIONS) {
     try {
       (
         await getDocs(
@@ -172,13 +209,29 @@ export async function deleteUserData(userId: string): Promise<void> {
       console.error('deleteUserData: failed to delete', colName, error);
     }
   }
-  docRefs.push(doc(db, "users", userId));
+  // documents are keyed by ownerId and keep their analyses as subcollections
+  try {
+    const docsSnap = await getDocs(
+      query(collection(db, "documents"), where("ownerId", "==", userId)),
+    );
+    for (const d of docsSnap.docs) {
+      const analysesSnap = await getDocs(
+        query(
+          collection(db, "documents", d.id, "analyses"),
+          where("ownerId", "==", userId),
+        ),
+      );
+      analysesSnap.docs.forEach((a) => docRefs.push(a.ref));
+      docRefs.push(d.ref);
+    }
+  } catch (error) {
+    console.error('deleteUserData: failed to delete documents', error);
+  }
+  // The users/<uid> doc must survive erasure: it is the deletion tombstone.
   docRefs.push(doc(db, "privacy_settings", userId));
   docRefs.push(doc(db, "currencies", userId));
   try {
-    batch.delete(doc(db, "privacy_settings", userId));
-    batch.delete(doc(db, "currencies", userId));
-    await batch.commit();
+    await deleteInBatches(docRefs);
   } catch (error) {
     handleFirestoreError(error, OperationType.DELETE, "userData");
     throw error;


### PR DESCRIPTION
## Problem

Privacy export and erasure only covered a handful of collections (transactions, subscriptions, anomalies, reports, trend_analysis), omitting most user data: goals, challenges, emergency funds, health scores, chat conversations/messages, budget categories/rollovers, portfolio data, tax estimates, and documents (including their analyses subcollections). Additionally, `deleteUserData` was broken: it pushed refs into an undeclared `docRefs` array and never called `deleteInBatches`, so erasure only deleted `privacy_settings` and `currencies`.

## Fix

- Extracted a shared `USER_COLLECTIONS` list used by both export and erasure.
- `exportUserData` now exports all user collections plus documents and their analyses subcollections (documents are keyed by `ownerId`).
- `deleteUserData` now declares `docRefs`, includes the full collection list plus documents/analyses (ownerId query), and actually deletes everything via `deleteInBatches` (500/batch). The `users/<uid>` tombstone doc is preserved so erased accounts are not resurrected on reload.

## Files changed

- `src/lib/privacyUtils.ts`

## Testing

- Export now includes all listed collections; erasure deletes them in batches while keeping the tombstone.
- `npx eslint src/lib/privacyUtils.ts` — problems reduced from 5 to 3 (fixed the unused `deleteInBatches`).
- `npx tsc --noEmit` — no new errors.

Closes #471
