### PR TITLE
fix: align PrivacySettings interface with PrivacyDashboard data shape

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -20,17 +20,14 @@ import { db, auth, handleFirestoreError, OperationType } from "./firebase";
 import { format } from "date-fns";
 
 export interface PrivacySettings {
-  dataCollection: boolean;
-  shareAnalytics: boolean;
-  personalizedAds: boolean;
-  thirdPartySharing: boolean;
-  retentionPeriod: "6months" | "1year" | "2years" | "indefinite";
-  exportFormat: "json" | "csv";
-  lastUpdated: string;
+  userId?: string;
   dataRetentionEnabled: boolean;
   analyticsEnabled: boolean;
   sharingEnabled: boolean;
-  mfaEnabled: boolean;
+  exportRequestedAt: string;
+  deletionRequestedAt: string;
+  updatedAt: string;
+  lastUpdated?: string;
 }
 
 export interface ActivityLogEntry {
@@ -42,17 +39,12 @@ export interface ActivityLogEntry {
 }
 
 export const DEFAULT_PRIVACY_SETTINGS: PrivacySettings = {
-  dataCollection: true,
-  shareAnalytics: true,
-  personalizedAds: false,
-  thirdPartySharing: false,
-  retentionPeriod: "1year",
-  exportFormat: "json",
-  lastUpdated: new Date().toISOString(),
   dataRetentionEnabled: false,
   analyticsEnabled: false,
   sharingEnabled: false,
-  mfaEnabled: false,
+  exportRequestedAt: "",
+  deletionRequestedAt: "",
+  updatedAt: new Date().toISOString(),
 };
 
 export async function getPrivacySettings(


### PR DESCRIPTION
## Summary of What Has Been Done
Updated the `PrivacySettings` interface in `src/lib/privacyUtils.ts` to match the data shape used by `src/components/privacy/PrivacyDashboard.tsx`. The interface previously had fields not used by the component (`dataCollection`, `shareAnalytics`, etc.) while missing fields actually written by the component (`userId`, `exportRequestedAt`, `deletionRequestedAt`, `updatedAt`).

## Changes Made
- Replaced `PrivacySettings` interface with fields matching PrivacyDashboard usage
- Updated `DEFAULT_PRIVACY_SETTINGS` to match new interface

## Impact it Made
Eliminates TypeScript type mismatches between the interface and runtime data.

## Note: Please assign this PR to the `tmdeveloper007` account.
