### PR TITLE
fix: harden serverless /api/process and /api/analyze

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -57,6 +57,65 @@ function sanitizeStorageFilename(filename: string): string {
   return name;
 }
 
+
+function getAllowedOrigins(): Set<string> {
+  const isProduction = process.env.NODE_ENV === "production";
+  const origins = [
+    process.env.APP_URL,
+    process.env.FRONTEND_URL,
+    ...(isProduction
+      ? []
+      : [
+          "http://localhost:3000",
+          "http://127.0.0.1:3000",
+          "http://localhost:3001",
+          "http://127.0.0.1:3001",
+          "http://localhost:5173",
+          "http://127.0.0.1:5173",
+        ]),
+  ].filter((origin): origin is string => Boolean(origin) && origin !== "MY_APP_URL");
+  return new Set(origins);
+}
+
+function applyCors(req: IncomingMessage, res: ServerResponse): void {
+  const origin = String(req.headers?.origin ?? "");
+  const allowed = getAllowedOrigins();
+  if (origin && allowed.has(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+  } else if (!origin && process.env.NODE_ENV !== "production") {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+  }
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+}
+
+function isPdfBuffer(buffer: Buffer, mimetype?: string): boolean {
+  const mimeOk = !mimetype || mimetype === "application/pdf" || mimetype === "application/x-pdf";
+  const magicOk =
+    buffer.length >= 4 &&
+    buffer[0] === 0x25 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x44 &&
+    buffer[3] === 0x46;
+  return Boolean(magicOk && mimeOk);
+}
+
+const analyzeRateBuckets = new Map<string, number[]>();
+
+function acceptAnalyzeRequest(ip: string, limit = 10, windowMs = 10 * 60 * 1000): boolean {
+  const now = Date.now();
+  const recent = (analyzeRateBuckets.get(ip) || []).filter((ts) => now - ts < windowMs);
+  if (recent.length >= limit) {
+    analyzeRateBuckets.set(ip, recent);
+    return false;
+  }
+  recent.push(now);
+  analyzeRateBuckets.set(ip, recent);
+  return true;
+}
+
+
 type AnalysisResponse = {
   summary: string;
   key_metrics: Record<string, unknown>;
@@ -436,9 +495,7 @@ function parseMultipart(
 }
 
 export default async function handler(req: VercelReq, res: VercelRes) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  applyCors(req, res);
 
   if (req.method === "OPTIONS") {
     res.status(204).end();
@@ -447,6 +504,22 @@ export default async function handler(req: VercelReq, res: VercelRes) {
 
   if (req.method !== "POST") {
     res.status(405).json({ error: "Method Not Allowed" });
+    return;
+  }
+
+  const clientIp = String(
+    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
+      req.socket?.remoteAddress ||
+      "unknown",
+  );
+  if (!acceptAnalyzeRequest(clientIp)) {
+    res.status(429).json({
+      error: {
+        stage: "RATE_LIMIT",
+        reason: "Too many analysis requests. Please try again later.",
+        recommendation: "Wait a few minutes before retrying.",
+      },
+    });
     return;
   }
 
@@ -531,13 +604,25 @@ export default async function handler(req: VercelReq, res: VercelRes) {
       );
     }
 
+    if (!isPdfBuffer(fileBuffer)) {
+      throw new PipelineError(
+        "PDF_INGESTION",
+        "Uploaded file is not a valid PDF.",
+        "Please upload a PDF that starts with %PDF magic bytes.",
+      );
+    }
+
     let extractedText = "";
     try {
       const parsedPdf = await pdfParse(fileBuffer);
       extractedText = String(parsedPdf?.text || "").trim();
     } catch (pdfErr: any) {
-      console.warn("[analyze] pdfParse failed, using text fallback:", pdfErr?.message);
-      extractedText = fileBuffer.toString("utf8").replace(/[^\x20-\x7E\n\r\t]/g, " ").trim();
+      console.warn("[analyze] pdfParse failed, rejecting non-extractable upload:", pdfErr?.message);
+      throw new PipelineError(
+        "PDF_INGESTION",
+        "Unable to extract text from the uploaded PDF.",
+        "Please upload a text-based PDF and try again.",
+      );
     }
 
     if (!extractedText || extractedText.length < 20) {
@@ -704,13 +789,15 @@ full_report MUST be at least 300 words.`;
 
     console.error(`[analyze] ${stage}: ${reason}`);
 
+    const isProd = process.env.NODE_ENV === "production";
     res.status(500).json({
       error: {
         stage,
-        reason,
+        reason: isProd
+          ? "An unexpected error occurred while analyzing the document."
+          : reason,
         recommendation,
-        stack:
-          process.env.NODE_ENV !== "production" ? error?.stack : undefined,
+        stack: isProd ? undefined : error?.stack,
       },
     });
   }

--- a/api/process.ts
+++ b/api/process.ts
@@ -54,6 +54,66 @@ function sanitizeStorageFilename(filename: string): string {
   return name;
 }
 
+
+function getAllowedOrigins(): Set<string> {
+  const isProduction = process.env.NODE_ENV === "production";
+  const origins = [
+    process.env.APP_URL,
+    process.env.FRONTEND_URL,
+    ...(isProduction
+      ? []
+      : [
+          "http://localhost:3000",
+          "http://127.0.0.1:3000",
+          "http://localhost:3001",
+          "http://127.0.0.1:3001",
+          "http://localhost:5173",
+          "http://127.0.0.1:5173",
+        ]),
+  ].filter((origin): origin is string => Boolean(origin) && origin !== "MY_APP_URL");
+  return new Set(origins);
+}
+
+function applyCors(req: any, res: any): void {
+  const origin = String(req.headers?.origin ?? "");
+  const allowed = getAllowedOrigins();
+  if (origin && allowed.has(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+  } else if (!origin && !process.env.NODE_ENV?.includes("production")) {
+    // Non-browser / same-origin tooling in development
+    res.setHeader("Access-Control-Allow-Origin", "*");
+  }
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+}
+
+function isPdfBuffer(buffer: Buffer, mimetype?: string): boolean {
+  const mimeOk = !mimetype || mimetype === "application/pdf" || mimetype === "application/x-pdf";
+  const magicOk =
+    buffer.length >= 4 &&
+    buffer[0] === 0x25 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x44 &&
+    buffer[3] === 0x46; // %PDF
+  return Boolean(magicOk && mimeOk);
+}
+
+const processRateBuckets = new Map<string, number[]>();
+
+function acceptProcessRequest(ip: string, limit = 10, windowMs = 10 * 60 * 1000): boolean {
+  const now = Date.now();
+  const recent = (processRateBuckets.get(ip) || []).filter((ts) => now - ts < windowMs);
+  if (recent.length >= limit) {
+    processRateBuckets.set(ip, recent);
+    return false;
+  }
+  recent.push(now);
+  processRateBuckets.set(ip, recent);
+  return true;
+}
+
+
 // ---------------------------------------------------------------------------
 // Pure-JS multipart parser — no native deps, works on Vercel
 // ---------------------------------------------------------------------------
@@ -159,11 +219,8 @@ async function extractPdfText(buffer: Buffer): Promise<string> {
     return String(result?.text ?? "").trim();
   } catch (err: any) {
     console.warn("[process] pdf-parse failed:", err?.message);
-    return buffer
-      .toString("latin1")
-      .replace(/[^\x20-\x7E\n\r\t]/g, " ")
-      .replace(/\s{4,}/g, "   ")
-      .trim();
+    // Do not feed binary garbage into the model; caller handles empty text.
+    return "";
   }
 }
 
@@ -404,13 +461,26 @@ async function getAdminApp(): Promise<any | null> {
 // ---------------------------------------------------------------------------
 
 export default async function handler(req: any, res: any) {
-  // CORS
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  applyCors(req, res);
 
   if (req.method === "OPTIONS") { res.status(204).end(); return; }
   if (req.method !== "POST") { res.status(405).json({ error: "Method Not Allowed" }); return; }
+
+  const clientIp = String(
+    (req.headers?.["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
+      req.socket?.remoteAddress ||
+      "unknown",
+  );
+  if (!acceptProcessRequest(clientIp)) {
+    res.status(429).json({
+      error: {
+        stage: "RATE_LIMIT",
+        reason: "Too many upload requests. Please try again later.",
+        recommendation: "Wait a few minutes before retrying.",
+      },
+    });
+    return;
+  }
 
   const startTime = Date.now();
 
@@ -497,6 +567,17 @@ export default async function handler(req: any, res: any) {
           stage: "PDF_INGESTION",
           reason: "No file content received.",
           recommendation: "Please select a valid PDF file and try again.",
+        },
+      });
+      return;
+    }
+
+    if (!isPdfBuffer(fileBuffer)) {
+      res.status(400).json({
+        error: {
+          stage: "PDF_INGESTION",
+          reason: "Uploaded file is not a valid PDF.",
+          recommendation: "Please upload a PDF that starts with %PDF magic bytes.",
         },
       });
       return;
@@ -649,12 +730,15 @@ export default async function handler(req: any, res: any) {
     });
   } catch (err: any) {
     console.error("[process] Unhandled error:", err?.message, err?.stack);
+    const isProd = process.env.NODE_ENV === "production";
     res.status(500).json({
       error: {
         stage: err?.stage ?? "PIPELINE_ERROR",
-        reason: err?.message ?? String(err),
+        reason: isProd
+          ? "An unexpected error occurred while processing the document."
+          : (err?.message ?? String(err)),
         recommendation: "An unexpected error occurred. Please try again.",
-        stack: process.env.NODE_ENV !== "production" ? err?.stack : undefined,
+        stack: isProd ? undefined : err?.stack,
       },
     });
   }


### PR DESCRIPTION
## Summary

Bring Vercel upload handlers closer to Express hardening: CORS allowlist, PDF magic checks, basic per-IP rate limits, and sanitized production errors. Stop feeding binary fallback text into the model.

## Related Issue

Closes #633

## Changes Made

- `api/process.ts` — CORS allowlist, rate limit, PDF magic reject, empty extract on parse fail, prod error sanitize
- `api/analyze.ts` — same CORS/rate/PDF/error treatment; reject failed PDF parse instead of utf8 garbage

## Testing

- [x] Diff review against Express patterns
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Tested locally with a real Firebase project and Gemini API key
- [x] No `.env` secrets committed

## Notes for Reviewer

In-memory rate limit is per-instance (fine for a first cut on serverless). Auth remains tracked separately in #600.

Made with [Cursor](https://cursor.com)