### PR TITLE
fix: remove duplicate untyped safeJsonParse from utils.ts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -123,10 +123,4 @@ export function clearSharedDocId() {
   window.history.replaceState({}, "", url.toString());
 }
 
-export function safeJsonParse(value: string, fallback: any = null) {
-  try {
-    return JSON.parse(value);
-  } catch (error) {
-    return fallback;
-  }
-}
+


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the duplicate untyped `safeJsonParse(value: string, fallback: any = null)` function from `src/lib/utils.ts`. The file had two definitions: a typed generic version at line 25 and an untyped version at line 126 that shadowed it.

## Changes Made
- Removed duplicate `safeJsonParse(value: string, fallback: any = null)` function

## Impact it Made
- Fixes callers expecting typed return values from `safeJsonParse<T>()`
- Prevents TypeScript duplicate declaration errors in CI

## Note: Please assign this PR to the `tmdeveloper007` account.
