### PR TITLE
fix: remove duplicate apiFetch import in AnalysisList

### DIFF
--- a/src/components/AnalysisList.tsx
+++ b/src/components/AnalysisList.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { toast } from "sonner";
-import { apiFetch } from "@/src/lib/api";
 import { formatDateSafe } from "@/src/lib/utils";
 
 export function AnalysisList({ type, user, onSelect }: any) {


### PR DESCRIPTION
## Problem

`AnalysisList.tsx` imports `apiFetch` twice from the same module (`@/src/lib/api`) — duplicate import.

## Fix

Removed the second `import { apiFetch } from "@/src/lib/api";`, keeping the single import at the top.

## Files changed

- `src/components/AnalysisList.tsx`

## Testing

- `npx eslint src/components/AnalysisList.tsx` and `npx tsc --noEmit` pass with no new errors.

Closes #472
