### PR TITLE
fix: load privacy settings from Firestore with localStorage as offline cache (Issue #608)

### DIFF
--- a/src/components/privacy/PrivacyDashboard.tsx
+++ b/src/components/privacy/PrivacyDashboard.tsx
@@ -18,10 +18,12 @@ import {
   deleteUserData,
   getPrivacySettings,
   updatePrivacySettings,
+  DEFAULT_PRIVACY_SETTINGS,
   PrivacySettings,
 } from "@/src/lib/privacyUtils";
 import { toast } from "sonner";
 import { auth } from "@/src/lib/firebase";
+import { safeJsonParse } from "@/src/lib/utils";
 import { deleteUser, signOut } from "firebase/auth";
 
 export function PrivacyDashboard({ user }: { user: any }) {
@@ -44,19 +46,19 @@ export function PrivacyDashboard({ user }: { user: any }) {
     if (!user) return;
      
     setIsLoading(true);
+    const cached = localStorage.getItem(`privacySettings_${user.uid}`);
+    const cachedSettings = cached
+      ? (safeJsonParse(cached, null as Partial<PrivacySettings> | null))
+      : null;
     try {
-      const stored = localStorage.getItem(`privacySettings_${user.uid}`);
-      setPrivacySettings(stored ? JSON.parse(stored) : {
-        userId: user.uid,
-        dataRetentionEnabled: true,
-        analyticsEnabled: true,
-        sharingEnabled: false,
-        exportRequestedAt: "",
-        deletionRequestedAt: "",
-        updatedAt: new Date().toISOString(),
-      });
+      // Firestore is the single source of truth. localStorage is only an
+      // offline cache so saved choices survive neither cache clears nor
+      // cross-device switches.
+      const remote = await getPrivacySettings(user.uid);
+      setPrivacySettings({ ...DEFAULT_PRIVACY_SETTINGS, ...remote });
     } catch (error) {
       console.error("Failed to load privacy data:", error);
+      setPrivacySettings({ ...DEFAULT_PRIVACY_SETTINGS, ...cachedSettings });
     } finally {
        
       setIsLoading(false);

--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -61,12 +61,18 @@ export async function getPrivacySettings(
   try {
     const docRef = doc(db, "privacy_settings", userId);
     const snap = await getDoc(docRef);
-    if (snap.exists()) return snap.data() as PrivacySettings;
+    if (snap.exists()) {
+      // Merge over the defaults so documents written before every field was
+      // introduced still expose a complete, typed settings object.
+      return { ...DEFAULT_PRIVACY_SETTINGS, ...snap.data() };
+    }
     await setDoc(docRef, DEFAULT_PRIVACY_SETTINGS);
     return DEFAULT_PRIVACY_SETTINGS;
   } catch (err) {
+    // Re-throw so callers can fall back to their offline cache instead of
+    // silently presenting defaults that overwrite the user's saved choices.
     console.error("getPrivacySettings: failed to retrieve privacy settings", err);
-    return DEFAULT_PRIVACY_SETTINGS;
+    throw err;
   }
 }
 

--- a/tests/privacy-settings-source-of-truth.test.mjs
+++ b/tests/privacy-settings-source-of-truth.test.mjs
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const privacyUtils = readFileSync(
+  path.join(repoRoot, "src/lib/privacyUtils.ts"),
+  "utf8",
+);
+const privacyDashboard = readFileSync(
+  path.join(repoRoot, "src/components/privacy/PrivacyDashboard.tsx"),
+  "utf8",
+);
+
+test("PrivacyDashboard loads from Firestore with a localStorage fallback", () => {
+  assert.ok(
+    privacyDashboard.includes("const remote = await getPrivacySettings(user.uid);"),
+    "loadPrivacyData must read privacy settings from Firestore",
+  );
+  assert.ok(
+    /setPrivacySettings\(\{ \.\.\.DEFAULT_PRIVACY_SETTINGS, \.\.\.remote \}\)/.test(
+      privacyDashboard,
+    ),
+    "the Firestore snapshot must be merged over DEFAULT_PRIVACY_SETTINGS",
+  );
+  assert.ok(
+    /setPrivacySettings\(\{ \.\.\.DEFAULT_PRIVACY_SETTINGS, \.\.\.cachedSettings \}\)/.test(
+      privacyDashboard,
+    ),
+    "the localStorage cache must be used as the offline fallback",
+  );
+});
+
+test("getPrivacySettings throws so callers can use their offline cache", () => {
+  assert.ok(
+    privacyUtils.includes("throw err;"),
+    "getPrivacySettings must re-throw on a read failure instead of returning defaults",
+  );
+  assert.ok(
+    privacyUtils.includes("return { ...DEFAULT_PRIVACY_SETTINGS, ...snap.data() };"),
+    "getPrivacySettings must merge the stored document over the defaults",
+  );
+});


### PR DESCRIPTION
## Problem

The privacy panel writes preferences to Firestore (`privacy_settings/{uid}`) but initializes its state only from localStorage. `getPrivacySettings` (the Firestore reader) was imported but never called. Consequences:

- After a cache clear, private window, or new device, the panel re-initializes to defaults, silently discarding the user's saved privacy choices.
- A stale local copy can overwrite newer Firestore values on the next toggle, so the Firestore record drifts from what the user actually selected.
- No single source of truth across devices — especially harmful for a privacy feature (e.g. a user who disabled data sharing sees it silently re-enabled).

## Fix

- `getPrivacySettings` now merges the stored document over `DEFAULT_PRIVACY_SETTINGS` (so documents written before every field existed still return a complete typed object), and **re-throws** on a read failure instead of silently returning defaults — that lets the dashboard fall back to its cache rather than presenting defaults that would overwrite saved choices.
- `PrivacyDashboard.loadPrivacyData` now loads from `getPrivacySettings(user.uid)` (Firestore) on mount as the single source of truth, and only falls back to the localStorage cache when the Firestore read fails (offline case). The existing effect still writes through to Firestore and syncs the cache on every change, so all three requirements hold:
  - Firestore is authoritative,
  - localStorage is an offline cache only,
  - every change is written through to Firestore.

## Files changed

- `src/lib/privacyUtils.ts`
- `src/components/privacy/PrivacyDashboard.tsx`
- `tests/privacy-settings-source-of-truth.test.mjs` (new)

## Testing

- Added `tests/privacy-settings-source-of-truth.test.mjs` (2 tests) asserting the dashboard loads from Firestore with a cache fallback and that `getPrivacySettings` re-throws on failure instead of returning defaults.
- `node --test tests/privacy-settings-source-of-truth.test.mjs` and the other static suites pass.
- Note: new users now see the Firestore-seeded defaults (`dataRetentionEnabled`/`analyticsEnabled` `false`) instead of the old localStorage-only `true`/`true` — this is the point of the fix (consistent, single source of truth).
- Could not run `npm run typecheck` / `npm run lint`: `node_modules` is not installed in this checkout.

Closes #608
