### PR TITLE
fix : add missing fetchActivityLog utility function and activityLog state

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -7,6 +7,7 @@ import {
   collection,
   query,
   where,
+  orderBy,
   getDocs,
   doc,
   writeBatch,
@@ -81,6 +82,31 @@ export async function updatePrivacySettings(
     );
   } catch (error) {
     handleFirestoreError(error, OperationType.UPDATE, "privacy_settings");
+  }
+}
+
+export async function fetchActivityLog(
+  userId: string,
+): Promise<ActivityLogEntry[]> {
+  try {
+    const logRef = collection(db, "activity_log");
+    const q = query(logRef, where("userId", "==", userId), orderBy("timestamp", "desc"));
+    const snapshot = await getDocs(q);
+    const entries: ActivityLogEntry[] = [];
+    snapshot.forEach((docSnap) => {
+      const data = docSnap.data();
+      entries.push({
+        id: docSnap.id,
+        action: data.action || "",
+        timestamp: data.timestamp?.toDate?.() ?? new Date(),
+        details: data.details || "",
+        category: data.category || "data",
+      });
+    });
+    return entries;
+  } catch (err) {
+    console.error("fetchActivityLog: failed to retrieve activity log", err);
+    return [];
   }
 }
 


### PR DESCRIPTION
## Summary of What Has Been Done

The `PrivacyDashboard` component was calling `fetchActivityLog(user.uid)` and `setActivityLog(logs)` but neither the function nor the state were defined, causing a runtime ReferenceError. This fix adds both.

## Changes Made

- **`src/lib/privacyUtils.ts`**: 
  - Added `orderBy` to Firebase imports
  - Added `fetchActivityLog` function that queries the `activity_log` Firestore collection for the given userId, ordered by timestamp descending, returning `ActivityLogEntry[]`
  - The function gracefully returns an empty array if the collection is empty or queries fail

- **`src/components/privacy/PrivacyDashboard.tsx`**:
  - Added `fetchActivityLog` and `ActivityLogEntry` to imports from `@/src/lib/privacyUtils`
  - Added `activityLog` state: `useState<ActivityLogEntry[]>([])`
  - The existing `loadPrivacyData` calls now work correctly

## Impact it Made

- Eliminates runtime ReferenceError on the Privacy page
- Activity log data is now correctly loaded when available
- Component functions without crashing

Closes #569.

Note: Please assign this PR to the `tmdeveloper007` account.
