### PR TITLE
fix: scope cashflow balance by user

### DIFF
--- a/src/components/cashflow/CashFlowDashboard.tsx
+++ b/src/components/cashflow/CashFlowDashboard.tsx
@@ -42,6 +42,11 @@ import {
 } from "@/src/lib/cashflowUtils";
 
 const CHART_COLORS = ["#6366f1", "#8b5cf6", "#3b82f6", "#06b6d4", "#10b981"];
+const LEGACY_STARTING_BALANCE_KEY = "finsight_starting_balance";
+
+function startingBalanceKey(userId: string) {
+  return `finsight_starting_balance:${userId}`;
+}
 
 export function CashFlowDashboard({ user }: { user: any }) {
   const [loading, setLoading] = useState(true);
@@ -60,15 +65,24 @@ export function CashFlowDashboard({ user }: { user: any }) {
     if (!user) return;
     setLoading(true);
     try {
-      const stored = Number(localStorage.getItem("finsight_starting_balance") || 0);
-      const starting = Number.isFinite(stored) ? stored : 0;
-      setStartingBalance(starting);
+      const userBalanceKey = startingBalanceKey(user.uid);
+      let stored = localStorage.getItem(userBalanceKey);
+      if (stored === null) {
+        stored = localStorage.getItem(LEGACY_STARTING_BALANCE_KEY);
+        if (stored !== null) {
+          localStorage.setItem(userBalanceKey, stored);
+          localStorage.removeItem(LEGACY_STARTING_BALANCE_KEY);
+        }
+      }
+      const starting = Number(stored || 0);
+      const safeStarting = Number.isFinite(starting) ? starting : 0;
+      setStartingBalance(safeStarting);
       const transactions = await fetchUserTransactions(user.uid, 6);
       const forecastData = calculateMonthlyForecast(transactions, 6);
       const balanceProj = calculateBalanceProjection(
         transactions,
         forecastData,
-        starting,
+        safeStarting,
       );
       const recurringTx = identifyRecurringTransactions(transactions);
       const confScore = calculateConfidenceScore(transactions, forecastData);
@@ -88,7 +102,7 @@ export function CashFlowDashboard({ user }: { user: any }) {
     const parsed = Number(value);
     const balance = Number.isFinite(parsed) ? parsed : 0;
     setStartingBalance(balance);
-    localStorage.setItem("finsight_starting_balance", String(balance));
+    if (user?.uid) localStorage.setItem(startingBalanceKey(user.uid), String(balance));
     setProjection(calculateBalanceProjection([], forecast, balance));
   }
 


### PR DESCRIPTION
## Description
Scopes cash flow starting balances to the signed-in user.

## Changes Made
- Stores balances with a user-specific localStorage key.
- Migrates the legacy global balance on first use.

## Impact
One user's starting balance is no longer shown to another user on the same device.

## Related Issues
- Resolves #628

Made with [Cursor](https://cursor.com)