### PR TITLE
fix: removed orphaned .catch() from RolloverManager.tsx

### DIFF
--- a/src/components/rollover/RolloverManager.tsx
+++ b/src/components/rollover/RolloverManager.tsx
@@ -527,4 +527,3 @@ function SummaryCard({
   );
 }
 
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the orphaned `.catch(err => console.error("Promise.all failed:", err));` line from the bottom of `src/components/rollover/RolloverManager.tsx`. This trailing `.catch()` was chained on `undefined` (the return value of the previous statement) rather than an actual Promise, which caused a runtime error on every render of the RolloverManager component.

## Changes Made
- `src/components/rollover/RolloverManager.tsx`: Removed orphaned `.catch()` call (line 530).

## Impact it Made
- Eliminates runtime error thrown on every RolloverManager render
- Cleaner browser console with no spurious errors
- Prevents potential error masking if the orphaned catch swallowed real errors

Closes #521

Note: Please assign this PR to the `tmdeveloper007` account.
