### PR TITLE
fix(health): retain recalculated metrics locally

### DIFF
--- a/src/components/health/HealthScoreDashboard.tsx
+++ b/src/components/health/HealthScoreDashboard.tsx
@@ -277,7 +277,7 @@ export function HealthScoreDashboard({ user }: HealthScoreDashboardProps) {
           budgetAdherenceScore: budget,
           metrics: metricsPayload,
         });
-        const updatedScore = { ...existing, ...metricsPayload, overallScore: overall, spendingScore: spending, savingsScore: savings, budgetAdherenceScore: budget };
+        const updatedScore = { ...existing, metrics: metricsPayload, overallScore: overall, spendingScore: spending, savingsScore: savings, budgetAdherenceScore: budget };
         setHistoricalScores((prev) =>
           prev.map((s) => (s.id === existing.id ? updatedScore : s))
         );


### PR DESCRIPTION
## Summary
Store recalculated health metrics under the metrics field in local score state.

Closes #638

Made with [Cursor](https://cursor.com)