### PR TITLE
fix: don't burn daily analysis quota on multer-rejected uploads (issue 683)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -857,11 +857,14 @@ async function startServer() {
   // `concurrentAnalyzeLimiter` must run BEFORE `analyzeRateLimiter`: the rate
   // limiter counts every request that reaches it, so a request rejected at the
   // concurrency gate (429 CONCURRENT_LIMIT) must never consume daily quota.
+  // `upload.single` runs before `analyzeRateLimiter` so multer-rejected
+  // uploads (400 bad MIME, 413 LIMIT_FILE_SIZE) don't burn a daily analysis
+  // slot either — only valid files count toward the quota.
   app.post(
     "/api/analyze",
     concurrentAnalyzeLimiter,
-    analyzeRateLimiter,
     upload.single("file"),
+    analyzeRateLimiter,
     async (req: any, res) => {
       try {
 


### PR DESCRIPTION
## Problem

The `/api/analyze` route ran `analyzeRateLimiter` before `upload.single("file")`, so every request that reached the limiter was counted toward the 5/day quota — including ones multer then rejected with a 400 (non-PDF via `fileFilter`) or 413 (`LIMIT_FILE_SIZE`). Five failed uploads exhausted the entire 24h quota and locked the user out, contradicting the deliberate intent (server.ts:856-859) that requests which never run an analysis shouldn't consume a daily slot.

## Fix

Reordered the `/api/analyze` middleware to `concurrentAnalyzeLimiter` → `upload.single("file")` → `analyzeRateLimiter` → handler. Multer now rejects invalid/oversized uploads before the quota counter is touched, so only known-valid files consume a daily analysis slot. The concurrency limiter remains first (its 429s still don't burn quota), and the existing multer error middleware returns the clean 400/413 JSON responses.

## Files changed

- `server.ts` (`/api/analyze` route registration, lines 860-866)

## Testing

- `npx tsc --noEmit` produces no new errors beyond the 4 pre-existing ones on `main`.
- Middleware trace: bad MIME / oversized file -> multer error -> 400/413 (never reaches `analyzeRateLimiter`); concurrency 429 -> still no quota burn; valid file -> rate limiter counts -> handler.

Closes #683
