### PR TITLE
fix: secure Firestore list access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -87,7 +87,7 @@ service cloud.firestore {
 
     match /reports/{reportId} {
       allow get: if isOwner(existing().userId) || isAdmin();
-      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
+      allow list: if resource.data.userId == request.auth.uid || isAdmin();
       allow create: if isSignedIn() && isOwner(incoming().userId);
       allow update: if isOwner(existing().userId) || isAdmin();
       allow delete: if isOwner(existing().userId) || isAdmin();
@@ -95,7 +95,7 @@ service cloud.firestore {
 
     match /documents/{docId} {
       allow read: if isOwner(existing().ownerId) || isAdmin();
-      allow list: if request.auth != null && (request.query.ownerId == request.auth.uid || isAdmin());
+      allow list: if resource.data.ownerId == request.auth.uid || isAdmin();
       allow create: if isSignedIn() && isValidDocument(incoming());
       allow update: if (isOwner(existing().ownerId) && incoming().diff(existing()).affectedKeys().hasOnly(['status', 'updatedAt', 'riskLevel'])) || isAdmin();
       allow delete: if isOwner(existing().ownerId) || isAdmin();
@@ -105,7 +105,7 @@ service cloud.firestore {
       // SECURITY: Only allow reading own analyses or if admin
       // Prevents cross-user data leakage of financial AI analysis results
       allow get: if isOwner(existing().ownerId) || isAdmin();
-      allow list: if request.auth != null && (request.query.ownerId == request.auth.uid || isAdmin());
+      allow list: if resource.data.ownerId == request.auth.uid || isAdmin();
       allow create: if isSignedIn() && isValidAnalysis(incoming());
       allow update: if isAdmin();
       allow delete: if isOwner(existing().ownerId) || isAdmin();


### PR DESCRIPTION
## Summary
Fix Firestore list rules to authorize against each returned document while preserving admin access.

## Related Issue
Closes #620

## Changes Made
- Replaced invalid query-field checks with document ownership checks.

## Testing
- [x] Reviewed rules diff
- [x] No `.env` secrets committed

Made with [Cursor](https://cursor.com)