### PR TITLE
fix: remove duplicate firestore.rules match blocks that nullified userId immutability (issue #675)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -113,28 +113,8 @@ service cloud.firestore {
       allow delete: if isOwner(existing().ownerId) || isAdmin();
     }
 
-    match /anomalies/{anomalyId} {
-      // SECURITY: Per-user RLS for the anomalies collection
-      // Prevents cross-user access to anomaly detection data
-      allow get: if isOwner(existing().userId);
-      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
-      allow create: if isSignedIn() && isOwner(incoming().userId);
-      allow update: if isOwner(existing().userId) || isAdmin();
-      allow delete: if isOwner(existing().userId) || isAdmin();
-    }
-
     match /subscriptions/{subId} {
       allow read: if isOwner(existing().userId) || isAdmin();
-      allow create: if isSignedIn() && isOwner(incoming().userId);
-      allow update: if isOwner(existing().userId) || isAdmin();
-      allow delete: if isOwner(existing().userId) || isAdmin();
-    }
-
-    match /transactions/{txnId} {
-      // SECURITY: Per-user RLS for the transactions collection
-      // Prevents cross-user access to financial transaction data
-      allow get: if isOwner(existing().userId);
-      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
       allow create: if isSignedIn() && isOwner(incoming().userId);
       allow update: if isOwner(existing().userId) || isAdmin();
       allow delete: if isOwner(existing().userId) || isAdmin();


### PR DESCRIPTION
## Problem

`firestore.rules` declared the `transactions` and `anomalies` collections twice. Firestore security rules OR-combine every matching `match` block, so the looser legacy block (`allow update: if isOwner(existing().userId) || isAdmin()` with no `incoming().userId` check) granted the update and made the stricter userId-immutability rule dead code. A user could rename the `userId` on their own records to a victim's UID, poisoning the victim's namespace.

## Fix

Remove the duplicate legacy `match /transactions/{txnId}` and `match /anomalies/{anomalyId}` blocks. Each collection now has a single definition whose `update` rule requires `incoming().userId == existing().userId`, so ownership can never be transferred or spoofed.

## Files changed

- `firestore.rules` — deleted the duplicate loose `transactions` and `anomalies` match blocks (20 lines removed); the stricter per-collection rules with the `userId`-immutability check on `update` are now the only definitions.

## Testing

- Rules were reviewed to confirm each of `transactions` and `anomalies` now has exactly one `match` block containing `incoming().userId == existing().userId` on `update`.
- No application code is affected; this is a rules-only change.

Closes #675
