### PR TITLE
[Bug] Savings opportunities annualize every recurring charge as monthly - wrong savings claims

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -24,6 +24,7 @@ import {
   subMonths,
   eachMonthOfInterval,
   format,
+  differenceInDays,
 } from "date-fns";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import { toDate } from "@/src/lib/utils";
@@ -318,7 +319,33 @@ export function identifyOpportunities(
     if (!matchesHint && !recurring) continue;
 
     const monthly = total(list) / Math.max(1, list.length);
-    const annualized = monthly * 12;
+
+    // Detect the real cadence from the intervals between charges before
+    // annualizing. Every recurring merchant used to be treated as monthly,
+    // which inflated weekly savings ~4x and deflated quarterly savings ~3x.
+    const sorted = [...list].sort((a, b) => {
+      const da = toDate(a.date)?.getTime() ?? 0;
+      const db = toDate(b.date)?.getTime() ?? 0;
+      return da - db;
+    });
+    let avgInterval = 0;
+    if (sorted.length >= 2) {
+      let intervalTotal = 0;
+      let intervalCount = 0;
+      for (let i = 1; i < sorted.length; i++) {
+        const prev = toDate(sorted[i - 1].date);
+        const cur = toDate(sorted[i].date);
+        if (!prev || !cur) continue;
+        intervalTotal += differenceInDays(cur, prev);
+        intervalCount += 1;
+      }
+      avgInterval = intervalCount > 0 ? intervalTotal / intervalCount : 0;
+    }
+    // Weekly cadence ≈ 52 charges/year, monthly ≈ 12, quarterly ≈ 4. Charges
+    // bunched closer than a week are capped at the weekly rate rather than
+    // inflating the annual figure.
+    const chargesPerYear = avgInterval >= 1 ? Math.min(52, 365 / avgInterval) : 12;
+    const annualized = monthly * chargesPerYear;
     const display = list[0].merchant || list[0].description || key;
     opportunities.push({
       id: uid(),


### PR DESCRIPTION
## Problem
`identifyOpportunities` in `src/lib/insightsUtils.ts` annualizes every recurring charge as if it were monthly (`annualized = monthly * 12`). Weekly charges are annualized 12x instead of ~52x, so the savings-opportunity claims are wrong and lowball actual annual savings.

## Fix
- Detects each charge's real cadence from the average day-gap between its transactions (`differenceInDays` on sorted dates).
- Computes charges per year from the cadence: for intervals >= 1 day, `Math.min(52, 365 / avgInterval)`, otherwise falls back to monthly (`12`).
- Annualized amount is now `monthly * chargesPerYear`; charges with no history fall back to monthly.

## Files changed
- `src/lib/insightsUtils.ts`

## Testing
- `node --test "tests/*.test.mjs"` — all pass.
- `tsc --noEmit` — no new errors (only pre-existing baseline errors).
- `eslint` on changed files — clean.

Closes #567
