### PR TITLE
fix: abort Express analyze when Storage upload fails

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1185,11 +1185,22 @@ CRITICAL RULES:
             );
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } catch (storageError: any) {
-            console.warn(
-              "FIREBASE_STORAGE_UPLOAD_WARNING: Storage bucket not ready, continuing document creation:",
+            console.error(
+              "FIREBASE_STORAGE_UPLOAD_FAILED:",
               storageError?.message || storageError,
             );
+            throw new PipelineError(
+              "STORAGE_UPLOAD",
+              "Failed to store the uploaded PDF in Firebase Storage.",
+              "Check Storage bucket configuration and service-account permissions, then retry.",
+            );
           }
+        } else {
+          throw new PipelineError(
+            "STORAGE_UPLOAD",
+            "Firebase Admin is not initialized; cannot store the uploaded PDF.",
+            "Configure Firebase Admin credentials and retry the upload.",
+          );
         }
 
 


### PR DESCRIPTION
## Summary

Stop fail-open on Firebase Storage errors in Express `/api/analyze`. If the PDF cannot be stored, the request errors out instead of writing a completed doc with a phantom `storagePath`.

## Related Issue

Closes #634

## Changes Made

- `server.ts` — throw `PipelineError` on Storage upload failure; also error if Admin SDK is not initialized

## Testing

- [x] Code review of upload path
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Tested locally with a real Firebase project and Gemini API key
- [x] No `.env` secrets committed

## Notes for Reviewer

Inverse of #609 (Storage kept when Firestore fails).

Made with [Cursor](https://cursor.com)