### PR TITLE
fix: route all server Firestore calls through the configured database id

### DIFF
--- a/api/process.ts
+++ b/api/process.ts
@@ -373,7 +373,10 @@ async function getAdminApp(): Promise<any | null> {
       }
     }
 
-    _adminApp = { admin, getFirestore: () => admin.firestore() };
+    _adminApp = {
+      admin,
+      getFirestore: () => admin.firestore(getFirestoreDatabaseId()),
+    };
     return _adminApp;
   } catch (err: any) {
     console.warn("[process] Firebase Admin init failed:", err?.message);

--- a/server.ts
+++ b/server.ts
@@ -524,7 +524,7 @@ async function enrichUserContext(req: any, res: any, next: any) {
       return next();
     }
 
-    const db = getFirestore();
+    const db = getFirestore(firestoreDatabaseId);
     const userDoc = await db.collection("users").doc(req.ownerId).get();
     req.userRole = userDoc.data()?.role || "free";
     next();
@@ -727,7 +727,7 @@ async function startServer() {
 
     // Check Firestore connectivity
     try {
-      const db = getFirestore();
+      const db = getFirestore(firestoreDatabaseId);
       await db.listCollections();
       checks.firestore = "ok";
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/firestore-database-consistency.test.mjs
+++ b/tests/firestore-database-consistency.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const serverTs = readFileSync(path.join(repoRoot, "server.ts"), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+const processApi = readFileSync(
+  path.join(repoRoot, "api", "process.ts"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+const analyzeApi = readFileSync(
+  path.join(repoRoot, "api", "analyze.ts"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("server.ts has no bare getFirestore() call sites", () => {
+  const bareCalls = serverTs.match(/getFirestore\(\s*\)/g) || [];
+  assert.deepEqual(
+    bareCalls,
+    [],
+    "every Firestore call must pass firestoreDatabaseId so role lookups " +
+      "and health checks read the same database that documents are written to",
+  );
+});
+
+test("server.ts routes Firestore calls through firestoreDatabaseId", () => {
+  const namedCalls = serverTs.match(/getFirestore\(firestoreDatabaseId\)/g) || [];
+  assert.ok(
+    namedCalls.length >= 4,
+    "expected getFirestore(firestoreDatabaseId) in enrichUserContext, " +
+      "/api/health, analyze, signed-URL and delete handlers",
+  );
+});
+
+test("serverless handlers persist to the configured Firestore database", () => {
+  assert.ok(
+    processApi.includes("admin.firestore(getFirestoreDatabaseId())"),
+    "api/process.ts must resolve Firestore with getFirestoreDatabaseId()",
+  );
+  assert.ok(
+    analyzeApi.includes("getFirestore(getFirestoreDatabaseId())"),
+    "api/analyze.ts must resolve Firestore with getFirestoreDatabaseId()",
+  );
+});


### PR DESCRIPTION
## Problem

The server mixed Firestore database usage: document writes, signed-URL checks, and deletion all used `getFirestore(firestoreDatabaseId)`, but two call sites used the bare default database:

- `enrichUserContext` (server.ts) looked up `users/{uid}` with `getFirestore()` — with a named database configured, the role lookup always missed, so `req.userRole` stayed `undefined` and the premium/admin rate-limit skip never activated.
- `/api/health` checked collection availability with `getFirestore()` — it could report healthy (or fail) based on the wrong database.
- `api/process.ts` also resolved Firestore through `admin.firestore()` (default DB) while `api/analyze.ts` used the configured database id.

## Fix

- `server.ts` — `enrichUserContext` and `/api/health` now use `getFirestore(firestoreDatabaseId)`, matching the analyze, signed-URL, and delete handlers.
- `api/process.ts` — `getAdminApp()` now resolves Firestore via `admin.firestore(getFirestoreDatabaseId())`.
- Added `tests/firestore-database-consistency.test.mjs` asserting there are no bare `getFirestore()` call sites in `server.ts`, that the named-id calls exist across the handlers, and that both serverless handlers resolve the configured database.

## Files changed

- `server.ts`
- `api/process.ts`
- `tests/firestore-database-consistency.test.mjs`

## Testing

- `node --test tests/firestore-database-consistency.test.mjs` passes (3 tests).
- Full static suite: `tests/storage-rules.test.mjs` and `tests/analyze-quota-guard.test.mjs` still pass. `tests/anomaly-leave-one-out.test.mjs` and `tests/bill-payment-lifecycle.test.mjs` fail only because `node_modules` (e.g. `date-fns`) is not installed in the working copy — pre-existing, unrelated.
- `npm run typecheck` / `npm run lint` could not be executed locally for the same reason.

Closes #605
