### PR TITLE
[Bug] Cash-flow forecast divides by months-with-activity - projections inflated up to 6x

### DIFF
--- a/src/components/cashflow/CashFlowDashboard.tsx
+++ b/src/components/cashflow/CashFlowDashboard.tsx
@@ -59,7 +59,7 @@ export function CashFlowDashboard({ user }: { user: any }) {
     setLoading(true);
     try {
       const transactions = await fetchUserTransactions(user.uid, 6);
-      const forecastData = calculateMonthlyForecast(transactions);
+      const forecastData = calculateMonthlyForecast(transactions, 6);
       const balanceProj = calculateBalanceProjection(
         transactions,
         forecastData,

--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -124,8 +124,9 @@ export async function fetchUserTransactions(
 
 export function calculateMonthlyForecast(
   transactions: Transaction[],
+  windowMonths: number = 6,
 ): ForecastData[] {
-  const months = getNextMonths(6);
+  const months = getNextMonths(windowMonths);
   const incomeByMonth: Record<string, number> = {};
   const expenseByMonth: Record<string, Record<string, number>> = {};
 
@@ -140,23 +141,25 @@ export function calculateMonthlyForecast(
     }
   });
 
+  // Averages are computed over the full observation window: months without
+  // activity are zero-filled so a charge that appears once in the window is
+  // projected at its true monthly rate instead of its per-month-with-activity
+  // rate.
   const avgIncome =
     Object.values(incomeByMonth).length > 0
       ? Object.values(incomeByMonth).reduce((a, b) => a + b, 0) /
-        Object.values(incomeByMonth).length
+        windowMonths
       : 0;
 
   const categoryTotals: Record<string, number> = {};
-  const categoryCounts: Record<string, number> = {};
   Object.values(expenseByMonth).forEach((monthData) => {
     Object.entries(monthData).forEach(([cat, amt]) => {
       categoryTotals[cat] = (categoryTotals[cat] || 0) + amt;
-      categoryCounts[cat] = (categoryCounts[cat] || 0) + 1;
     });
   });
   const avgByCategory: Record<string, number> = {};
   Object.entries(categoryTotals).forEach(([cat, total]) => {
-    avgByCategory[cat] = total / (categoryCounts[cat] || 1);
+    avgByCategory[cat] = total / windowMonths;
   });
 
   return months.map((month) => {


### PR DESCRIPTION
## Problem
`calculateMonthlyForecast` in `src/lib/cashflowUtils.ts` averages historical income/expense using denominators equal to the number of months in which activity actually occurred, rather than the observation window size. With the 6-month window, months without activity drop out of the average, so projected income/expense can be inflated up to 6x. Category forecasts have the same bug (`avgByCategory[cat] = total / (categoryCounts[cat] || 1)`).

## Fix
- `calculateMonthlyForecast` now accepts a `windowMonths` parameter (default `6`) and divides each month's income/expense totals by the full window size.
- `categoryCounts` is removed; per-category averages use the same window-size denominator, and months with no activity in a category contribute `0`.
- The dashboard caller in `CashFlowDashboard.tsx` explicitly passes `6`.

## Files changed
- `src/lib/cashflowUtils.ts`
- `src/components/cashflow/CashFlowDashboard.tsx`

## Testing
- `node --test "tests/*.test.mjs"` — all pass.
- `tsc --noEmit` — no new errors (only pre-existing baseline errors).
- `eslint` on changed files — clean.

Closes #559
