### PR TITLE
fix: make calculateBudgetAdherence monotonic (issue #676)

### DIFF
--- a/src/lib/healthUtils.ts
+++ b/src/lib/healthUtils.ts
@@ -139,7 +139,11 @@ export function calculateBudgetAdherence(
     const spent = categorySpend.get(cat.name) || 0;
     if (cat.monthlyLimit <= 0) return;
     const ratio = spent / cat.monthlyLimit;
-    const adherence = ratio <= 1 ? 100 - ratio * 20 : Math.max(0, 100 - (ratio - 1) * 40);
+    // Monotonic adherence: every step over budget must strictly lower the
+    // score. A single linear penalty (100 - ratio * 20, capped at 0) keeps
+    // the curve continuous and monotonically decreasing, so spending 105% of
+    // a limit can never outscore spending exactly 100%.
+    const adherence = Math.max(0, 100 - ratio * 20);
     totalAdherence += Math.max(0, adherence);
     counted++;
   });


### PR DESCRIPTION
## Problem

`calculateBudgetAdherence` used a two-piece formula that was non-monotonic:
`ratio = 1.00` scored 80, but `ratio = 1.05` scored 98, and mild overspenders
(up to ~1.5x budget) scored higher than at-budget users. Because the component
is weighted at 0.30 in `calculateOverallScore`, overspenders got a better
headline health score than users who landed exactly on budget.

## Fix

Replace the two-piece formula with a single continuous, monotonically
decreasing penalty: `adherence = Math.max(0, 100 - ratio * 20)`, capped at 0.
The two sides now join at `ratio = 1` with no discontinuity, and the score
strictly falls as the spending/budget ratio grows.

Score checkpoints: ratio 0.0 -> 100, 0.5 -> 90, 1.0 -> 80, 1.05 -> 79,
1.5 -> 70, 2.0 -> 60, 5.0 -> 0.

## Files changed

- `src/lib/healthUtils.ts` — `calculateBudgetAdherence` adherence formula.

## Testing

- `npx tsc --noEmit` produces no new errors beyond the 4 pre-existing ones on `main`.
- Verified the new curve is monotonic and continuous at the boundary by evaluating the formula at ratios 0.5 / 1.0 / 1.05 / 1.5 / 2.0.

Closes #676
