### PR TITLE
fix: stop overwriting per-challenge difficulty on generation (issue 680)

### DIFF
--- a/src/components/challenges/ChallengesDashboard.tsx
+++ b/src/components/challenges/ChallengesDashboard.tsx
@@ -27,7 +27,6 @@ import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import {
   type Challenge,
   type SpendingPattern,
-  type Difficulty,
   type BadgeTier,
   BADGE_META,
   DIFFICULTY_REWARDS,
@@ -35,7 +34,6 @@ import {
   generateWeeklyChallenges,
   generateMonthlyChallenges,
   generateRecommendations,
-  calculateDifficulty,
   awardBadge,
   getProgressPercentage,
   createChallenge,
@@ -226,7 +224,6 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
     }
     setGenerating(true);
     try {
-      const difficulty: Difficulty = calculateDifficulty(spending);
       const weekly = generateWeeklyChallenges(spending);
       const monthly = generateMonthlyChallenges(spending);
       const all = [...weekly, ...monthly];
@@ -240,11 +237,11 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
 
       let created = 0;
       for (const data of newChallenges) {
-        await createChallenge(user.uid, { ...data, difficulty });
+        await createChallenge(user.uid, data);
         created++;
       }
       if (created > 0) {
-        toast.success(`Generated ${created} personalized challenges (${difficulty} difficulty)`);
+        toast.success(`Generated ${created} personalized challenges`);
       } else {
         toast.info('You already have these challenges');
       }


### PR DESCRIPTION
## Problem

`generateChallenges` overwrote every per-challenge difficulty with a single global value (`{ ...data, difficulty }`), clobbering the deliberate per-challenge assignments in `challengeUtils.ts` — e.g. "Reach A 20% Savings Rate" is meant to always be `hard` (400 pts), and "Pause One Subscription This Week" should be `easy`/`hard` based on spend. The completion toast, difficulty badge, and leaderboard points all reflected the wrong tier.

## Fix

Dropped the override: `await createChallenge(user.uid, data)` keeps each challenge's generator-assigned difficulty. `createChallenge` already falls back to `data.difficulty || 'easy'`, so no fallback logic is lost. The now-unused global `difficulty` computation and its `Difficulty`/`calculateDifficulty` imports were removed, and the success toast no longer claims a single global difficulty.

## Files changed

- `src/components/challenges/ChallengesDashboard.tsx` (`generateChallenges`)

## Testing

- `npx tsc --noEmit` produces no new errors beyond the 4 pre-existing ones on `main`.
- All weekly/monthly generators (challengeUtils.ts:151-245) explicitly set `difficulty`, so no challenge loses its intended tier.

Closes #680
