### PR TITLE
fix(reports): preserve base currency in exports

### DIFF
--- a/src/components/reports/ReportExport.tsx
+++ b/src/components/reports/ReportExport.tsx
@@ -213,6 +213,7 @@ export function ReportExport() {
         transactions,
         expenseSummary,
         incomeSummary,
+        baseCurrency,
       );
       setReportData(data);
 


### PR DESCRIPTION
## Summary
Pass the configured base currency when building exported report data so preview and export totals match.

Closes #635

Made with [Cursor](https://cursor.com)