### PR TITLE
fix: correct Conservative/Aggressive goal contribution suggestions (issue #745)

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -46,11 +46,7 @@ export function calculateDaysRemaining(deadline: string): number {
 export function generateContributionSuggestions(
   targetAmount: number,
   currentAmount: number,
-  deadline: string,
-  options: {
-    conservative?: boolean;
-    aggressive?: boolean;
-  } = {}
+  deadline: string
 ): { label: string; amount: number }[] {
   const remaining = targetAmount - currentAmount;
   if (remaining <= 0) return [{ label: 'Goal reached', amount: 0 }];
@@ -67,11 +63,11 @@ export function generateContributionSuggestions(
     },
     {
       label: 'Conservative',
-      amount: Math.ceil(baseMonthly * (options.conservative ? 0.85 : 1.2)),
+      amount: Math.ceil(baseMonthly * 0.85),
     },
     {
       label: 'Aggressive',
-      amount: Math.max(1, Math.floor(baseMonthly * (options.aggressive ? 1.2 : 0.85))),
+      amount: Math.max(1, Math.floor(baseMonthly * 1.2)),
     },
   ];
 


### PR DESCRIPTION
## Problem
The Conservative and Aggressive goal contribution suggestions are swapped. The "Aggressive" plan shows the base monthly contribution while the Recommended label shows a higher amount, so the labels and values don't match.

## Fix
- Removed the `options` parameter from `generateContributionSuggestions`.
- Each label is now derived directly from the base amount: Recommended = base, Conservative = `ceil(base * 0.85)`, Aggressive = `max(1, floor(base * 1.2))`.

## Files changed
- `src/lib/goalUtils.ts`

## Testing
- Verified the label/value mapping with self-contained test cases covering all three plans.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #745
