### PR TITLE
fix: added blocking dark-mode script to eliminate FOUC on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,13 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/logo.png" />
     <link rel="mask-icon" href="/logo.png" color="#0ea5e9" />
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var isDark = stored === 'dark' || (stored !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) { document.documentElement.classList.add('dark'); }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary of What Has Been Done
Injected a blocking inline `<script>` in `index.html` (inside `<head>`) that runs synchronously before the page is rendered. This script reads the stored theme from `localStorage.getItem('theme')`, falls back to the OS `prefers-color-scheme` preference, and immediately adds `class="dark"` to the `<html>` element if the resolved theme is dark.

## Changes Made
- `index.html`: Added a self-invoking blocking `<script>` that applies the `dark` class before any CSS or JS executes.

## Impact it Made
- Zero flash of unstyled content for dark-mode users on initial page load
- Immediate dark-mode rendering when the stored theme is dark or the system prefers dark
- The `ThemeProvider` in `themeContext.tsx` takes over from this baseline once it hydrates

Closes #525

Note: Please assign this PR to the `tmdeveloper007` account.
