### PR TITLE
[Bug] Detected subscriptions with a stale last charge get a past renewal date and vanish from reminders

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -21,6 +21,7 @@ import {
   addDays,
   startOfDay,
   differenceInDays,
+  isBefore,
   isAfter,
 } from "date-fns";
 
@@ -258,6 +259,21 @@ export function analyzeSubscriptionPattern(
   return { frequency: "monthly", confidence: 0.3 };
 }
 
+function advanceByFrequency(
+  date: Date,
+  frequency: "monthly" | "yearly" | "weekly",
+): Date {
+  switch (frequency) {
+    case "weekly":
+      return addWeeks(date, 1);
+    case "yearly":
+      return addYears(date, 1);
+    case "monthly":
+    default:
+      return addMonths(date, 1);
+  }
+}
+
 export function predictNextRenewalDate(
   transactions: Transaction[],
   frequency: "monthly" | "yearly" | "weekly",
@@ -266,17 +282,18 @@ export function predictNextRenewalDate(
     (a, b) => b.date.getTime() - a.date.getTime(),
   );
   const lastDate = sorted[0]?.date || new Date();
+  const now = new Date();
 
-  switch (frequency) {
-    case "weekly":
-      return addWeeks(startOfDay(lastDate), 1);
-    case "monthly":
-      return addMonths(startOfDay(lastDate), 1);
-    case "yearly":
-      return addYears(startOfDay(lastDate), 1);
-    default:
-      return addMonths(startOfDay(lastDate), 1);
-  }
+  // Advance forward from the last observed charge to the first future
+  // occurrence. A stale last charge (paused service, missed payment, long
+  // gap) must not produce a past renewal date that hides the subscription
+  // from upcoming-renewals and reminders.
+  let next = startOfDay(lastDate);
+  do {
+    next = advanceByFrequency(next, frequency);
+  } while (isBefore(next, now));
+
+  return next;
 }
 
 export function calculateSubscriptionCosts(subscriptions: Subscription[]): {


### PR DESCRIPTION
## Problem
`predictNextRenewalDate` in `src/lib/subscriptionUtils.ts` does not advance the last-charge date past today. For a subscription with a stale last charge, it returns a past renewal date, so the subscription is never picked up by the reminders view and disappears from upcoming renewals.

## Fix
- Added an `advanceByFrequency` helper that steps a date forward by the subscription's cadence (monthly / yearly / weekly).
- `predictNextRenewalDate` now loops `advanceByFrequency` until the next renewal date is after the current date (`isBefore(next, now)`), so renewals always land in the future.
- Added the `isBefore` import from `date-fns`.

## Files changed
- `src/lib/subscriptionUtils.ts`

## Testing
- `node --test "tests/*.test.mjs"` — all pass.
- `tsc --noEmit` — no new errors (only pre-existing baseline errors).
- `eslint` on changed files — clean.

Closes #565
