### PR TITLE
fix : correct concentration multiplier in calculateSpendingScore to ensure integer score

### DIFF
--- a/src/lib/healthUtils.ts
+++ b/src/lib/healthUtils.ts
@@ -90,9 +90,11 @@ export function calculateSpendingScore(transactions: Transaction[]): number {
   if (discretionaryRatio > 0.5) score -= 20;
   if (discretionaryRatio > 0.35) score -= 10;
   if (categoryCount < 3) score -= 10;
-  score *= concentration;
+  if (concentration < 1) {
+    score = Math.round(score * 0.9);
+  }
 
-  return Math.min(100, Math.max(0, Math.round(score)));
+  return Math.min(100, Math.max(0, score));
 }
 
 export function calculateSavingsScore(transactions: Transaction[]): number {


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the `calculateSpendingScore` function in `src/lib/healthUtils.ts` to ensure the score remains an integer throughout the calculation. Previously, `score *= concentration` could produce fractional intermediate values (e.g., `85 * 0.9 = 76.5`) before the final `Math.round`.

The fix replaces the multiplication with a conditional rounding that applies the 10% penalty as an explicit integer operation.

## Changes Made

- **`src/lib/healthUtils.ts`**: Replaced `score *= concentration; return Math.min(100, Math.max(0, Math.round(score)));` with:
  ```typescript
  if (concentration < 1) {
    score = Math.round(score * 0.9);
  }
  return Math.min(100, Math.max(0, score));
  ```

## Impact it Made

- Score remains an integer throughout the calculation
- No functional change for most inputs due to the existing `Math.round` call
- Cleaner, more predictable integer arithmetic in the scoring function

Closes #573.

Note: Please assign this PR to the `tmdeveloper007` account.
