### PR TITLE
fix: project goal timeline until target instead of capping at 24 months (issue #746)

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -89,9 +89,8 @@ export function generateTimelineProjection(
   const projection: { month: string; projected: number }[] = [];
   let running = currentAmount;
 
-  for (let i = 1; i <= 24 && running < targetAmount; i++) {
-    running += monthlyContribution;
-    if (running > targetAmount) running = targetAmount;
+  for (let i = 1; running < targetAmount && i <= 600; i++) {
+    running = Math.min(targetAmount, running + monthlyContribution);
     projection.push({
       month: format(addMonths(now, i), 'MMM yyyy'),
       projected: Math.round(running),


### PR DESCRIPTION
## Problem
The goal timeline projection stops after 24 months even when the target amount has not been reached, so long-term goals are shown as never reaching their target.

## Fix
- The projection loop now runs until `running >= targetAmount` with a safety cap of 600 iterations to prevent runaway loops.
- Each running total is clamped with `Math.min(targetAmount, ...)` so the final entry lands exactly on the target instead of overshooting.

## Files changed
- `src/lib/goalUtils.ts`

## Testing
- Verified the loop exits at the target and the cap prevents infinite iteration for very large goals.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #746
