### PR TITLE
fix: verify Storage ownership before deleting documents (issue #674)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,14 @@ service cloud.firestore {
              // Only allow https fileUrl so a stored link can never render as
              // a javascript:/data: URL or a link-injection vector.
              data.fileUrl is string && data.fileUrl.size() <= 2048 && data.fileUrl.startsWith('https://') &&
-             data.status in ['pending', 'processing', 'completed', 'failed'];
+             data.status in ['pending', 'processing', 'completed', 'failed'] &&
+             // If a storagePath is stored on the record, it must live inside
+             // the caller's own namespace. Otherwise a client could create a
+             // document whose storagePath points at another user's object and
+             // abuse the server-side purge/delete endpoints that trust it.
+             (!data.keys().has('storagePath') ||
+              (data.storagePath is string &&
+               data.storagePath.startsWith('analyses/' + request.auth.uid + '/')));
     }
 
     function isValidAnalysis(data) {

--- a/server.ts
+++ b/server.ts
@@ -1556,6 +1556,64 @@ CRITICAL RULES:
       const storagePath =
         typeof docData?.storagePath === "string" ? docData.storagePath : "";
 
+      // SECURITY: the ownership check above only proves the caller owns the
+      // Firestore record. The record's storagePath is client-controlled at
+      // create time, so it must never be trusted to point at another user's
+      // Storage object. Mirror the download endpoint (see
+      // POST /api/document-download-url, which verifies namespace + uploadedBy
+      // metadata): refuse to delete unless the object lives under the caller's
+      // own prefix AND was uploaded by the caller.
+      if (storagePath) {
+        const expectedPrefix = `analyses/${req.ownerId}/`;
+        if (!storagePath.startsWith(expectedPrefix)) {
+          console.warn(
+            `UNAUTHORIZED_PURGE_ATTEMPT: userId=${req.ownerId}, storagePath=${storagePath}, reason=path prefix mismatch`,
+          );
+          return res.status(403).json({
+            error: {
+              stage: "AUTHORIZATION",
+              reason: "You do not have access to this document",
+              recommendation: "Verify the document belongs to your account.",
+            },
+          });
+        }
+
+        try {
+          const [metadata] = await getStorage().bucket().file(storagePath).getMetadata();
+          const uploadedBy = metadata?.metadata?.uploadedBy;
+          if (!metadata || uploadedBy !== req.ownerId) {
+            console.warn(
+              `UNAUTHORIZED_PURGE_ATTEMPT: userId=${req.ownerId}, storagePath=${storagePath}, reason=uploadedBy mismatch`,
+            );
+            return res.status(403).json({
+              error: {
+                stage: "AUTHORIZATION",
+                reason: "You do not have access to this document",
+                recommendation: "Verify the document belongs to your account.",
+              },
+            });
+          }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (metadataError: any) {
+          // A missing object (404) is fine — there is nothing left to delete.
+          // Any other failure must not purge a record whose Storage ownership
+          // could not be verified.
+          if (metadataError?.code !== 404) {
+            console.error(
+              "STORAGE_OBJECT_METADATA_ERROR:",
+              metadataError?.message || metadataError,
+            );
+            return res.status(500).json({
+              error: {
+                stage: "DOCUMENT_DELETE",
+                reason: "Failed to verify storage object ownership",
+                recommendation: "Please try again.",
+              },
+            });
+          }
+        }
+      }
+
       // Delete the analyses subcollection docs and the parent document in a
       // single batch so the record cannot be left half-purged.
       const analysesRef = docRef.collection("analyses");


### PR DESCRIPTION
## Problem

`DELETE /api/documents/delete` verified Firestore-record ownership but never verified that the Storage object being deleted belonged to the caller. `isValidDocument` in `firestore.rules` did not restrict extra fields, so any signed-in user could create a `documents` record with their own `ownerId` and an arbitrary `storagePath` pointing at another user's PDF. The ownership gate passed and the server permanently deleted the victim's file (Admin SDK bypasses `storage.rules`).

## Fix

- Mirror the download endpoint's guard in the delete handler: before purging, require the resolved `storagePath` to live under `analyses/<ownerId>/` and fetch the object's metadata, rejecting with 403 unless `metadata.metadata.uploadedBy === req.ownerId`. A missing object (404) is tolerated so legitimate cleanups still work; any other metadata failure returns 500 without deleting the record.
- Harden `isValidDocument` in `firestore.rules` so a `documents` record may only be created with a `storagePath` inside the creator's own namespace (`analyses/<uid>/`).

## Files changed

- `server.ts` — `/api/documents/delete` handler now verifies Storage path prefix and `uploadedBy` metadata before deleting.
- `firestore.rules` — `isValidDocument` now restricts `storagePath` to the caller's own namespace.

## Testing

- `npx tsc --noEmit` produces no new errors beyond the 4 pre-existing ones on `main`.
- Manually traced the handler: a forged record with a victim's `storagePath` now hits the path-prefix or `uploadedBy` mismatch and returns 403 before any delete is issued; legitimate records (own prefix + own `uploadedBy`) delete exactly as before.

Closes #674
