### PR TITLE
fix: align forecast filters with loaded months

### DIFF
--- a/src/components/forecast/ForecastComparison.tsx
+++ b/src/components/forecast/ForecastComparison.tsx
@@ -145,6 +145,12 @@ export function ForecastComparison({ user }: ForecastComparisonProps) {
     };
   }, [user]);
 
+  useEffect(() => {
+    if (monthly.length === 0) return;
+    const months = monthly.map((forecast) => forecast.month).sort();
+    setFilter({ startDate: months[0], endDate: months[months.length - 1] });
+  }, [monthly]);
+
   const filteredMonthly = useMemo(
     () => applyFilters(monthly, filter),
     [monthly, filter]


### PR DESCRIPTION
## Summary
Set the forecast date range to the first and last available forecast months after data loads or regenerates.

## Related Issue
Closes #624

## Changes Made
- Synchronize forecast filters with loaded monthly forecast data.

## Testing
- [x] `npx eslint src/components/forecast/ForecastComparison.tsx`
- [x] No `.env` secrets committed

Made with [Cursor](https://cursor.com)