### PR TITLE
fix: use localSuggestions state for empty-state check in BudgetRecommendations

### DIFF
--- a/src/components/budget/BudgetRecommendations.tsx
+++ b/src/components/budget/BudgetRecommendations.tsx
@@ -129,7 +129,7 @@ export function BudgetRecommendations({
     );
   }
 
-  if (!suggestions || suggestions.length === 0) {
+  if (!localSuggestions || localSuggestions.length === 0) {
     return (
       <Card className="bg-slate-900 border-slate-800 rounded-2xl">
         <CardContent className="p-8 flex flex-col items-center justify-center min-h-[300px]">


### PR DESCRIPTION
## Summary of What Has Been Done
Changed the empty-state conditional in `src/components/budget/BudgetRecommendations.tsx` (line 132) from checking the `suggestions` prop to checking the `localSuggestions` state variable. When a user dismisses all budget suggestions, the prop `suggestions` retains its original non-empty value while `localSuggestions` becomes empty, so the empty-state message would never appear without this fix.

## Changes Made
- `src/components/budget/BudgetRecommendations.tsx`: Changed `if (!suggestions || suggestions.length === 0)` to `if (!localSuggestions || localSuggestions.length === 0)`

## Changes that Have Been Made
1. Changed the empty-state conditional check from the `suggestions` prop to the `localSuggestions` local state variable
2. This ensures the empty state message is shown when all budget suggestions have been dismissed by the user

## Impact it Made
- Users will correctly see the "No budget suggestions available" empty-state message after dismissing all recommendations
- Fixes a UX bug where the suggestions area would appear blank without the empty-state message when all items are removed

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #535