### PR TITLE
fix: removed duplicate apiFetch import in AnalysisList.tsx

### DIFF
--- a/src/components/AnalysisList.tsx
+++ b/src/components/AnalysisList.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { toast } from "sonner";
-import { apiFetch } from "@/src/lib/api";
 import { formatDateSafe } from "@/src/lib/utils";
 
 export function AnalysisList({ type, user, onSelect }: any) {


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the duplicate `import { apiFetch } from "@/src/lib/api";` from `src/components/AnalysisList.tsx`. The file was importing `apiFetch` twice (lines 10 and 44). The first import on line 10 is the correct one to keep.

## Changes Made
- `src/components/AnalysisList.tsx`: Removed redundant `import { apiFetch } from "@/src/lib/api";` on line 44.

## Impact it Made
- Cleaned up redundant import declaration
- Eliminates TypeScript error TS2300 (Duplicate identifier 'apiFetch')
- Follows standard TypeScript/ESLint import best practices

Closes #522

Note: Please assign this PR to the `tmdeveloper007` account.
