### PR TITLE
fix: correct conservative and aggressive contribution amounts in goalUtils

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -66,11 +66,11 @@ export function generateContributionSuggestions(
     },
     {
       label: 'Conservative',
-      amount: Math.ceil(baseMonthly * (options.conservative ? 1.2 : 0.85)),
+      amount: Math.ceil(baseMonthly * (options.conservative ? 0.85 : 1.2)),
     },
     {
       label: 'Aggressive',
-      amount: Math.max(1, Math.floor(baseMonthly * (options.aggressive ? 0.85 : 1.2))),
+      amount: Math.max(1, Math.floor(baseMonthly * (options.aggressive ? 1.2 : 0.85))),
     },
   ];
 


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the swapped conservative and aggressive contribution multipliers in the `generateContributionSuggestions` function in `src/lib/goalUtils.ts` (lines 69 and 73). Conservative mode was using a 1.2x multiplier (suggesting MORE savings than needed), and aggressive mode was using a 0.85x multiplier (suggesting LESS savings than needed). These were exactly reversed.

## Changes Made
- `src/lib/goalUtils.ts`: 
  - Conservative: changed from `1.2 : 0.85` to `0.85 : 1.2`
  - Aggressive: changed from `0.85 : 1.2` to `1.2 : 0.85`

## Changes that Have Been Made
1. Swapped the multiplier values for conservative (0.85) and aggressive (1.2) contribution suggestions
2. Conservative mode now suggests a cautious, lower monthly contribution (0.85x the base amount)
3. Aggressive mode now suggests an ambitious, higher monthly contribution (1.2x the base amount)

## Impact it Made
- Users selecting conservative savings goals receive appropriate lower estimates
- Users selecting aggressive savings goals receive appropriate higher estimates
- Goal contribution suggestions now accurately reflect their stated mode names
- Improved trust in AI-generated financial goal planning

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #538