### PR TITLE
fix: pass estimated monthly income into subscription burden (issue 682)

### DIFF
--- a/src/components/subscriptions/SubscriptionAnalyzer.tsx
+++ b/src/components/subscriptions/SubscriptionAnalyzer.tsx
@@ -28,6 +28,7 @@ import {
   fetchUserSubscriptions,
   detectAndSaveSubscriptions,
   generateSubscriptionSummary,
+  estimateMonthlyIncome,
   Subscription,
 } from "@/src/lib/subscriptionUtils";
 
@@ -40,6 +41,7 @@ const FREQUENCY_FILTERS = [
 
 export function SubscriptionAnalyzer({ user }: { user: any }) {
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [estimatedMonthlyIncome, setEstimatedMonthlyIncome] = useState(0);
   const [loading, setLoading] = useState(true);
   const [analyzing, setAnalyzing] = useState(false);
   const [filter, setFilter] = useState<string>("all");
@@ -48,6 +50,7 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
   useEffect(() => {
     if (user?.uid) {
       loadSubscriptions();
+      loadIncome();
     }
   }, [user?.uid]);
 
@@ -61,6 +64,15 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
       toast.error("Failed to load subscriptions");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const loadIncome = async () => {
+    try {
+      const transactions = await fetchUserTransactions(user.uid, 183);
+      setEstimatedMonthlyIncome(estimateMonthlyIncome(transactions));
+    } catch (error) {
+      console.error("Error loading income:", error);
     }
   };
 
@@ -92,8 +104,8 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
   };
 
   const summary = useMemo(() => {
-    return generateSubscriptionSummary(subscriptions);
-  }, [subscriptions]);
+    return generateSubscriptionSummary(subscriptions, estimatedMonthlyIncome);
+  }, [subscriptions, estimatedMonthlyIncome]);
 
   const filteredSubscriptions = useMemo(() => {
     let result = subscriptions;

--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -384,6 +384,22 @@ export function getUpcomingRenewals(
     .sort((a, b) => a.nextRenewalDate.getTime() - b.nextRenewalDate.getTime());
 }
 
+export function estimateMonthlyIncome(
+  transactions: Transaction[],
+  windowMonths: number = 6,
+): number {
+  const incomeByMonth = new Map<string, number>();
+  transactions.forEach((t) => {
+    if (t.type !== "income") return;
+    const key = `${t.date.getFullYear()}-${t.date.getMonth()}`;
+    incomeByMonth.set(key, (incomeByMonth.get(key) || 0) + t.amount);
+  });
+  const monthCount = incomeByMonth.size;
+  if (monthCount === 0) return 0;
+  const total = Array.from(incomeByMonth.values()).reduce((a, b) => a + b, 0);
+  return total / Math.min(monthCount, windowMonths);
+}
+
 export function calculateSubscriptionBurden(
   monthlyCost: number,
   estimatedMonthlyIncome?: number,


### PR DESCRIPTION
## Problem

`generateSubscriptionSummary(subscriptions)` was always called without `estimatedMonthlyIncome`, so `calculateSubscriptionBurden` hit its `!estimatedMonthlyIncome || <= 0` guard and returned `0`. The "Subscription Burden" KPI permanently displayed `0%` and the `subscriptionBurden > 20` "High burden" warning could never fire, silently reporting over-burdened users as safe.

## Fix

- Added `estimateMonthlyIncome(transactions, windowMonths = 6)` in `subscriptionUtils.ts`: sums `type === 'income'` transactions per calendar month and averages over the months that had income (matching the forecast module's pattern), returning `0` when there is no income data.
- `SubscriptionAnalyzer` now fetches the last 6 months of transactions on load (`fetchUserTransactions(user.uid, 183)`), computes the estimate, and passes it into `generateSubscriptionSummary(subscriptions, estimatedMonthlyIncome)`.
- The `isNaN` guard, burden percentage, and "High burden" alert all reflect a real value once income data exists.

## Files changed

- `src/lib/subscriptionUtils.ts` (`estimateMonthlyIncome`)
- `src/components/subscriptions/SubscriptionAnalyzer.tsx` (income state + fetch, summary memo)

## Testing

- `npx tsc --noEmit` produces no new errors beyond the 4 pre-existing ones on `main`.
- Node-based checks: 6 months of ₹1000/mo income -> ₹1000 estimate; 2 income months of ₹2000 -> ₹2000; no income -> 0; single ₹3000 -> ₹3000.

Closes #682
