### PR TITLE
fix: delete uploaded PDF on Firestore permission-denied fallback (Issue #609)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1238,15 +1238,11 @@ CRITICAL RULES:
             writeErrorMessage.includes("permission-denied") ||
             writeErrorMessage.includes("missing or insufficient permissions");
 
-          if (isPermissionDenied) {
-            documentId = `local-${ownerId}-${now.getTime()}`;
-            console.warn(
-              "FIRESTORE_WRITE_FALLBACK: returning local analysis record because Firestore writes are not available",
-            );
-          } else {
-            // The PDF was already uploaded to Storage before these writes began.
-            // Delete it so a failed pipeline does not leave a permanent orphaned
-            // object (with uploadedBy metadata) behind.
+          // The PDF was already uploaded to Storage before these writes began.
+          // Delete it on ANY Firestore write failure so a failed pipeline never
+          // leaves a permanent orphaned object (with uploadedBy metadata) that
+          // cannot be downloaded (no owning Firestore record) or swept later.
+          const cleanupUploadedPdf = async () => {
             try {
               const bucket = getStorage().bucket();
               await bucket.file(storagePath).delete();
@@ -1262,6 +1258,16 @@ CRITICAL RULES:
                 );
               }
             }
+          };
+
+          if (isPermissionDenied) {
+            await cleanupUploadedPdf();
+            documentId = `local-${ownerId}-${now.getTime()}`;
+            console.warn(
+              "FIRESTORE_WRITE_FALLBACK: returning local analysis record because Firestore writes are not available",
+            );
+          } else {
+            await cleanupUploadedPdf();
             throw new PipelineError(
               "FIRESTORE_WRITE",
               `Firestore database write failed: ${writeError?.message || String(writeError)}`,

--- a/tests/orphaned-upload-cleanup.test.mjs
+++ b/tests/orphaned-upload-cleanup.test.mjs
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const serverTs = readFileSync(path.join(repoRoot, "server.ts"), "utf8");
+
+test("the uploaded PDF is deleted on both Firestore write failure paths", () => {
+  const cleanupBlock = serverTs.slice(serverTs.indexOf("cleanupUploadedPdf"));
+  const permissionDeniedBranch = serverTs.slice(
+    serverTs.indexOf("if (isPermissionDenied) {"),
+    serverTs.indexOf("return res.status(200).json({"),
+  );
+
+  assert.ok(
+    /const cleanupUploadedPdf = async \(\) => {/.test(serverTs),
+    "a shared cleanup helper must exist for deleting the just-uploaded object",
+  );
+  assert.ok(
+    cleanupBlock.includes("await bucket.file(storagePath).delete();"),
+    "the cleanup helper must delete the uploaded object",
+  );
+  assert.ok(
+    /if \(isPermissionDenied\) {\s*\n\s*await cleanupUploadedPdf\(\);/.test(
+      permissionDeniedBranch,
+    ),
+    "the permission-denied fallback must delete the uploaded object",
+  );
+  assert.ok(
+    /} else {\s*\n\s*await cleanupUploadedPdf\(\);/.test(permissionDeniedBranch),
+    "the non-permission-denied failure path must still delete the uploaded object",
+  );
+});


### PR DESCRIPTION
## Problem

On the Express analyze pipeline, the PDF is uploaded to Firebase Storage *before* the Firestore metadata write. When Firestore rejects the write:

- the non-permission-denied path deleted the just-uploaded object,
- but the **permission-denied** fallback returned `200` with `persistenceMode: "local"` and kept the object in Storage.

That object is permanently orphaned: the download endpoint refuses to sign files without a live owning Firestore record (`server.ts:1401-1422`), and account deletion only removes storage backed by known records — so the file (with `uploadedBy` metadata and a full financial PDF) is unreachable and undeletable.

## Fix

- Extracted the storage cleanup into a single `cleanupUploadedPdf` helper and now call it on **both** write-failure branches:
  - permission-denied fallback → deletes the uploaded PDF before returning the local record,
  - other write failures → deletes it as before.
- The 404 case (object not found) is still ignored so the helper is safe when no upload actually happened (e.g. when Admin is uninitialized).

## Files changed

- `server.ts`
- `tests/orphaned-upload-cleanup.test.mjs` (new)

## Testing

- Added `tests/orphaned-upload-cleanup.test.mjs` asserting both branches invoke the shared cleanup that deletes `storagePath`.
- `node --test tests/orphaned-upload-cleanup.test.mjs`, `tests/storage-rules.test.mjs`, and `tests/analyze-quota-guard.test.mjs` all pass.
- Could not run `npm run typecheck` / `npm run lint`: `node_modules` is not installed in this checkout.

Follow-up (not included to keep this change minimal): a background sweep/retention job that lists the `analyses/` prefix and removes objects whose `storagePath` has no matching Firestore record older than N hours.

Closes #609
