### PR TITLE
fix: require subscription keyword gate before auto-detect

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -191,6 +191,7 @@ export function groupTransactionsIntoSubscriptions(
 
   for (const transaction of transactions) {
     if (transaction.type !== "expense") continue;
+    if (!isLikelySubscription(transaction.description)) continue;
     const normalized = normalizeText(transaction.description);
     const category = transaction.category.toLowerCase();
 


### PR DESCRIPTION
## Summary

Wire `isLikelySubscription` into grouping so amount+category pairs without a merchant/keyword signal are not saved as active subscriptions.

## Related Issue

Closes #630

## Changes Made

- `src/lib/subscriptionUtils.ts` — skip non-matching expense descriptions in `groupTransactionsIntoSubscriptions`

## Testing

- [x] Manual review of detection path
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Tested locally with a real Firebase project and Gemini API key
- [x] No `.env` secrets committed

## Notes for Reviewer

Two similar Food charges without subscription keywords no longer become subscriptions.

Made with [Cursor](https://cursor.com)