### PR TITLE
fix : remove duplicate PeriodSelector import in CategoryTrends component

### DIFF
--- a/src/components/trends/CategoryTrends.tsx
+++ b/src/components/trends/CategoryTrends.tsx
@@ -48,7 +48,6 @@ import {
   type Transaction,
   type TrendPeriod,
 } from '@/src/lib/trendsUtils';
-import { PeriodSelector } from './PeriodSelector';
 
 interface CategoryTrendsProps {
   user: { uid: string } | null;


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `PeriodSelector` import from `src/components/trends/CategoryTrends.tsx`. The import was present both at the top of the file (line 6) and again at line 51, before the component interface definition.

## Changes Made

- **`src/components/trends/CategoryTrends.tsx`**: Removed duplicate `import { PeriodSelector } from './PeriodSelector';` at line 51

## Impact it Made

- Cleaner, more maintainable import section
- No functional change

Closes #572.

Note: Please assign this PR to the `tmdeveloper007` account.
