### PR TITLE
Fix: Re-render portfolio chart on state deletion

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,12 @@
+## Description
+This Pull Request resolves Issue #513 by ensuring the Portfolio chart re-renders and correctly displays an empty state when all transactions/holdings are deleted.
+
+## Changes Made
+- Added \	ransactions\ and \holdings\ to the dependency array of the \useEffect\ responsible for fetching performance history in \PortfolioTracker.tsx\.
+- Implemented an early return that explicitly clears the \performanceHistory\ state if both \	ransactions\ and \holdings\ arrays are empty.
+
+## Impact
+The UI now correctly synchronizes with the underlying data state, preventing stale chart data from lingering after all assets have been deleted.
+
+## Related Issues
+- Resolves #513

--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -143,12 +143,16 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
     if (!user || !portfolioId || activeTab !== 'performance') return;
     let active = true;
     const loadHistory = async () => {
+      if (transactions.length === 0 && holdings.length === 0) {
+        if (active) setPerformanceHistory([]);
+        return;
+      }
       const history = await fetchPortfolioHistory(user.uid, portfolioId);
       if (active) setPerformanceHistory(history);
     };
     loadHistory();
     return () => { active = false; };
-  }, [user, portfolioId, activeTab]);
+  }, [user, portfolioId, activeTab, transactions, holdings]);
 
   const totalValue = useMemo(() => calculateTotalValue(holdings), [holdings]);
   const totalCost = useMemo(() => holdings.reduce((s, h) => s + h.quantity * h.avgCost, 0), [holdings]);


### PR DESCRIPTION
## Description
This Pull Request resolves Issue #513 by ensuring the Portfolio chart re-renders and correctly displays an empty state when all transactions/holdings are deleted.

## Changes Made
- Added \	ransactions\ and \holdings\ to the dependency array of the \useEffect\ responsible for fetching performance history in \PortfolioTracker.tsx\.
- Implemented an early return that explicitly clears the \performanceHistory\ state if both \	ransactions\ and \holdings\ arrays are empty.

## Impact
The UI now correctly synchronizes with the underlying data state, preventing stale chart data from lingering after all assets have been deleted.

## Related Issues
- Resolves #513
