### PR TITLE
[Bug] Emergency fund completion date rounded from days/30 - savings plan misses the deadline

### DIFF
--- a/src/lib/emergencyUtils.ts
+++ b/src/lib/emergencyUtils.ts
@@ -87,7 +87,11 @@ export function estimateMonthsToCompletion(
   const target = toDate(completionDate);
   if (!target) return 0;
   const days = differenceInCalendarDays(target, new Date());
-  return Math.max(0, Math.round(days / 30));
+  // Fractional months preserve the exact horizon so the recommended monthly
+  // contribution reaches the target by the completion date, instead of
+  // Math.round(days / 30) drifting past the 0.5 boundary and either
+  // under-funding or over-shooting the deadline.
+  return Math.max(0, days / 30);
 }
 
 export function estimateCompletionDate(


### PR DESCRIPTION
## Problem
`estimateMonthsToCompletion` in `src/lib/emergencyUtils.ts` rounds `days / 30` with `Math.round`. For small monthly savings targets the rounded value can drop to `0` months (or understate the true months), so the emergency-fund completion date appears to be "now" and the savings plan looks complete before it actually is.

## Fix
- Returns the fractional result `Math.max(0, days / 30)` instead of rounding, so completion estimates are honest and never collapse to 0 prematurely.

## Files changed
- `src/lib/emergencyUtils.ts`

## Testing
- `node --test "tests/*.test.mjs"` — all pass.
- `tsc --noEmit` — no new errors (only pre-existing baseline errors).
- `eslint` on changed files — clean.

Closes #566
