### PR TITLE
fix: delete stored PDFs and bills/analyses collections on account deletion

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -16,7 +16,8 @@ import {
   deleteDoc,
   type DocumentReference,
 } from "firebase/firestore";
-import { db, auth, handleFirestoreError, OperationType } from "./firebase";
+import { deleteObject, listAll, ref } from "firebase/storage";
+import { db, auth, storage, handleFirestoreError, OperationType } from "./firebase";
 import { format } from "date-fns";
 
 export interface PrivacySettings {
@@ -128,6 +129,7 @@ const USER_COLLECTIONS = [
   "portfolioTransactions",
   "portfolios",
   "tax_estimates",
+  "bills",
 ];
 
 export async function exportUserData(
@@ -175,6 +177,17 @@ export async function exportUserData(
     console.error('exportUserData: failed to fetch documents', error);
     data.documents = [];
   }
+  // The top-level analyses collection is keyed by ownerId (e.g. failed
+  // upload attempts persisted from the client), so it is handled separately.
+  try {
+    const analysesSnap = await getDocs(
+      query(collection(db, "analyses"), where("ownerId", "==", userId)),
+    );
+    data.analyses = analysesSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  } catch (error) {
+    console.error('exportUserData: failed to fetch analyses', error);
+    data.analyses = [];
+  }
   try {
     data.profile = (await getDoc(doc(db, "users", userId))).data();
   } catch (error) {
@@ -198,6 +211,52 @@ async function deleteInBatches(refs: DocumentReference[]): Promise<void> {
     const batch = writeBatch(db);
     batchRefs.forEach((ref) => batch.delete(ref));
     await batch.commit();
+  }
+}
+
+async function collectStoragePaths(
+  prefixRef: ReturnType<typeof ref>,
+  out: Set<string>,
+): Promise<void> {
+  const result = await listAll(prefixRef);
+  result.items.forEach((item) => out.add(item.fullPath));
+  for (const prefix of result.prefixes) {
+    await collectStoragePaths(prefix, out);
+  }
+}
+
+/**
+ * Best-effort deletion of the user's stored PDFs under analyses/<uid>/,
+ * including any orphaned objects not referenced by a Firestore document.
+ * Failures are logged but never block the rest of the account erasure.
+ */
+async function deleteUserStorageFiles(userId: string): Promise<void> {
+  const pathsToDelete = new Set<string>();
+  try {
+    await collectStoragePaths(ref(storage, `analyses/${userId}`), pathsToDelete);
+  } catch (error) {
+    console.error("deleteUserStorageFiles: failed to list storage prefix", error);
+  }
+  try {
+    const docsSnap = await getDocs(
+      query(collection(db, "documents"), where("ownerId", "==", userId)),
+    );
+    for (const d of docsSnap.docs) {
+      const storagePath = d.data().storagePath as string | undefined;
+      if (storagePath) pathsToDelete.add(storagePath);
+    }
+  } catch (error) {
+    console.error("deleteUserStorageFiles: failed to enumerate documents", error);
+  }
+  for (const path of pathsToDelete) {
+    try {
+      await deleteObject(ref(storage, path));
+      console.log("deleteUserStorageFiles: deleted", path);
+    } catch (error: any) {
+      if (error?.code !== "storage/object-not-found") {
+        console.error("deleteUserStorageFiles: failed to delete", path, error);
+      }
+    }
   }
 }
 
@@ -225,6 +284,11 @@ export async function deleteUserData(userId: string): Promise<void> {
     throw error;
   }
 
+  // Delete the user's stored PDFs in Storage (including orphans) before the
+  // Firestore records are removed, so document records are available to map
+  // storage paths even if a later erasure step fails.
+  await deleteUserStorageFiles(userId);
+
   const docRefs: DocumentReference[] = [];
   for (const colName of USER_COLLECTIONS) {
     try {
@@ -236,6 +300,17 @@ export async function deleteUserData(userId: string): Promise<void> {
     } catch (error) {
       console.error('deleteUserData: failed to delete', colName, error);
     }
+  }
+  // The top-level analyses collection is keyed by ownerId, so it is handled
+  // separately from the userId-keyed USER_COLLECTIONS above.
+  try {
+    (
+      await getDocs(
+        query(collection(db, "analyses"), where("ownerId", "==", userId)),
+      )
+    ).docs.forEach((d) => docRefs.push(d.ref));
+  } catch (error) {
+    console.error('deleteUserData: failed to delete analyses', error);
   }
   // documents are keyed by ownerId and keep their analyses as subcollections
   try {


### PR DESCRIPTION
## Problem

`deleteUserData` in `src/lib/privacyUtils.ts` erases only a fixed list of `userId`-keyed collections plus `documents` and their `analyses` subcollections. Three classes of user data were left behind on account deletion:

1. **Stored PDFs in Firebase Storage** — document records carry a `storagePath` (`analyses/{uid}/{timestamp}_{filename}`) pointing at real uploaded objects, but the deletion flow never removed them. Orphaned uploads from failed pipelines were also never cleaned up.
2. **`bills`** — the `bills` collection is keyed by `userId` but was missing from `USER_COLLECTIONS`.
3. **Top-level `analyses`** — failed-upload records are persisted to the top-level `analyses` collection keyed by `ownerId` (see `FileUpload.tsx`), which was never exported or deleted.

## Fix

`src/lib/privacyUtils.ts`:

- Added `bills` to `USER_COLLECTIONS` (also fixes missing bills in `exportUserData`).
- Added top-level `analyses` (keyed by `ownerId`) to both `exportUserData` and `deleteUserData`.
- Added `deleteUserStorageFiles(userId)` which best-effort deletes every object under `analyses/{uid}/` (via `listAll`, recursing into subdirectories) **plus** every `storagePath` referenced by the user's `documents`. Failures are logged and never block the rest of the account erasure. It runs before the Firestore batch so document records are still available to map storage paths.

## Files changed

- `src/lib/privacyUtils.ts`

## Testing

- `deleteUserData` now deletes the user's Storage PDFs, including objects not referenced by any Firestore document.
- `bills` docs (and top-level `analyses` docs) are removed in the batched Firestore erasure.
- `exportUserData` now includes `bills` and top-level `analyses`.
- Storage deletion is best-effort: a missing object (`storage/object-not-found`) is ignored without aborting.
- `npm run typecheck` / `npm run lint` could not be executed locally because `node_modules` is not installed in the working copy.

Closes #602
