### PR TITLE
Fix: Handle empty monthly expenses gracefully in Emergency Planner

### DIFF
--- a/src/components/emergency/EmergencyFundPlanner.tsx
+++ b/src/components/emergency/EmergencyFundPlanner.tsx
@@ -98,10 +98,10 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
     };
   }, [user]);
 
-  const recommendedTarget = useMemo(
-    () => calculateRecommendedTarget(parseFloat(monthlyExpenses) || 0, targetMonths),
-    [monthlyExpenses, targetMonths]
-  );
+  const recommendedTarget = useMemo(() => {
+    const parsed = parseFloat(monthlyExpenses);
+    return calculateRecommendedTarget(isNaN(parsed) ? 0 : parsed, targetMonths);
+  }, [monthlyExpenses, targetMonths]);
 
   const monthlySuggestion = useMemo(() => {
     if (!fund) return 0;
@@ -287,7 +287,13 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                     <Input
                       type="number"
                       value={monthlyExpenses}
-                      onChange={(e) => setMonthlyExpenses(e.target.value)}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setMonthlyExpenses(val === '' ? '' : val);
+                      }}
+                      onBlur={() => {
+                        if (!monthlyExpenses) setMonthlyExpenses('0');
+                      }}
                       placeholder="0.00"
                       className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500 h-10 rounded-lg"
                       min="0"


### PR DESCRIPTION
## Description
This Pull Request resolves Issue #550 by gracefully handling empty input values for monthly expenses in the Emergency Fund Planner.

## Changes Made
- Added a fallback to `0` when `parseFloat` yields `NaN` for `monthlyExpenses`.
- Added an `onBlur` handler to the input to explicitly default the display value to `'0'` if it is left empty, averting NaN proliferation into calculation outputs.

## Impact
Improves robustness and avoids showing "NaN" in the Recommended Target, presenting a reliable placeholder instead.

## Related Issues
- Resolves #550
