### PR TITLE
[Bug] Anomaly detection crashes on Firestore Timestamp dates (RangeError in calculateCategoryBaseline)

### DIFF
--- a/src/lib/anomalyStats.ts
+++ b/src/lib/anomalyStats.ts
@@ -5,6 +5,7 @@
  */
 
 import { format } from "date-fns";
+import { toDate } from "./utils";
 
 export interface Transaction {
   id: string;
@@ -51,7 +52,8 @@ export function calculateCategoryBaseline(
         : 0;
     const monthlyTotals = new Map<string, number>();
     items.forEach((item) => {
-      const date = item.date instanceof Date ? item.date : new Date(item.date);
+      const date = toDate(item.date);
+      if (!date) return;
       const key = format(date, "yyyy-MM");
       monthlyTotals.set(key, (monthlyTotals.get(key) || 0) + Math.abs(item.amount));
     });

--- a/src/lib/anomalyStats.ts
+++ b/src/lib/anomalyStats.ts
@@ -5,7 +5,7 @@
  */
 
 import { format } from "date-fns";
-import { toDate } from "./utils";
+import { toDate } from "./utils.ts";
 
 export interface Transaction {
   id: string;

--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -117,7 +117,7 @@ export async function fetchTransactions(
     const snap = await getDocs(q);
     return snap.docs.map((d) => {
       const data = d.data() as Omit<Transaction, "id">;
-      return { ...data, id: d.id } as Transaction;
+      return { ...data, date: toDate(data.date) || new Date(), id: d.id } as Transaction;
     });
   } catch (error) {
     if ((error as any)?.code === "failed-precondition") {
@@ -130,7 +130,7 @@ export async function fetchTransactions(
       return snap.docs
         .map((d) => {
           const data = d.data() as Omit<Transaction, "id">;
-          return { ...data, id: d.id } as Transaction;
+          return { ...data, date: toDate(data.date) || new Date(), id: d.id } as Transaction;
         })
         .filter((t) => {
           const time = toDate(t.date)?.getTime() ?? 0;


### PR DESCRIPTION
## Problem
Anomaly detection crashes when transactions carry Firestore `Timestamp` dates. `calculateCategoryBaseline` in `src/lib/anomalyStats.ts` builds month keys via `format(item.date, "yyyy-MM")`, which throws a `RangeError` for non-`Date` values. The same non-`Date` values also break the `date`-based grouping keys in `anomalyUtils.fetchTransactions`, causing anomalies/insights to be unreliable or to crash.

## Fix
- Imported the shared `toDate()` helper from `./utils` into `anomalyStats.ts`.
- `calculateCategoryBaseline` normalizes each transaction date with `toDate()` and skips entries that fail to parse.
- `anomalyUtils.fetchTransactions` normalizes both mapping sites with `toDate(data.date) || new Date()` so downstream month grouping is always correct.
- Used an explicit `./utils.ts` import so the pre-existing `tests/anomaly-leave-one-out.test.mjs` (which runtime-imports `anomalyStats.ts` via Node ESM) still resolves.

## Files changed
- `src/lib/anomalyStats.ts`
- `src/lib/anomalyUtils.ts`

## Testing
- `node --test "tests/*.test.mjs"` — all pass, including `anomaly-leave-one-out.test.mjs`.
- `tsc --noEmit` — no new errors (only pre-existing baseline errors).
- `eslint` on changed files — clean.

Closes #560
