### PR TITLE
fix : remove debug console.log from subscribeToTopic in notificationUtils

### DIFF
--- a/src/lib/notificationUtils.ts
+++ b/src/lib/notificationUtils.ts
@@ -142,7 +142,6 @@ export async function subscribeToTopic(userId: string, topic: string): Promise<b
   try {
     // This would integrate with Firebase Cloud Messaging
     // For now, return true to indicate the function exists
-    console.log(`Subscribing user ${userId} to topic: ${topic}`);
     return true;
   } catch (error) {
     console.error('Error subscribing to topic:', error);


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the debug `console.log` statement from the `subscribeToTopic` function in `src/lib/notificationUtils.ts`. The function now returns `true` silently, consistent with the pattern used elsewhere in the file where `console.error` is used only for actual errors.

## Changes Made

- **`src/lib/notificationUtils.ts`**: Removed `console.log(`Subscribing user ${userId} to topic: ${topic}`)` from the `subscribeToTopic` function body

## Changes that Need to Be Made

None - this fix is self-contained.

## Impact it Made

- Cleaner production code without unnecessary console output
- Better signal-to-noise ratio in browser developer console
- Consistent with other functions in the file that use structured logging

Closes #570.

Note: Please assign this PR to the `tmdeveloper007` account.
