### PR TITLE
fix: persist currency transaction type

### DIFF
--- a/src/components/currency/CurrencyManager.tsx
+++ b/src/components/currency/CurrencyManager.tsx
@@ -210,6 +210,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: parseFloat(newTx.amount),
         currency: newTx.currency,
         category: newTx.category,
+        type: newTx.type,
         date: toFirestoreDate(newTx.date),
         createdAt: serverTimestamp(),
       });
@@ -239,6 +240,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
         amount: parseFloat(editForm.amount),
         currency: editForm.currency,
         category: editForm.category,
+        type: editForm.type,
         date: toFirestoreDate(editForm.date),
       });
       toast.success('Transaction updated');


### PR DESCRIPTION
## Summary
Save the selected income or expense type when currency transactions are created and edited.

## Related Issue
Closes #622

## Changes Made
- Persist transaction type in create and update writes.

## Testing
- [x] `npx eslint src/components/currency/CurrencyManager.tsx`
- [x] No `.env` secrets committed

Made with [Cursor](https://cursor.com)