### PR TITLE
fix(bills): keep recurring bills active after payment

### DIFF
--- a/src/components/bills/BillReminders.tsx
+++ b/src/components/bills/BillReminders.tsx
@@ -52,7 +52,6 @@ import {
   getOverdueBills,
   calculateMonthlyObligations,
   getDaysUntilDue,
-  generateRecurringSchedule,
   isOverdue,
 } from '@/src/lib/billUtils';
 
@@ -161,23 +160,10 @@ export function BillReminders({ user }: BillRemindersProps) {
 
   const handlePay = async (bill: Bill) => {
     if (!user) return;
-    const ok = await markBillAsPaid(bill, user.uid);
-    if (ok) {
+    const updated = await markBillAsPaid(bill, user.uid);
+    if (updated) {
       setBills((prev) =>
-        prev.map((b) =>
-          b.id === bill.id
-            ? {
-                ...b,
-                isPaid: true,
-                lastPaidDate: new Date().toISOString(),
-                nextDueDate: generateRecurringSchedule(
-                  { ...b, isPaid: true, lastPaidDate: new Date().toISOString() },
-                  new Date(),
-                  1
-                )[0] || b.nextDueDate,
-              }
-            : b
-        )
+        prev.map((b) => (b.id === bill.id ? updated : b))
       );
       toast.success(`${bill.name} marked as paid`, {
         description: `${formatCurrency(bill.amount)} recorded as expense`,

--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -16,7 +16,6 @@ import {
   orderBy,
 } from 'firebase/firestore';
 import {
-  addDays,
   addWeeks,
   addMonths,
   addYears,
@@ -52,6 +51,17 @@ export interface BillInput {
 }
 
 const UPCOMING_WINDOW_DAYS = 7;
+
+export function isRecurringFrequency(frequency: BillFrequency): boolean {
+  return frequency === 'weekly' || frequency === 'monthly' || frequency === 'yearly';
+}
+
+function advanceByFrequency(date: Date, frequency: BillFrequency): Date {
+  if (frequency === 'weekly') return addWeeks(date, 1);
+  if (frequency === 'monthly') return addMonths(date, 1);
+  if (frequency === 'yearly') return addYears(date, 1);
+  return date;
+}
 
 export async function fetchUserBills(userId: string): Promise<Bill[]> {
   try {
@@ -140,23 +150,64 @@ export function calculateNextDueDate(
 ): string | null {
   const base = toDate(dueDate);
   if (!base) return null;
+  if (!isRecurringFrequency(frequency)) {
+    return startOfDay(base).toISOString();
+  }
 
   const reference = fromDate ? startOfDay(fromDate) : startOfDay(new Date());
   let next = startOfDay(base);
 
   while (isBefore(next, reference)) {
-    if (frequency === 'weekly') {
-      next = addWeeks(next, 1);
-    } else if (frequency === 'monthly') {
-      next = addMonths(next, 1);
-    } else if (frequency === 'yearly') {
-      next = addYears(next, 1);
-    } else {
-      break;
-    }
+    next = advanceByFrequency(next, frequency);
   }
 
   return next.toISOString();
+}
+
+/** Next cycle after a payment — always moves at least one period for recurring bills. */
+export function advanceDueDateAfterPayment(
+  dueDate: string,
+  frequency: BillFrequency,
+  paidDate: Date = new Date()
+): string | null {
+  if (!isRecurringFrequency(frequency)) return null;
+
+  const base = toDate(dueDate);
+  if (!base) return null;
+
+  const reference = startOfDay(paidDate);
+  let next = startOfDay(base);
+
+  do {
+    next = advanceByFrequency(next, frequency);
+  } while (next.getTime() <= reference.getTime());
+
+  return next.toISOString();
+}
+
+export function applyBillPayment(
+  bill: Bill,
+  paidDate: Date = new Date()
+): Pick<Bill, 'isPaid' | 'lastPaidDate' | 'nextDueDate' | 'dueDate'> {
+  const recurring = isRecurringFrequency(bill.frequency);
+  const currentDue = bill.nextDueDate || bill.dueDate;
+
+  if (!recurring) {
+    return {
+      isPaid: true,
+      lastPaidDate: paidDate.toISOString(),
+      nextDueDate: bill.nextDueDate ?? bill.dueDate,
+      dueDate: bill.dueDate,
+    };
+  }
+
+  const nextDueDate = advanceDueDateAfterPayment(currentDue, bill.frequency, paidDate) || currentDue;
+  return {
+    isPaid: false,
+    lastPaidDate: paidDate.toISOString(),
+    nextDueDate,
+    dueDate: nextDueDate,
+  };
 }
 
 export function isOverdue(bill: Bill, reference: Date = new Date()): boolean {
@@ -223,20 +274,12 @@ export function calculateMonthlyObligations(bills: Bill[]): number {
 export async function markBillAsPaid(
   bill: Bill,
   userId: string
-): Promise<boolean> {
+): Promise<Bill | null> {
   try {
     const paidDate = new Date();
-    const nextDueDate = calculateNextDueDate(
-      bill.nextDueDate || bill.dueDate,
-      bill.frequency,
-      paidDate
-    );
+    const payment = applyBillPayment(bill, paidDate);
 
-    await updateDoc(doc(db, 'bills', bill.id), {
-      isPaid: false,
-      lastPaidDate: paidDate.toISOString(),
-      nextDueDate,
-    });
+    await updateDoc(doc(db, 'bills', bill.id), payment);
 
     const transactionData = {
       userId,
@@ -250,11 +293,11 @@ export async function markBillAsPaid(
     };
     await addDoc(collection(db, 'transactions'), transactionData);
 
-    return true;
+    return { ...bill, ...payment };
   } catch (error) {
     console.error('Error marking bill as paid:', error);
     handleFirestoreError(error, OperationType.UPDATE, `bills/${bill.id}`);
-    return false;
+    return null;
   }
 }
 
@@ -263,14 +306,16 @@ export function generateRecurringSchedule(
   reference: Date = new Date(),
   occurrences = 6
 ): string[] {
+  if (bill.isPaid && !isRecurringFrequency(bill.frequency)) {
+    return [];
+  }
+
   const schedule: string[] = [];
   let next = toDate(bill.nextDueDate || bill.dueDate) || startOfDay(reference);
   for (let i = 0; i < occurrences; i++) {
     schedule.push(next.toISOString());
-    if (bill.frequency === 'weekly') next = addWeeks(next, 1);
-    else if (bill.frequency === 'monthly') next = addMonths(next, 1);
-    else if (bill.frequency === 'yearly') next = addYears(next, 1);
-    else break;
+    if (!isRecurringFrequency(bill.frequency)) break;
+    next = advanceByFrequency(next, bill.frequency);
   }
   return schedule;
 }

--- a/tests/bill-payment-lifecycle.test.mjs
+++ b/tests/bill-payment-lifecycle.test.mjs
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  addWeeks,
+  addMonths,
+  addYears,
+  isBefore,
+  startOfDay,
+  differenceInCalendarDays,
+} from "date-fns";
+
+function isRecurringFrequency(frequency) {
+  return frequency === "weekly" || frequency === "monthly" || frequency === "yearly";
+}
+
+function advanceByFrequency(date, frequency) {
+  if (frequency === "weekly") return addWeeks(date, 1);
+  if (frequency === "monthly") return addMonths(date, 1);
+  if (frequency === "yearly") return addYears(date, 1);
+  return date;
+}
+
+function advanceDueDateAfterPayment(dueDate, frequency, paidDate = new Date()) {
+  if (!isRecurringFrequency(frequency)) return null;
+  const base = new Date(dueDate);
+  if (Number.isNaN(base.getTime())) return null;
+  const reference = startOfDay(paidDate);
+  let next = startOfDay(base);
+  do {
+    next = advanceByFrequency(next, frequency);
+  } while (next.getTime() <= reference.getTime());
+  return next.toISOString();
+}
+
+function applyBillPayment(bill, paidDate = new Date()) {
+  const recurring = isRecurringFrequency(bill.frequency);
+  const currentDue = bill.nextDueDate || bill.dueDate;
+  if (!recurring) {
+    return {
+      isPaid: true,
+      lastPaidDate: paidDate.toISOString(),
+      nextDueDate: bill.nextDueDate ?? bill.dueDate,
+      dueDate: bill.dueDate,
+    };
+  }
+  const nextDueDate = advanceDueDateAfterPayment(currentDue, bill.frequency, paidDate) || currentDue;
+  return {
+    isPaid: false,
+    lastPaidDate: paidDate.toISOString(),
+    nextDueDate,
+    dueDate: nextDueDate,
+  };
+}
+
+function isOverdue(bill, reference = new Date()) {
+  if (bill.isPaid) return false;
+  const due = new Date(bill.nextDueDate || bill.dueDate);
+  return isBefore(startOfDay(due), startOfDay(reference));
+}
+
+function isUpcoming(bill, reference = new Date()) {
+  if (bill.isPaid || isOverdue(bill, reference)) return false;
+  const due = new Date(bill.nextDueDate || bill.dueDate);
+  const days = differenceInCalendarDays(startOfDay(due), startOfDay(reference));
+  return days >= 0 && days <= 7;
+}
+
+function baseBill(overrides) {
+  return {
+    id: "1",
+    userId: "u1",
+    name: "Netflix",
+    amount: 15,
+    dueDate: "2026-08-06T00:00:00.000Z",
+    frequency: "monthly",
+    category: "Subscription",
+    isPaid: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    nextDueDate: "2026-08-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("monthly recurring payment stays active and advances past pay day", () => {
+  const paidAt = new Date("2026-08-06T12:00:00.000Z");
+  const result = applyBillPayment(baseBill({ frequency: "monthly" }), paidAt);
+  assert.equal(result.isPaid, false);
+  assert.ok(new Date(result.nextDueDate).getTime() > startOfDay(paidAt).getTime());
+  assert.equal(result.dueDate, result.nextDueDate);
+});
+
+test("weekly and yearly recurring payments stay active", () => {
+  const paidAt = new Date("2026-08-06T12:00:00.000Z");
+  const weekly = applyBillPayment(baseBill({ frequency: "weekly" }), paidAt);
+  const yearly = applyBillPayment(baseBill({ frequency: "yearly" }), paidAt);
+  assert.equal(weekly.isPaid, false);
+  assert.equal(yearly.isPaid, false);
+  assert.ok(new Date(weekly.nextDueDate) > startOfDay(paidAt));
+  assert.ok(new Date(yearly.nextDueDate) > startOfDay(paidAt));
+});
+
+test("one-time custom bill remains completed after payment", () => {
+  const paidAt = new Date("2026-08-06T12:00:00.000Z");
+  const result = applyBillPayment(baseBill({ frequency: "custom" }), paidAt);
+  assert.equal(result.isPaid, true);
+  assert.equal(result.dueDate, "2026-08-06T00:00:00.000Z");
+});
+
+test("paid recurring bill still appears in obligation and upcoming helpers", () => {
+  const paidAt = new Date("2026-08-06T12:00:00.000Z");
+  const payment = applyBillPayment(baseBill({ frequency: "monthly" }), paidAt);
+  const bill = { ...baseBill({ frequency: "monthly" }), ...payment };
+  assert.equal(bill.isPaid, false);
+  assert.equal(isOverdue(bill, paidAt), false);
+  const days = differenceInCalendarDays(startOfDay(new Date(bill.nextDueDate)), startOfDay(paidAt));
+  assert.ok(days > 0);
+  assert.equal(isUpcoming(bill, paidAt), days <= 7);
+});


### PR DESCRIPTION
## Summary

Marking a recurring bill paid advanced `nextDueDate` but the UI still forced `isPaid: true`, and payment on the due date did not move past that day. Recurring bills now stay active with a future due date; one-time (`custom`) bills stay completed.

## Related Issue

Closes #252

## Changes Made

- Added `applyBillPayment` / `advanceDueDateAfterPayment` in `billUtils.ts`
- `markBillAsPaid` returns the updated bill and persists the correct paid/active state
- Bill reminders apply that returned state instead of hardcoding `isPaid: true`
- Regression tests for weekly, monthly, yearly, and one-time payment lifecycle

## Testing

- [x] `npx tsc --noEmit` — no new errors in changed files
- [x] `npm test` — passes
- [ ] Tested locally with a real Firebase project and Gemini API key
- [x] No `.env` secrets committed

## Screenshots (if UI change)

N/A

## Notes for Reviewer

`custom` is treated as one-time. Weekly/monthly/yearly remain in upcoming/overdue/obligation views after payment.

Made with [Cursor](https://cursor.com)