### PR TITLE
fix: use USD as default currency in generatePDF instead of INR

### DIFF
--- a/src/lib/reportUtils.ts
+++ b/src/lib/reportUtils.ts
@@ -239,7 +239,7 @@ export async function generatePDF(
   pdf.text("Summary", margin, y);
   y += 6;
 
-  const currency = reportData.currency || "INR";
+  const currency = reportData.currency || "USD";
 
   pdf.setFontSize(10);
   pdf.setTextColor(51, 65, 85);
@@ -343,7 +343,7 @@ export function buildReportData(
   transactions: ReportTransaction[],
   expenseSummary: ExpenseSummaryItem[],
   incomeSummary: IncomeSummaryItem[],
-  currency: string = "INR",
+  currency: string = "USD",
 ): ReportData {
   const totalIncome = incomeSummary.reduce((sum, item) => sum + item.total, 0);
   const totalExpenses = expenseSummary.reduce(
@@ -384,7 +384,7 @@ export async function saveReportToFirestore(
       },
       totalIncome: reportData.totalIncome,
       totalExpenses: reportData.totalExpenses,
-      currency: reportData.currency || "INR",
+      currency: reportData.currency || "USD",
       createdAt: new Date().toISOString(),
     };
     await setDoc(newDocRef, payload);


### PR DESCRIPTION
## Summary of What Has Been Done
Changed the hardcoded fallback currency in `src/lib/reportUtils.ts` from `"INR"` to `"USD"` in three places: the `generatePDF` function, the `buildReportData` function signature, and the `saveReportToFirestore` function.

## Changes Made
- Changed `reportData.currency || "INR"` to `reportData.currency || "USD"` (3 locations)
- Changed `currency: string = "INR"` default parameter to `currency: string = "USD"`

## Impact it Made
Ensures PDF reports default to USD instead of INR for users without an explicit currency preference.

## Note: Please assign this PR to the `tmdeveloper007` account.
