### PR TITLE
fix: scope local analysis cache to the signed-in owner

### DIFF
--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -75,15 +75,9 @@ export function getLocalDocuments(ownerId?: string): any[] {
         record.latestAnalysis = item.analysis;
       }
 
-      if (
-        !ownerId ||
-        !record.ownerId ||
-        record.ownerId === ownerId ||
-        record.ownerId === "anonymous" ||
-        record.ownerId === "anonymous_user" ||
-        record.ownerId?.startsWith("local-") ||
-        record.ownerId?.includes("anon")
-      ) {
+      if (!ownerId) {
+        docs.push(record);
+      } else if (record.ownerId === ownerId) {
         docs.push(record);
       }
     }


### PR DESCRIPTION
## Summary

When filtering localStorage analyses by ownerId, only return exact matches. Anonymous/local-* entries no longer appear under another signed-in user.

## Related Issue

Closes #631

## Changes Made

- `src/lib/storageUtils.ts` — strict owner filter; unfiltered mode unchanged when ownerId is omitted

## Testing

- [x] Code review of filter branches
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Tested locally with a real Firebase project and Gemini API key
- [x] No `.env` secrets committed

## Notes for Reviewer

Shared-browser cross-account cache leak for anonymous/local docs.

Made with [Cursor](https://cursor.com)