### PR TITLE
fix(analysis): clarify private share links

### DIFF
--- a/src/components/AnalysisDetail.tsx
+++ b/src/components/AnalysisDetail.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/src/components/ui/tabs";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import ReactMarkdown from "react-markdown";
+import { toast } from "sonner";
 import { getLocalDocumentById } from "@/src/lib/storageUtils";
 
 const XBrandIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -225,6 +226,9 @@ export function AnalysisDetail({ docId, user, onBack }: AnalysisDetailProps) {
     if (success) {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
+      toast.warning(
+        "Link copied for your own use. Recipients need ownership or admin access.",
+      );
     }
   };
 
@@ -930,10 +934,10 @@ export function AnalysisDetail({ docId, user, onBack }: AnalysisDetailProps) {
 
             <div className="mb-6 pr-8">
               <h2 className="text-xl font-black text-white">
-                Share Financial Report
+                Copy Private Report Link
               </h2>
               <p className="mt-2 text-sm leading-6 text-slate-400">
-                Send a direct access link to this FinSight AI analysis.
+                Copy this link for your own use. Recipients need ownership or admin access to open this analysis.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
Warn users that copied analysis links remain private and require owner or admin access.

Closes #639

Made with [Cursor](https://cursor.com)