### PR TITLE
fix: exclude completed challenges from active tabs and prevent progress rewrites

### DIFF
--- a/src/components/challenges/ChallengesDashboard.tsx
+++ b/src/components/challenges/ChallengesDashboard.tsx
@@ -117,11 +117,11 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
   }, [user]);
 
   const weeklyChallenges = useMemo(
-    () => challenges.filter((c) => c.type === 'weekly'),
+    () => challenges.filter((c) => c.type === 'weekly' && !c.isCompleted),
     [challenges]
   );
   const monthlyChallenges = useMemo(
-    () => challenges.filter((c) => c.type === 'monthly'),
+    () => challenges.filter((c) => c.type === 'monthly' && !c.isCompleted),
     [challenges]
   );
   const completedChallenges = useMemo(

--- a/src/lib/challengeUtils.ts
+++ b/src/lib/challengeUtils.ts
@@ -262,7 +262,9 @@ export async function createChallenge(userId: string, data: Omit<Challenge, 'id'
 export async function updateChallengeProgress(challengeId: string, currentProgress: number): Promise<void> {
   const snap = await getDoc(doc(db, 'challenges', challengeId));
   if (!snap.exists()) return;
-  const targetAmount = (snap.data() as Challenge).targetAmount ?? 0;
+  const data = snap.data() as Challenge;
+  if (data.isCompleted) return;
+  const targetAmount = data.targetAmount ?? 0;
   const completed = currentProgress >= targetAmount && targetAmount > 0;
   const patch: Record<string, unknown> = { currentProgress };
   if (completed) {


### PR DESCRIPTION
## Problem

- Completed challenges remained listed in the active Weekly and Monthly tabs (only the History tab should show them).
- `updateChallengeProgress` did not check `isCompleted`, so logging progress on an already-completed challenge overwrote `completedAt` with a fresh timestamp.

## Fix

- Weekly/Monthly tab filters now exclude completed challenges (`type === 'weekly' && !isCompleted`).
- `updateChallengeProgress` now returns early when the challenge is already completed, so progress and `completedAt` are never rewritten.

## Files changed

- `src/components/challenges/ChallengesDashboard.tsx`
- `src/lib/challengeUtils.ts`

## Testing

- Completed challenges appear only under History; re-logging progress on a completed challenge is a no-op.
- `npx eslint` on both files — no new problems vs main.

Closes #473
