### PR TITLE
fix: preserve original day-of-month when advancing recurring bills (issue #743)

### DIFF
--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -19,7 +19,6 @@ import {
 import {
   addWeeks,
   addMonths,
-  addYears,
   isBefore,
   startOfDay,
   differenceInCalendarDays,
@@ -71,7 +70,11 @@ function advanceByFrequency(
     next.setDate(Math.min(day, lastDayOfNextMonth));
     return next;
   }
-  if (frequency === 'yearly') return addYears(date, 1);
+  if (frequency === 'yearly') {
+    const day = originalDueDay ?? date.getDate();
+    const lastDay = new Date(date.getFullYear() + 1, date.getMonth() + 1, 0).getDate();
+    return new Date(date.getFullYear() + 1, date.getMonth(), Math.min(day, lastDay));
+  }
   return date;
 }
 
@@ -169,10 +172,11 @@ export function calculateNextDueDate(
   }
 
   const reference = fromDate ? startOfDay(fromDate) : startOfDay(new Date());
+  const originalDay = base.getDate();
   let next = startOfDay(base);
 
   while (isBefore(next, reference)) {
-    next = advanceByFrequency(next, frequency);
+    next = advanceByFrequency(next, frequency, originalDay);
   }
 
   return next.toISOString();


### PR DESCRIPTION
## Problem
Recurring bills drift at month ends. A bill set for Jan 31 advances to Feb 28, and then the next cycle is re-anchored on Feb 28, so the due date keeps drifting forward (Mar 28, Apr 28, ...) instead of staying at the end of month. Yearly bills set on Feb 29 drift in non-leap years.

## Fix
- `advanceByFrequency` yearly branch now preserves the original day of month (Feb 29 rolls to Feb 28 in non-leap years instead of drifting).
- `calculateNextDueDate` threads the original day through the entire recurring chain via `advanceByFrequency(next, frequency, originalDay)` instead of re-anchoring on each computed due date.
- Removed the now-unused `addYears` import.

## Files changed
- `src/lib/billUtils.ts`

## Testing
- Verified edge cases numerically: Jan 31 monthly -> 2026-09-30; Jan 30 monthly -> 2026-09-30; Mar 31 monthly -> 2026-09-30; Feb 29 yearly -> 2027-02-28.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #743
