### PR TITLE
[Bug] 'Projected Balance' is cumulative 6-month net cash flow, not an account balance

### DIFF
--- a/src/components/cashflow/CashFlowDashboard.tsx
+++ b/src/components/cashflow/CashFlowDashboard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/src/components/ui/card";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
+import { Input } from "@/src/components/ui/input";
 import { Progress } from "@/src/components/ui/progress";
 import {
   XAxis,
@@ -49,6 +50,7 @@ export function CashFlowDashboard({ user }: { user: any }) {
   const [recurring, setRecurring] = useState<RecurringTransaction[]>([]);
   const [confidence, setConfidence] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  const [startingBalance, setStartingBalance] = useState(0);
 
   useEffect(() => {
     loadCashFlowData();
@@ -58,11 +60,15 @@ export function CashFlowDashboard({ user }: { user: any }) {
     if (!user) return;
     setLoading(true);
     try {
+      const stored = Number(localStorage.getItem("finsight_starting_balance") || 0);
+      const starting = Number.isFinite(stored) ? stored : 0;
+      setStartingBalance(starting);
       const transactions = await fetchUserTransactions(user.uid, 6);
-      const forecastData = calculateMonthlyForecast(transactions);
+      const forecastData = calculateMonthlyForecast(transactions, 6);
       const balanceProj = calculateBalanceProjection(
         transactions,
         forecastData,
+        starting,
       );
       const recurringTx = identifyRecurringTransactions(transactions);
       const confScore = calculateConfidenceScore(transactions, forecastData);
@@ -76,6 +82,15 @@ export function CashFlowDashboard({ user }: { user: any }) {
     } finally {
       setLoading(false);
     }
+  }
+
+  function handleStartingBalanceChange(value: string) {
+    const parsed = Number(value);
+    const balance = Number.isFinite(parsed) ? parsed : 0;
+    setStartingBalance(balance);
+    localStorage.setItem("finsight_starting_balance", String(balance));
+    setProjection(calculateBalanceProjection([], forecast, balance));
+  }
   }
 
   async function handleRefresh() {
@@ -226,6 +241,22 @@ export function CashFlowDashboard({ user }: { user: any }) {
                     : "$0"}
                 </p>
               </div>
+            </div>
+            <div className="mt-3">
+              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500 mb-1">
+                Starting Balance
+              </p>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={
+                  startingBalance === 0 ? "" : String(startingBalance)
+                }
+                onChange={(e) => handleStartingBalanceChange(e.target.value)}
+                placeholder="Enter your current balance"
+                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500 h-9 text-sm"
+              />
             </div>
           </CardContent>
         </Card>

--- a/src/components/cashflow/CashFlowDashboard.tsx
+++ b/src/components/cashflow/CashFlowDashboard.tsx
@@ -64,7 +64,7 @@ export function CashFlowDashboard({ user }: { user: any }) {
       const starting = Number.isFinite(stored) ? stored : 0;
       setStartingBalance(starting);
       const transactions = await fetchUserTransactions(user.uid, 6);
-      const forecastData = calculateMonthlyForecast(transactions, 6);
+      const forecastData = calculateMonthlyForecast(transactions);
       const balanceProj = calculateBalanceProjection(
         transactions,
         forecastData,
@@ -90,7 +90,6 @@ export function CashFlowDashboard({ user }: { user: any }) {
     setStartingBalance(balance);
     localStorage.setItem("finsight_starting_balance", String(balance));
     setProjection(calculateBalanceProjection([], forecast, balance));
-  }
   }
 
   async function handleRefresh() {

--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -177,18 +177,16 @@ export function calculateMonthlyForecast(
 export function calculateBalanceProjection(
   transactions: Transaction[],
   forecast: ForecastData[],
+  startingBalance: number = 0,
 ): BalanceProjection[] {
-  // Seed with the sum of all fetched transactions: today's real balance,
-  // which already includes the current (partial) month's activity.
-  let currentBalance = 0;
-  transactions.forEach((t) => {
-    if (t.type === "income") currentBalance += t.amount;
-    else currentBalance -= t.amount;
-  });
+  // Seed with the user's real current account balance. Past net cash flow is
+  // NOT used as the seed (it is a cumulative figure, not a balance) so the
+  // projection reflects an actual account balance rather than a fabricated
+  // sum of up to six months of activity.
+  let currentBalance = startingBalance;
 
-  // The current month's actuals are already folded into currentBalance, so
-  // adding its projected net on top would count the month twice. The current
-  // month reports the real balance; only future months advance the balance.
+  // The current month's projected net is not applied: the current month
+  // reports the real starting balance; only future months advance the balance.
   const currentMonth = getMonthKey(new Date());
 
   return forecast.map((f) => {

--- a/tests/cashflow-balance-projection.test.mjs
+++ b/tests/cashflow-balance-projection.test.mjs
@@ -21,9 +21,10 @@ const bodyStart = source.indexOf("{", start);
 const bodyEnd = source.indexOf("\n}", bodyStart);
 const body = source.slice(bodyStart, bodyEnd + 1);
 
-test("projection seeds the starting balance from actual transactions", () => {
-  assert.match(body, /transactions\.forEach/);
-  assert.match(body, /currentBalance/);
+test("projection seeds from the real starting balance, not cumulative net flow", () => {
+  assert.match(body, /startingBalance/);
+  assert.match(body, /let currentBalance = startingBalance/);
+  assert.doesNotMatch(body, /transactions\.forEach/);
 });
 
 test("projection reports today's real balance for the current month", () => {


### PR DESCRIPTION
## Problem
'Projected Balance' is currently mislabeled. `calculateBalanceProjection` in `src/lib/cashflowUtils.ts` seeds `currentBalance` from the sum of past transactions and then adds net monthly cash flow, so the chart shows cumulative net cash flow rather than an account balance — and there is no way for the user to supply their real starting balance.

## Fix
- `calculateBalanceProjection` now accepts a `startingBalance` parameter (default `0`) and seeds `currentBalance` from it instead of from a transaction-sum.
- Removed the `transactions.forEach` net-flow seeding; projections are now driven by the monthly forecast.
- `CashFlowDashboard.tsx` adds a "Starting Balance" input (persisted to `localStorage("finsight_starting_balance")`) that recomputes the projection when changed.
- Updated `tests/cashflow-balance-projection.test.mjs` to assert the balance is seeded from the provided `startingBalance`.

## Files changed
- `src/lib/cashflowUtils.ts`
- `src/components/cashflow/CashFlowDashboard.tsx`
- `tests/cashflow-balance-projection.test.mjs`

## Testing
- `node --test "tests/*.test.mjs"` — all pass.
- `tsc --noEmit` — no new errors (only pre-existing baseline errors).
- `eslint` on changed files — clean.

Closes #562
