### PR TITLE
fix: delete messages with conversations

### DIFF
--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -14,6 +14,7 @@ import {
   setDoc,
   updateDoc,
   deleteDoc,
+  writeBatch,
   serverTimestamp,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
@@ -126,6 +127,17 @@ export async function loadConversations(userId: string): Promise<Conversation[]>
 
 export async function deleteConversation(conversationId: string): Promise<boolean> {
   try {
+    const messages = await getDocs(query(
+      collection(db, MESSAGE_COLLECTION),
+      where('conversationId', '==', conversationId),
+    ));
+
+    for (let index = 0; index < messages.docs.length; index += 450) {
+      const batch = writeBatch(db);
+      messages.docs.slice(index, index + 450).forEach((message) => batch.delete(message.ref));
+      await batch.commit();
+    }
+
     await deleteDoc(doc(db, CHAT_COLLECTION, conversationId));
     return true;
   } catch (error) {


### PR DESCRIPTION
## Description
Removes stored chat messages when their conversation is deleted.

## Changes Made
- Queries messages by conversation ID before removing the conversation.
- Deletes message documents in batches of 450.

## Impact
Deleted conversations no longer leave orphaned chat messages.

## Related Issues
- Resolves #629

Made with [Cursor](https://cursor.com)