### PR TITLE
fix(forecast): derive projections from transaction history

### DIFF
--- a/src/components/forecast/ForecastComparison.tsx
+++ b/src/components/forecast/ForecastComparison.tsx
@@ -46,16 +46,51 @@ import {
   type ForecastFilter,
   generateMonthlyForecast,
   generateQuarterlyForecast,
-  calculateNetBalance,
   applyFilters,
   exportForecastChart,
   calculateTrend,
   getForecasts,
   createForecast,
+  updateForecast,
+  aggregateTransactionsByMonth,
 } from '@/src/lib/forecastUtils';
+import { fetchTransactions } from '@/src/lib/anomalyUtils';
 
 interface ForecastComparisonProps {
   user: import('firebase/auth').User | null;
+}
+
+async function buildForecastFromTransactions(
+  userId: string,
+  monthsAhead = 12
+): Promise<MonthlyForecast[]> {
+  const txns = await fetchTransactions(userId, 12);
+  const historicalData = aggregateTransactionsByMonth(txns);
+  return generateMonthlyForecast(historicalData, monthsAhead);
+}
+
+async function persistGeneratedForecasts(
+  userId: string,
+  generated: MonthlyForecast[]
+): Promise<void> {
+  if (!generated.length) return;
+  const existing = await getForecasts(userId);
+  const byMonth = new Map(existing.map((f) => [f.month, f]));
+  for (const m of generated.slice(0, 6)) {
+    const payload = {
+      month: m.month,
+      projectedIncome: m.income,
+      projectedExpenses: m.expenses,
+      netBalance: m.net,
+      confidence: m.confidence,
+    };
+    const match = byMonth.get(m.month);
+    if (match) {
+      await updateForecast(match.id, payload);
+    } else {
+      await createForecast(userId, payload);
+    }
+  }
 }
 
 export function ForecastComparison({ user }: ForecastComparisonProps) {
@@ -92,18 +127,15 @@ export function ForecastComparison({ user }: ForecastComparisonProps) {
           setMonthly(mapped);
           setQuarterly(generateQuarterlyForecast(mapped));
         } else if (active) {
-          const generated = generateMonthlyForecast([], 12);
+          const generated = await buildForecastFromTransactions(user.uid, 12);
+          if (!active) return;
           setMonthly(generated);
           setQuarterly(generateQuarterlyForecast(generated));
-          for (const m of generated.slice(0, 6)) {
-            await createForecast(user.uid, {
-              month: m.month,
-              projectedIncome: m.income,
-              projectedExpenses: m.expenses,
-              netBalance: m.net,
-              confidence: m.confidence,
-            });
+          if (generated.length === 0) {
+            toast.error('Not enough transaction history to generate a forecast');
+            return;
           }
+          await persistGeneratedForecasts(user.uid, generated);
         }
       } catch (error) {
         console.error('Error loading forecasts:', error);
@@ -173,9 +205,16 @@ export function ForecastComparison({ user }: ForecastComparisonProps) {
     if (!user) return;
     setSaving(true);
     try {
-      const generated = generateMonthlyForecast([], 12);
+      const generated = await buildForecastFromTransactions(user.uid, 12);
+      if (generated.length === 0) {
+        setMonthly([]);
+        setQuarterly([]);
+        toast.error('Not enough transaction history to generate a forecast');
+        return;
+      }
       setMonthly(generated);
       setQuarterly(generateQuarterlyForecast(generated));
+      await persistGeneratedForecasts(user.uid, generated);
       toast.success('Forecast regenerated');
     } catch (error) {
       handleFirestoreError(error, OperationType.CREATE, 'forecasts');

--- a/src/lib/forecastUtils.ts
+++ b/src/lib/forecastUtils.ts
@@ -47,6 +47,25 @@ export interface ForecastFilter {
   categories?: string[];
 }
 
+export function aggregateTransactionsByMonth(
+  transactions: { amount: number; date: unknown; type?: string }[]
+): { month: string; income: number; expenses: number }[] {
+  const byMonth: Record<string, { income: number; expenses: number }> = {};
+
+  for (const t of transactions) {
+    const d = toDate(t.date);
+    if (!d) continue;
+    const key = format(d, 'yyyy-MM');
+    if (!byMonth[key]) byMonth[key] = { income: 0, expenses: 0 };
+    if (t.type === 'income') byMonth[key].income += t.amount;
+    else byMonth[key].expenses += t.amount;
+  }
+
+  return Object.entries(byMonth)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, v]) => ({ month, ...v }));
+}
+
 export function generateMonthlyForecast(
   historicalData: { month: string; income: number; expenses: number }[],
   monthsAhead = 6


### PR DESCRIPTION
## Summary

Forecast comparison was calling `generateMonthlyForecast([], 12)` whenever there were no saved forecast docs, so it ignored existing income/expense transactions and could persist empty projections. Initial load and Regenerate now build history from transactions, skip saving when there is nothing to project, and upsert the generated months.

## Related Issue

Closes #250

## Changes Made

- Added `aggregateTransactionsByMonth` in `forecastUtils.ts`
- Wired `ForecastComparison` load + regenerate through transaction history
- Persist only when generated forecasts are non-empty; update existing month docs on regenerate

## Testing

- [x] `npx tsc --noEmit` — no new errors in changed files (pre-existing `RolloverManager.tsx` syntax errors remain)
- [x] ESLint on changed files — no new issues introduced by this change
- [x] `npm test` — passes
- [ ] Tested locally with a real Firebase project and Gemini API key
- [x] No `.env` secrets committed

## Screenshots (if UI change)

N/A

## Notes for Reviewer

If the user has no transactions in the lookback window, the UI stays empty and shows a toast instead of writing zero forecasts.

Made with [Cursor](https://cursor.com)