### PR TITLE
fix: ensure setIsLoading(false) is called on all promise paths in InsightsDashboard

### DIFF
--- a/src/components/insights/InsightsDashboard.tsx
+++ b/src/components/insights/InsightsDashboard.tsx
@@ -73,30 +73,20 @@ export function InsightsDashboard({ user }: InsightsDashboardProps) {
     }
 
     let cancelled = false;
-    let loadingState = true;
 
-    // Set initial state - needed for derived loading state
-     
     setIsLoading(true);
 
     fetchTransactions(user.uid)
       .then(transactions => {
-        if (cancelled || !loadingState) return;
-        loadingState = false;
+        if (cancelled) return;
         setBundle(buildInsights(transactions, user.uid));
+        setIsLoading(false);
       })
       .catch(error => {
-        if (cancelled || !loadingState) return;
-        loadingState = false;
+        if (cancelled) return;
         handleFirestoreError(error, OperationType.LIST, "transactions");
         setBundle(buildInsights([], user.uid));
-      })
-      .finally(() => {
-        if (!cancelled && loadingState) {
-          loadingState = false;
-           
-          setIsLoading(false);
-        }
+        setIsLoading(false);
       });
 
     return () => {


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the broken loading state management in `src/components/insights/InsightsDashboard.tsx`. The `finally` block checked `if (!cancelled && loadingState)` but `loadingState` had already been set to `false` by the preceding `.then()` or `.catch()` handler, so `setIsLoading(false)` inside `finally` was never reached.

## Changes Made
- Removed the dead `finally` block
- Added `setIsLoading(false)` call directly in both `.then()` and `.catch()` handlers
- Removed the now-unnecessary `loadingState` flag variable

## Impact it Made
Guarantees the loading spinner is dismissed reliably on every code path, fixing potential UI freezes.

## Note: Please assign this PR to the `tmdeveloper007` account.
