### PR TITLE
fix: correct inverted concentration check in calculateSpendingScore in healthUtils

### DIFF
--- a/src/lib/healthUtils.ts
+++ b/src/lib/healthUtils.ts
@@ -83,7 +83,7 @@ export function calculateSpendingScore(transactions: Transaction[]): number {
   const discretionaryRatio = totalSpent > 0 ? discretionary / totalSpent : 0;
 
   const uniquePayees = new Set(expenses.map((t) => t.description?.toLowerCase().trim()).filter(Boolean)).size;
-  const concentration = uniquePayees <= expenses.length * 0.5 ? 1 : 0.9;
+  const concentration = uniquePayees <= expenses.length * 0.5 ? 0.9 : 1;
 
   let score = 100;
   if (avgTransactionSize > totalSpent * 0.3) score -= 15;


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the inverted concentration check in the `calculateSpendingScore` function in `src/lib/healthUtils.ts` (line 86). The original logic applied a 0.9 penalty multiplier when spending was DIVERSE (many unique payees), and applied no penalty when spending was CONCENTRATED (few unique payees). This is the opposite of the intended behavior: concentrated spending in few places should be penalized as higher financial risk.

## Changes Made
- `src/lib/healthUtils.ts`: Swapped the penalty values from `uniquePayees <= expenses.length * 0.5 ? 1 : 0.9` to `uniquePayees <= expenses.length * 0.5 ? 0.9 : 1`

## Changes that Have Been Made
1. Changed the concentration multiplier from `1 : 0.9` to `0.9 : 1`
2. Now concentrated spending (few unique payees) receives the 0.9 penalty, and diverse spending (many unique payees) receives no penalty

## Impact it Made
- Health score now correctly penalizes concentrated spending patterns (spending heavily in few places = higher financial risk)
- Users with diverse spending across many merchants will see improved spending scores
- More accurate financial health assessment

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #537