### PR TITLE
fix: exclude soft-deleted bills from bill surfaces and reminders (Issue #607)

### DIFF
--- a/src/components/bills/BillReminders.tsx
+++ b/src/components/bills/BillReminders.tsx
@@ -118,7 +118,7 @@ export function BillReminders({ user }: BillRemindersProps) {
 
   const overdueBills = useMemo(() => getOverdueBills(bills, today), [bills, today]);
   const upcomingBills = useMemo(() => getUpcomingBills(bills, today), [bills, today]);
-  const activeBills = useMemo(() => bills.filter((b) => !b.isPaid), [bills]);
+  const activeBills = useMemo(() => bills.filter((b) => !b.isPaid && !b.deleted), [bills]);
   const monthlyObligations = useMemo(() => calculateMonthlyObligations(bills), [bills]);
 
   const scheduleData = useMemo(() => {

--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -41,6 +41,7 @@ export interface Bill {
   lastPaidDate?: string | null;
   createdAt: string;
   nextDueDate?: string | null;
+  deleted?: boolean;
 }
 
 export interface BillInput {
@@ -76,6 +77,7 @@ export async function fetchUserBills(userId: string): Promise<Bill[]> {
     const bills: Bill[] = [];
     snapshot.forEach((docSnap) => {
       const data = docSnap.data();
+      if (data.deleted === true) return;
       bills.push({
         id: docSnap.id,
         userId: data.userId || '',
@@ -88,6 +90,7 @@ export async function fetchUserBills(userId: string): Promise<Bill[]> {
         lastPaidDate: data.lastPaidDate || null,
         createdAt: data.createdAt || '',
         nextDueDate: data.nextDueDate || null,
+        deleted: data.deleted === true,
       });
     });
     return bills;
@@ -212,14 +215,14 @@ export function applyBillPayment(
 }
 
 export function isOverdue(bill: Bill, reference: Date = new Date()): boolean {
-  if (bill.isPaid) return false;
+  if (bill.deleted || bill.isPaid) return false;
   const due = toDate(bill.nextDueDate || bill.dueDate);
   if (!due) return false;
   return isBefore(startOfDay(due), startOfDay(reference));
 }
 
 export function isUpcoming(bill: Bill, reference: Date = new Date()): boolean {
-  if (bill.isPaid || isOverdue(bill, reference)) return false;
+  if (bill.deleted || bill.isPaid || isOverdue(bill, reference)) return false;
   const due = toDate(bill.nextDueDate || bill.dueDate);
   if (!due) return false;
   const days = differenceInCalendarDays(startOfDay(due), startOfDay(reference));
@@ -258,7 +261,7 @@ export function getDaysUntilDue(bill: Bill, reference: Date = new Date()): numbe
 
 export function calculateMonthlyObligations(bills: Bill[]): number {
   return bills.reduce((total, bill) => {
-    if (bill.isPaid) return total;
+    if (bill.deleted || bill.isPaid) return total;
     switch (bill.frequency) {
       case 'weekly':
         return total + bill.amount * 52 / 12;
@@ -276,6 +279,7 @@ export async function markBillAsPaid(
   bill: Bill,
   userId: string
 ): Promise<Bill | null> {
+  if (bill.deleted) return null;
   try {
     const paidDate = new Date();
     const payment = applyBillPayment(bill, paidDate);

--- a/tests/soft-deleted-bills.test.mjs
+++ b/tests/soft-deleted-bills.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const billUtils = readFileSync(path.join(repoRoot, "src/lib/billUtils.ts"), "utf8");
+const billReminders = readFileSync(
+  path.join(repoRoot, "src/components/bills/BillReminders.tsx"),
+  "utf8",
+);
+
+test("fetchUserBills skips and maps the deleted flag", () => {
+  assert.ok(
+    billUtils.includes("if (data.deleted === true) return;"),
+    "fetchUserBills must skip bills soft-deleted via softDeleteBill",
+  );
+  assert.ok(
+    billUtils.includes("deleted: data.deleted === true,"),
+    "fetchUserBills must carry the deleted flag onto the Bill object",
+  );
+});
+
+test("deleted bills never drive reminders or obligations", () => {
+  assert.ok(
+    /bill\.deleted \|\| bill\.isPaid/.test(billUtils),
+    "isOverdue must ignore deleted bills",
+  );
+  assert.ok(
+    /bill\.deleted \|\| bill\.isPaid \|\| isOverdue/.test(billUtils),
+    "isUpcoming must ignore deleted bills",
+  );
+  assert.ok(
+    /bill\.deleted \|\| bill\.isPaid\) return total/.test(billUtils),
+    "calculateMonthlyObligations must exclude deleted bills",
+  );
+  assert.ok(
+    billUtils.includes("if (bill.deleted) return null;"),
+    "markBillAsPaid must refuse to process deleted bills",
+  );
+});
+
+test("BillReminders excludes deleted bills from the active list", () => {
+  assert.ok(
+    /bills\.filter\(\(b\) => !b\.isPaid && !b\.deleted\)/.test(billReminders),
+    "activeBills must not include deleted bills",
+  );
+});


### PR DESCRIPTION
## Problem

`softDeleteBill` flips `deleted: true` on the bill document instead of removing it, but `fetchUserBills` queries `bills` by `userId` with no `deleted` filter. Every bill surface (`BillReminders`, `BillCard`) renders that unfiltered result set, so a "deleted" bill:

- still appears in the bill list and reminders panel,
- keeps firing due/overdue reminders (`isOverdue`/`isUpcoming` only checked `isPaid`),
- still counts toward monthly obligations.

The `deleted` flag was effectively write-only.

## Fix

- Added `deleted?: boolean` to the `Bill` interface.
- `fetchUserBills` now skips documents with `data.deleted === true` in the mapping loop (safe for legacy bills that predate the flag) and maps `deleted: data.deleted === true` onto the result.
- Defense in depth for any caller that passes deleted bills directly:
  - `isOverdue` and `isUpcoming` return `false` for deleted bills, so `getOverdueBills`/`getUpcomingBills` and reminder checks stop including them.
  - `calculateMonthlyObligations` excludes deleted bills.
  - `markBillAsPaid` refuses to process a deleted bill.
- `BillReminders`' `activeBills` list now filters `!b.deleted` as well.

## Files changed

- `src/lib/billUtils.ts`
- `src/components/bills/BillReminders.tsx`
- `tests/soft-deleted-bills.test.mjs` (new)

## Testing

- Added `tests/soft-deleted-bills.test.mjs` (3 tests) asserting the fetch loop skips/maps `deleted`, reminder/obligation helpers ignore deleted bills, and the active list excludes them.
- `node --test tests/soft-deleted-bills.test.mjs` and the other static suites pass.
- Note: `tests/bill-payment-lifecycle.test.mjs` still cannot run in this checkout because `node_modules` (date-fns) is not installed — a pre-existing limitation, unrelated to this change.

Closes #607
