### PR TITLE
fix: anchor category trend charts to the selected period (issue 677)

### DIFF
--- a/src/components/trends/CategoryTrends.tsx
+++ b/src/components/trends/CategoryTrends.tsx
@@ -35,6 +35,8 @@ import { Download, Loader2, TrendingUp, Filter, AlertTriangle } from 'lucide-rea
 import { toast } from 'sonner';
 import html2canvas from 'html2canvas';
 import { jsPDF } from 'jspdf';
+import { subMonths, subWeeks, startOfMonth } from 'date-fns';
+import { toDate } from '@/src/lib/utils';
 import {
   buildPeriodConfig,
   calculateCategoryDistribution,
@@ -123,6 +125,25 @@ export function CategoryTrends({ user }: CategoryTrendsProps) {
     [period, customStart, customEnd],
   );
 
+  // Chart windows follow the user's selected period instead of wall-clock
+  // "today". Month/week views extend one period back so the comparison charts
+  // have real data for the previous period instead of an always-empty column.
+  const comparisonStart = useMemo(() => {
+    if (period === 'month') return startOfMonth(subMonths(config.startDate, 1));
+    return config.startDate;
+  }, [period, config.startDate]);
+
+  const weeklyStart = useMemo(() => {
+    if (period === 'week') return subWeeks(config.endDate, 3);
+    return config.startDate;
+  }, [period, config.startDate, config.endDate]);
+
+  const fetchStart = useMemo(() => {
+    if (period === 'month') return comparisonStart;
+    if (period === 'week') return weeklyStart;
+    return config.startDate;
+  }, [period, comparisonStart, weeklyStart, config.startDate]);
+
   useEffect(() => {
     if (!user) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -136,7 +157,7 @@ export function CategoryTrends({ user }: CategoryTrendsProps) {
      
     setIsLoading(true);
 
-    fetchTransactionsForPeriod(user.uid, config)
+    fetchTransactionsForPeriod(user.uid, { ...config, startDate: fetchStart })
       .then((txns) => {
         if (!cancelled && loadingState) {
           loadingState = false;
@@ -160,19 +181,51 @@ export function CategoryTrends({ user }: CategoryTrendsProps) {
     return () => {
       cancelled = true;
     };
-  }, [user, config]);
+  }, [user, config, fetchStart]);
 
-  const categories = useMemo(() => getUniqueCategories(transactions), [transactions]);
+  // Charts that aggregate within the exact selected period (distribution,
+  // category counts, totals) must exclude the comparison window's extra
+  // fetched data (the previous month/week fetched for comparisons).
+  const periodTransactions = useMemo(
+    () =>
+      transactions.filter((t) => {
+        const d = toDate(t.date);
+        return (
+          !!d &&
+          d.getTime() >= config.startDate.getTime() &&
+          d.getTime() <= config.endDate.getTime()
+        );
+      }),
+    [transactions, config.startDate, config.endDate],
+  );
 
-  const monthlyData = useMemo(() => generateMonthlyComparison(transactions, 2), [transactions]);
-  const weeklyData = useMemo(() => generateWeeklyComparison(transactions, 4), [transactions]);
+  const categories = useMemo(() => getUniqueCategories(periodTransactions), [periodTransactions]);
+
+  const monthlyData = useMemo(
+    () => generateMonthlyComparison(transactions, comparisonStart, config.endDate),
+    [transactions, comparisonStart, config.endDate],
+  );
+  const weeklyData = useMemo(
+    () => generateWeeklyComparison(transactions, weeklyStart, config.endDate),
+    [transactions, weeklyStart, config.endDate],
+  );
   const pieData = useMemo(
-    () => calculateCategoryDistribution(transactions, categoryFilter === 'all' ? undefined : categoryFilter),
-    [transactions, categoryFilter],
+    () =>
+      calculateCategoryDistribution(
+        periodTransactions,
+        categoryFilter === 'all' ? undefined : categoryFilter,
+      ),
+    [periodTransactions, categoryFilter],
   );
   const trendData = useMemo(
-    () => generateTrendLines(transactions, 6, new Date(), categoryFilter === 'all' ? undefined : categoryFilter),
-    [transactions, categoryFilter],
+    () =>
+      generateTrendLines(
+        transactions,
+        comparisonStart,
+        config.endDate,
+        categoryFilter === 'all' ? undefined : categoryFilter,
+      ),
+    [transactions, comparisonStart, config.endDate, categoryFilter],
   );
 
   const totalSpent = useMemo(
@@ -246,7 +299,7 @@ export function CategoryTrends({ user }: CategoryTrendsProps) {
             Expense Category Trends
           </h1>
           <p className="text-sm text-slate-500 mt-1">
-            {config.label} · {transactions.length} transactions · ₹{totalSpent.toLocaleString()}
+            {config.label} · {periodTransactions.length} transactions · ₹{totalSpent.toLocaleString()}
           </p>
         </div>
 

--- a/src/lib/trendsUtils.ts
+++ b/src/lib/trendsUtils.ts
@@ -25,7 +25,6 @@ import {
   startOfMonth,
   endOfMonth,
   subMonths,
-  subWeeks,
   eachWeekOfInterval,
   eachMonthOfInterval,
 } from 'date-fns';
@@ -192,10 +191,12 @@ export function groupByCategoryAndPeriod(
 
 export function generateMonthlyComparison(
   transactions: Transaction[],
-  months: number = 2,
-  end: Date = new Date(),
+  start: Date,
+  end: Date,
 ): { data: CategoryPeriodDatum[]; periods: { key: string; label: string }[] } {
-  const start = startOfMonth(subMonths(end, months - 1));
+  // Bucket into the caller-provided window (the user's selected period)
+  // instead of a wall-clock "last N months from today". This keeps the
+  // comparison aligned with the period the transactions were fetched for.
   const periods = eachMonthOfInterval({ start, end }).map((d) => ({
     key: formatMonthKey(d),
     label: format(d, 'MMM yyyy'),
@@ -223,11 +224,10 @@ export function generateMonthlyComparison(
 
 export function generateWeeklyComparison(
   transactions: Transaction[],
-  weeks: number = 4,
-  end: Date = new Date(),
+  start: Date,
+  end: Date,
 ): { data: CategoryPeriodDatum[]; periods: { key: string; label: string }[] } {
-  const startRange = subWeeks(end, weeks);
-  const periods = eachWeekOfInterval({ start: startRange, end: end }).map((d) => ({
+  const periods = eachWeekOfInterval({ start, end }).map((d) => ({
     key: formatWeekKey(d),
     label: format(d, "'W'II MMM"),
   }));
@@ -275,11 +275,13 @@ export function calculateCategoryDistribution(
 
 export function generateTrendLines(
   transactions: Transaction[],
-  months: number = 6,
-  end: Date = new Date(),
+  start: Date,
+  end: Date,
   filterCategory?: string,
 ): TrendLinePoint[] {
-  const start = startOfMonth(subMonths(end, months - 1));
+  // Bucket into the selected period so quarter/custom selections no longer
+  // drop their earlier months (the old today-anchored window discarded every
+  // transaction outside the trailing months).
   const periods = eachMonthOfInterval({ start, end }).map((d) => ({
     key: formatMonthKey(d),
     label: format(d, 'MMM yyyy'),


### PR DESCRIPTION
## Problem

`CategoryTrends` fetched transactions for the user's **selected period** but every chart re-bucketed them into windows hard-anchored to `new Date()`:

- `generateMonthlyComparison(transactions, 2)` — trailing 2 months from today
- `generateWeeklyComparison(transactions, 4)` — trailing 4 weeks from today
- `generateTrendLines(transactions, 6, new Date(), ...)` — trailing 6 months from today

So the period selector had no effect: the default `month` view showed an **always-0 previous-month column**, a `custom` range that didn't overlap the trailing windows rendered all-zero/empty charts, and a `quarter` selection silently dropped its first month(s).

## Fix

- `generateMonthlyComparison`, `generateWeeklyComparison`, and `generateTrendLines` now bucket into an explicit `start`/`end` window instead of computing one from wall-clock today.
- `CategoryTrends` passes the selected period as that window. Month/week views extend one period back (previous month for the monthly comparison, previous 3 weeks for the weekly comparison) so the comparison columns contain real data.
- The fetch window is extended to cover the comparison window, and the distribution chart, category counts, and header total stay scoped to the exact selected period via a `periodTransactions` filter.

## Files changed

- `src/lib/trendsUtils.ts` — the three chart generators now take explicit `start`/`end` window arguments.
- `src/components/trends/CategoryTrends.tsx` — passes the selected period into the generators, extends the fetch for the comparison window, and scopes distribution/counts to the selected period.

## Testing

- `npx tsc --noEmit` produces no new errors beyond the 4 pre-existing ones on `main`.
- Manually traced the buckets: `month` -> previous + current month; `quarter` -> all 3 quarter months; `custom` -> months within the selected range (no more today-anchored dropping).

Closes #677
