### PR TITLE
fix : remove duplicate formatCurrency from reportUtils to avoid name collision

### DIFF
--- a/src/components/reports/ReportPreview.tsx
+++ b/src/components/reports/ReportPreview.tsx
@@ -21,7 +21,7 @@ import {
   TableRow,
 } from "@/src/components/ui/table";
 import { Badge } from "@/src/components/ui/badge";
-import { formatCurrency } from "@/src/lib/reportUtils";
+import { formatCurrency } from "@/src/lib/utils";
 import type {
   ExpenseSummaryItem,
   IncomeSummaryItem,

--- a/src/lib/reportUtils.ts
+++ b/src/lib/reportUtils.ts
@@ -13,7 +13,7 @@ import {
   Timestamp,
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
-import { toDate } from "@/src/lib/utils";
+import { toDate, formatCurrency } from "@/src/lib/utils";
 import { format, startOfDay, endOfDay } from "date-fns";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
@@ -51,18 +51,6 @@ export interface ReportData {
   totalExpenses: number;
   currency?: string;
   createdAt: Date;
-}
-
-export function formatCurrency(
-  amount: number,
-  currencyCode: string = "INR",
-): string {
-  return new Intl.NumberFormat("en-IN", {
-    style: "currency",
-    currency: currencyCode,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(amount);
 }
 
 export function formatDate(value: Date | any): string {


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `formatCurrency` function from `src/lib/reportUtils.ts` that shadowed the canonical implementation in `src/lib/utils.ts`. Updated all internal callers in `reportUtils.ts` and the consumer in `ReportPreview.tsx` to import from `utils.ts`.

## Changes Made

- **`src/lib/reportUtils.ts`**: Removed `formatCurrency` function definition; added `formatCurrency` to the existing import from `@/src/lib/utils`
- **`src/components/reports/ReportPreview.tsx`**: Updated `formatCurrency` import to come from `@/src/lib/utils` instead of `@/src/lib/reportUtils`

## Impact it Made

- Eliminates naming collision and reduces code duplication
- All currency formatting now uses the centralized `utils.ts` implementation
- Easier maintenance with a single source of truth for currency formatting

Closes #571.

Note: Please assign this PR to the `tmdeveloper007` account.
