### PR TITLE
Fix: Block negative values in category budget

### DIFF
--- a/src/components/budget/BudgetRecommendations.tsx
+++ b/src/components/budget/BudgetRecommendations.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   Card,
   CardContent,
@@ -55,15 +56,17 @@ export function BudgetRecommendations({
 
   const handleSaveEdit = (category: string) => {
     const value = parseFloat(editValue);
-    if (!isNaN(value) && value >= 0) {
-      setLocalSuggestions((prev) =>
-        prev.map((s) =>
-          s.category === category
-            ? { ...s, modifiedAmount: value, status: "modified" as const }
-            : s,
-        ),
-      );
+    if (isNaN(value) || value < 0) {
+      toast.error("Budget must be greater than or equal to 0");
+      return;
     }
+    setLocalSuggestions((prev) =>
+      prev.map((s) =>
+        s.category === category
+          ? { ...s, modifiedAmount: value, status: "modified" as const }
+          : s,
+      ),
+    );
     setEditingId(null);
   };
 
@@ -235,6 +238,7 @@ export function BudgetRecommendations({
                       <div className="flex items-center gap-2">
                         <Input
                           type="number"
+                          min="0"
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
                           className="w-28 h-9 text-sm bg-slate-900 border-slate-700 text-white rounded-lg"


### PR DESCRIPTION
## Description
This Pull Request resolves Issue #509 by introducing strict validation against negative budget inputs.

## Changes Made
- Added min="0" to the budget amount Input component in BudgetRecommendations.tsx.
- Updated handleSaveEdit to intercept negative numbers and dispatch a toast.error message, preventing invalid data from entering the application state.

## Impact
Users are now blocked from entering negative values, ensuring total budget sums correctly reflect planned expenditures.

## Related Issues
- Resolves #509
