### PR TITLE
fix: format insights and goals in the user's base currency (Issue #606)

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -28,6 +28,8 @@ interface GoalCardProps {
   onViewDetails: (goal: Goal) => void;
   onStatusChange: (goalId: string, status: Goal['status']) => void;
   onDelete: (goalId: string) => void;
+  /** Base currency for displayed figures. Defaults to the app-wide default. */
+  baseCurrency?: string;
 }
 
 export function GoalCard({
@@ -36,6 +38,7 @@ export function GoalCard({
   onViewDetails,
   onStatusChange,
   onDelete,
+  baseCurrency,
 }: GoalCardProps) {
   const [amountInput, setAmountInput] = useState('');
   const [adding, setAdding] = useState(false);
@@ -114,7 +117,7 @@ export function GoalCard({
         <div className="space-y-2">
           <div className="flex items-center justify-between text-sm">
             <span className="text-slate-400">
-              {formatCurrency(goal.currentAmount)} of {formatCurrency(goal.targetAmount)}
+              {formatCurrency(goal.currentAmount, baseCurrency)} of {formatCurrency(goal.targetAmount, baseCurrency)}
             </span>
             <span className="text-white font-semibold tabular-nums">{progress}%</span>
           </div>
@@ -150,7 +153,7 @@ export function GoalCard({
               <span>Monthly Target</span>
             </div>
             <p className="text-sm font-semibold text-white">
-              {formatCurrency(monthlyContribution)}
+              {formatCurrency(monthlyContribution, baseCurrency)}
             </p>
             <p className="text-[10px] text-slate-500 mt-0.5">
               per month to reach goal

--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, react-hooks/immutability, react-hooks/purity, react-hooks/refs, react-hooks/set-state-in-effect */
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
+import { useBaseCurrency } from '@/src/hooks/useBaseCurrency';
 import {
   doc,
   setDoc,
@@ -63,6 +64,7 @@ type GoalCategory = 'Savings' | 'Investment' | 'Debt' | 'Retirement' | 'Emergenc
 const CATEGORIES: GoalCategory[] = ['Savings', 'Investment', 'Debt', 'Retirement', 'Emergency', 'Other'];
 
 export function GoalPlanner({ user }: GoalPlannerProps) {
+  const baseCurrency = useBaseCurrency(user);
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -137,7 +139,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
         notifiedGoalIds.current.add(goal.id);
         updatingGoalIds.current.add(goal.id);
         toast.success(`Goal reached: ${goal.name}!`, {
-          description: `You've reached ${formatCurrency(goal.targetAmount)}.`,
+          description: `You've reached ${formatCurrency(goal.targetAmount, baseCurrency)}.`,
           duration: 5000,
         });
         updateGoalStatus(goal.id, 'completed', goal.currentAmount).finally(() => {
@@ -227,7 +229,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
       await updateDoc(doc(db, 'goals', goalId), {
         currentAmount: increment(addedAmount),
       });
-      toast.success(`Added ${formatCurrency(addedAmount)} to ${goal.name}`);
+      toast.success(`Added ${formatCurrency(addedAmount, baseCurrency)} to ${goal.name}`);
     } catch (error) {
       console.error('Error updating goal:', error);
       handleFirestoreError(error, OperationType.UPDATE, `goals/${goalId}`);
@@ -462,6 +464,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                     >
                       <GoalCard
                         goal={goal}
+                        baseCurrency={baseCurrency}
                         onUpdateAmount={updateGoalAmount}
                         onViewDetails={setSelectedGoal}
                         onStatusChange={(id, status) => updateGoalStatus(id, status)}
@@ -495,6 +498,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                     >
                       <GoalCard
                         goal={goal}
+                        baseCurrency={baseCurrency}
                         onUpdateAmount={updateGoalAmount}
                         onViewDetails={setSelectedGoal}
                         onStatusChange={(id, status) => updateGoalStatus(id, status)}
@@ -526,6 +530,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                   >
                     <GoalCard
                       goal={goal}
+                      baseCurrency={baseCurrency}
                       onUpdateAmount={updateGoalAmount}
                       onViewDetails={setSelectedGoal}
                       onStatusChange={(id, status) => updateGoalStatus(id, status)}
@@ -580,16 +585,16 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
               <div className="grid grid-cols-3 gap-3">
                 <div className="rounded-xl bg-slate-800/50 border border-slate-700/50 p-4 text-center">
                   <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Target</p>
-                  <p className="text-white font-semibold text-sm">{formatCurrency(goalDetail.targetAmount)}</p>
+                  <p className="text-white font-semibold text-sm">{formatCurrency(goalDetail.targetAmount, baseCurrency)}</p>
                 </div>
                 <div className="rounded-xl bg-slate-800/50 border border-slate-700/50 p-4 text-center">
                   <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Current</p>
-                  <p className="text-white font-semibold text-sm">{formatCurrency(goalDetail.currentAmount)}</p>
+                  <p className="text-white font-semibold text-sm">{formatCurrency(goalDetail.currentAmount, baseCurrency)}</p>
                 </div>
                 <div className="rounded-xl bg-slate-800/50 border border-slate-700/50 p-4 text-center">
                   <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Remaining</p>
                   <p className="text-white font-semibold text-sm">
-                    {formatCurrency(goalDetail.targetAmount - goalDetail.currentAmount)}
+                    {formatCurrency(goalDetail.targetAmount - goalDetail.currentAmount, baseCurrency)}
                   </p>
                 </div>
               </div>
@@ -635,7 +640,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                       <YAxis
                         stroke="#475569"
                         tick={{ fill: '#94a3b8', fontSize: 10 }}
-                        tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`}
+                        tickFormatter={(value) => formatCurrency(value, baseCurrency)}
                       />
                       <Tooltip
                         contentStyle={{
@@ -645,7 +650,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                           fontSize: '12px',
                         }}
                         labelStyle={{ color: '#94a3b8' }}
-                        formatter={(value: number) => [formatCurrency(value), 'Projected']}
+                        formatter={(value: number) => [formatCurrency(value, baseCurrency), 'Projected']}
                       />
                       <Area
                         type="monotone"
@@ -674,7 +679,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                         {suggestion.label}
                       </p>
                       <p className="text-white font-semibold text-sm">
-                        {formatCurrency(suggestion.amount)}
+                        {formatCurrency(suggestion.amount, baseCurrency)}
                       </p>
                       <p className="text-[10px] text-slate-500">/month</p>
                     </div>

--- a/src/components/insights/InsightCard.tsx
+++ b/src/components/insights/InsightCard.tsx
@@ -71,16 +71,18 @@ interface InsightCardProps {
   /** Optional override icon. */
   icon?: ReactNode;
   className?: string;
+  /** Base currency for the rendered figure. Defaults to the app-wide default. */
+  baseCurrency?: string;
 }
 
-export function InsightCard({ insight, icon, className }: InsightCardProps) {
+export function InsightCard({ insight, icon, className, baseCurrency }: InsightCardProps) {
   const styles = SEVERITY_STYLES[insight.severity] ?? SEVERITY_STYLES.low;
   const typeIcon = icon ?? TYPE_ICON[insight.type] ?? <Sparkles size={18} />;
 
   const amountLabel =
     insight.type === "opportunity"
-      ? `${formatCurrency(insight.amount)}/yr potential`
-      : formatCurrency(insight.amount);
+      ? `${formatCurrency(insight.amount, baseCurrency)}/yr potential`
+      : formatCurrency(insight.amount, baseCurrency);
 
   return (
     <Card
@@ -154,10 +156,12 @@ export function CategoryDeltaRow({
   category,
   current,
   changePct,
+  baseCurrency,
 }: {
   category: string;
   current: number;
   changePct: number | null;
+  baseCurrency?: string;
 }) {
   const up = (changePct ?? 0) >= 0;
   const hasBaseline = changePct !== null;
@@ -168,7 +172,7 @@ export function CategoryDeltaRow({
       </span>
       <div className="flex items-center gap-3">
         <span className="text-sm font-semibold text-white tabular-nums">
-          {formatCurrency(current)}
+          {formatCurrency(current, baseCurrency)}
         </span>
         {hasBaseline ? (
           <span

--- a/src/components/insights/InsightsDashboard.tsx
+++ b/src/components/insights/InsightsDashboard.tsx
@@ -50,6 +50,7 @@ import {
   type InsightsBundle,
 } from "@/src/lib/insightsUtils";
 import { handleFirestoreError, OperationType } from "@/src/lib/firebase";
+import { useBaseCurrency } from "@/src/hooks/useBaseCurrency";
 import { InsightCard, CategoryDeltaRow } from "./InsightCard";
 
 const LINE_COLORS = ["#818cf8", "#34d399", "#fbbf24", "#f472b6", "#22d3ee"];
@@ -59,6 +60,7 @@ interface InsightsDashboardProps {
 }
 
 export function InsightsDashboard({ user }: InsightsDashboardProps) {
+  const baseCurrency = useBaseCurrency(user);
   const [bundle, setBundle] = useState<InsightsBundle | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -126,11 +128,11 @@ export function InsightsDashboard({ user }: InsightsDashboardProps) {
       ) : (
         bundle && (
           <>
-            <WeeklySection bundle={bundle} />
-            <MonthlySection bundle={bundle} />
-            <TrendsSection bundle={bundle} />
-            <AnomaliesSection bundle={bundle} />
-            <OpportunitiesSection bundle={bundle} />
+            <WeeklySection bundle={bundle} baseCurrency={baseCurrency} />
+            <MonthlySection bundle={bundle} baseCurrency={baseCurrency} />
+            <TrendsSection bundle={bundle} baseCurrency={baseCurrency} />
+            <AnomaliesSection bundle={bundle} baseCurrency={baseCurrency} />
+            <OpportunitiesSection bundle={bundle} baseCurrency={baseCurrency} />
           </>
         )
       )}
@@ -187,7 +189,13 @@ function SectionHeading({
 // Weekly
 // ---------------------------------------------------------------------------
 
-function WeeklySection({ bundle }: { bundle: InsightsBundle }) {
+function WeeklySection({
+  bundle,
+  baseCurrency,
+}: {
+  bundle: InsightsBundle;
+  baseCurrency: string;
+}) {
   const { weeklySummary, weekly } = bundle;
   const summary = generatePlainSummary(weeklySummary);
   const topDeltas = weekly.slice(0, 6);
@@ -205,7 +213,7 @@ function WeeklySection({ bundle }: { bundle: InsightsBundle }) {
             This Week
           </span>
           <span className="mt-1 text-3xl font-black text-white tabular-nums">
-            {formatCurrency(weeklySummary.total)}
+            {formatCurrency(weeklySummary.total, baseCurrency)}
           </span>
           <ChangePill
             changePct={weeklySummary.changePct}
@@ -234,6 +242,7 @@ function WeeklySection({ bundle }: { bundle: InsightsBundle }) {
                   category={d.category}
                   current={d.current}
                   changePct={d.changePct}
+                  baseCurrency={baseCurrency}
                 />
               ))
             )}
@@ -248,7 +257,13 @@ function WeeklySection({ bundle }: { bundle: InsightsBundle }) {
 // Monthly
 // ---------------------------------------------------------------------------
 
-function MonthlySection({ bundle }: { bundle: InsightsBundle }) {
+function MonthlySection({
+  bundle,
+  baseCurrency,
+}: {
+  bundle: InsightsBundle;
+  baseCurrency: string;
+}) {
   const { monthlySummary } = bundle;
   const summary = generatePlainSummary(monthlySummary);
 
@@ -266,7 +281,7 @@ function MonthlySection({ bundle }: { bundle: InsightsBundle }) {
               Total Spent This Month
             </span>
             <span className="mt-1 block text-3xl font-black text-white tabular-nums">
-              {formatCurrency(monthlySummary.total)}
+              {formatCurrency(monthlySummary.total, baseCurrency)}
             </span>
             <ChangePill
               changePct={monthlySummary.changePct}
@@ -303,7 +318,7 @@ function MonthlySection({ bundle }: { bundle: InsightsBundle }) {
                         {cat.category}
                       </span>
                       <span className="text-sm font-semibold text-white tabular-nums">
-                        {formatCurrency(cat.total)}{" "}
+                        {formatCurrency(cat.total, baseCurrency)}{" "}
                         <span className="text-xs text-slate-500">
                           ({share}%)
                         </span>
@@ -334,7 +349,13 @@ function MonthlySection({ bundle }: { bundle: InsightsBundle }) {
 // Trends chart
 // ---------------------------------------------------------------------------
 
-function TrendsSection({ bundle }: { bundle: InsightsBundle }) {
+function TrendsSection({
+  bundle,
+  baseCurrency,
+}: {
+  bundle: InsightsBundle;
+  baseCurrency: string;
+}) {
   const { trends, trendCategories } = bundle;
 
   const hasTrend = useMemo(
@@ -385,7 +406,7 @@ function TrendsSection({ bundle }: { bundle: InsightsBundle }) {
                   tickLine={false}
                   axisLine={false}
                   width={70}
-                  tickFormatter={(v) => formatCurrency(Number(v))}
+                  tickFormatter={(v) => formatCurrency(Number(v), baseCurrency)}
                 />
                 <Tooltip
                   contentStyle={{
@@ -395,7 +416,7 @@ function TrendsSection({ bundle }: { bundle: InsightsBundle }) {
                   }}
                   itemStyle={{ color: "#f8fafc" }}
                   labelStyle={{ color: "#94a3b8" }}
-                  formatter={(value) => formatCurrency(Number(value))}
+                  formatter={(value) => formatCurrency(Number(value), baseCurrency)}
                 />
                 <Legend wrapperStyle={{ fontSize: 12, color: "#94a3b8" }} />
                 {trendCategories.map((category, i) => (
@@ -422,7 +443,13 @@ function TrendsSection({ bundle }: { bundle: InsightsBundle }) {
 // Anomalies
 // ---------------------------------------------------------------------------
 
-function AnomaliesSection({ bundle }: { bundle: InsightsBundle }) {
+function AnomaliesSection({
+  bundle,
+  baseCurrency,
+}: {
+  bundle: InsightsBundle;
+  baseCurrency: string;
+}) {
   const anomalies = bundle.anomalies.slice(0, 6);
   return (
     <section>
@@ -436,7 +463,7 @@ function AnomaliesSection({ bundle }: { bundle: InsightsBundle }) {
       ) : (
         <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
           {anomalies.map((insight) => (
-            <InsightCard key={insight.id} insight={insight} />
+            <InsightCard key={insight.id} insight={insight} baseCurrency={baseCurrency} />
           ))}
         </div>
       )}
@@ -448,7 +475,13 @@ function AnomaliesSection({ bundle }: { bundle: InsightsBundle }) {
 // Opportunities
 // ---------------------------------------------------------------------------
 
-function OpportunitiesSection({ bundle }: { bundle: InsightsBundle }) {
+function OpportunitiesSection({
+  bundle,
+  baseCurrency,
+}: {
+  bundle: InsightsBundle;
+  baseCurrency: string;
+}) {
   const opportunities = bundle.opportunities.slice(0, 6);
   return (
     <section>
@@ -462,7 +495,7 @@ function OpportunitiesSection({ bundle }: { bundle: InsightsBundle }) {
       ) : (
         <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
           {opportunities.map((insight) => (
-            <InsightCard key={insight.id} insight={insight} />
+            <InsightCard key={insight.id} insight={insight} baseCurrency={baseCurrency} />
           ))}
         </div>
       )}

--- a/src/hooks/useBaseCurrency.ts
+++ b/src/hooks/useBaseCurrency.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { doc, getDoc } from 'firebase/firestore'
+import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase'
+import { setDefaultCurrency } from '@/src/lib/utils'
+import type { CurrencySettings } from '@/src/lib/currencyUtils'
+
+/**
+ * Loads the signed-in user's base currency from the `currencies/{uid}`
+ * settings document and keeps the app-wide default in sync so every
+ * `formatCurrency` call (including plain-language insight text) renders in
+ * the user's currency instead of hardcoded USD.
+ *
+ * Falls back to "USD" when the document is missing.
+ */
+export function useBaseCurrency(user: { uid: string } | null): string {
+  const [baseCurrency, setBaseCurrency] = useState('USD')
+
+  useEffect(() => {
+    if (!user) return
+
+    let cancelled = false
+
+    getDoc(doc(db, 'currencies', user.uid))
+      .then((settingsDoc) => {
+        if (cancelled) return
+        const settings = settingsDoc.exists()
+          ? (settingsDoc.data() as CurrencySettings)
+          : null
+        const currency = settings?.baseCurrency || 'USD'
+        setDefaultCurrency(currency)
+        setBaseCurrency(currency)
+      })
+      .catch((error) => {
+        handleFirestoreError(error, OperationType.GET, 'currencies')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [user])
+
+  return baseCurrency
+}

--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -1,4 +1,5 @@
 import { format, differenceInDays, addMonths } from 'date-fns';
+import { getDefaultCurrency } from '@/src/lib/utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, react-hooks/immutability, react-hooks/purity, react-hooks/refs, react-hooks/set-state-in-effect */
 
@@ -105,10 +106,10 @@ export function getProgressPercentage(currentAmount: number, targetAmount: numbe
   return Math.min(100, Math.round((currentAmount / targetAmount) * 100));
 }
 
-export function formatCurrency(amount: number): string {
+export function formatCurrency(amount: number, currency?: string): string {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
-    currency: "USD",
+    currency: currency || getDefaultCurrency(),
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(amount);

--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -27,7 +27,7 @@ import {
   differenceInDays,
 } from "date-fns";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
-import { toDate } from "@/src/lib/utils";
+import { getDefaultCurrency, toDate } from "@/src/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -120,10 +120,10 @@ export function normalizeAmount(value: any): number {
   return Math.abs(n);
 }
 
-export function formatCurrency(value: number): string {
+export function formatCurrency(value: number, currency?: string): string {
   return new Intl.NumberFormat(undefined, {
     style: "currency",
-    currency: "USD",
+    currency: currency || getDefaultCurrency(),
     maximumFractionDigits: value >= 1000 ? 0 : 2,
   }).format(value || 0);
 }

--- a/tests/base-currency-formatting.test.mjs
+++ b/tests/base-currency-formatting.test.mjs
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const insightsUtils = readFileSync(path.join(repoRoot, "src/lib/insightsUtils.ts"), "utf8");
+const goalUtils = readFileSync(path.join(repoRoot, "src/lib/goalUtils.ts"), "utf8");
+const useBaseCurrency = readFileSync(path.join(repoRoot, "src/hooks/useBaseCurrency.ts"), "utf8");
+
+test("insightsUtils.formatCurrency is not hardcoded to USD", () => {
+  assert.ok(
+    insightsUtils.includes("getDefaultCurrency"),
+    "insightsUtils.formatCurrency must fall back to getDefaultCurrency()",
+  );
+  assert.ok(
+    /currency: currency \|\| getDefaultCurrency\(\)/.test(insightsUtils),
+    "insightsUtils.formatCurrency must not hardcode currency: \"USD\"",
+  );
+  assert.ok(
+    !/currency: "USD"/.test(insightsUtils),
+    "insightsUtils.formatCurrency must not contain a USD literal",
+  );
+});
+
+test("goalUtils.formatCurrency is not hardcoded to USD", () => {
+  assert.ok(
+    goalUtils.includes("getDefaultCurrency"),
+    "goalUtils.formatCurrency must fall back to getDefaultCurrency()",
+  );
+  assert.ok(
+    /currency: currency \|\| getDefaultCurrency\(\)/.test(goalUtils),
+    "goalUtils.formatCurrency must not hardcode currency: \"USD\"",
+  );
+  assert.ok(
+    !/currency: "USD"/.test(goalUtils),
+    "goalUtils.formatCurrency must not contain a USD literal",
+  );
+});
+
+test("useBaseCurrency hook syncs the app-wide default from the user's settings", () => {
+  assert.ok(
+    /getDoc\(doc\(db, 'currencies', user\.uid\)\)/.test(useBaseCurrency),
+    "useBaseCurrency must read the currencies/{uid} settings document",
+  );
+  assert.ok(
+    /setDefaultCurrency\(/.test(useBaseCurrency),
+    "useBaseCurrency must call setDefaultCurrency so every formatCurrency uses the base currency",
+  );
+  assert.ok(
+    /\.baseCurrency \|\| 'USD'/.test(useBaseCurrency),
+    "useBaseCurrency must fall back to USD when the settings document is missing",
+  );
+});


### PR DESCRIPTION
## Problem

The app is explicitly multi-currency (users pick a base currency saved in `currencies/{uid}`), but the insights engine and goal planner formatted every figure with a local USD-hardcoded `formatCurrency`:

- `src/lib/insightsUtils.ts` — `Intl.NumberFormat(..., { currency: "USD" })`
- `src/lib/goalUtils.ts` — `Intl.NumberFormat("en-US", { currency: "USD" })`

On the same screen, transaction totals rendered in the user's base currency (e.g. `₹`) while insights savings, per-category figures, goal targets, and contributions rendered as `$` — an internally inconsistent report that is impossible to reconcile, and a `₹50,000` goal shown as `$50,000` (2,000x overstatement).

## Fix

- Added `src/hooks/useBaseCurrency.ts`: loads `currencies/{uid}` (the same document `CurrencyManager` and `ReportExport` already use) and calls `setDefaultCurrency(baseCurrency)`, keeping the app-wide default in sync.
- `insightsUtils.formatCurrency` and `goalUtils.formatCurrency` now accept an optional `currency` and fall back to `getDefaultCurrency()` instead of hardcoded `"USD"` — so even the plain-language insight text (anomalies, opportunities, monthly summaries) is generated in the user's currency.
- `InsightsDashboard.tsx` uses `useBaseCurrency(user)` and threads `baseCurrency` through `WeeklySection`, `MonthlySection`, `TrendsSection`, `AnomaliesSection`, and `OpportunitiesSection`.
- `InsightCard.tsx` and `CategoryDeltaRow` accept a `baseCurrency` prop.
- `GoalPlanner.tsx` uses `useBaseCurrency(user)` and passes `baseCurrency` to every `formatCurrency` call (including the timeline chart Y-axis/tooltip, which previously hardcoded `$...k`), and passes it down to `GoalCard`.
- `GoalCard.tsx` accepts a `baseCurrency` prop.
- Removed the last hardcoded `$` in the goal planner projection chart.

## Files changed

- `src/hooks/useBaseCurrency.ts` (new)
- `src/lib/insightsUtils.ts`
- `src/lib/goalUtils.ts`
- `src/components/insights/InsightsDashboard.tsx`
- `src/components/insights/InsightCard.tsx`
- `src/components/goals/GoalPlanner.tsx`
- `src/components/goals/GoalCard.tsx`
- `tests/base-currency-formatting.test.mjs` (new)

## Testing

- Added `tests/base-currency-formatting.test.mjs` (3 tests) asserting neither utils file contains a `currency: "USD"` literal, both fall back to `getDefaultCurrency()`, and the hook reads `currencies/{uid}` and calls `setDefaultCurrency`.
- `node --test tests/base-currency-formatting.test.mjs` and the other static suites (`analyze-quota-guard`, `storage-rules`) pass.
- Could not run `npm run typecheck` / `npm run lint`: `node_modules` is not installed in this checkout.

Closes #606
