### PR TITLE
fix: detect new-category spikes and scale spike delta to category history (issue #747)

### DIFF
--- a/src/components/anomaly/AnomalyDashboard.tsx
+++ b/src/components/anomaly/AnomalyDashboard.tsx
@@ -383,17 +383,19 @@ async function runDetection(userId: string) {
   });
 
   categorySpikeAnomalies.forEach((spike) => {
+    const monthlyTotals = spike.baseline?.monthlyTotals ?? [];
     const confidence = calculateConfidenceScore(
       "category_spike",
       spike.amount,
-      spike.baseline.mean,
-      spike.baseline.stdDev,
+      spike.baseline?.mean ?? spike.amount,
+      spike.baseline?.stdDev ?? 0,
     );
     const lastMonthTotal =
-      spike.baseline.monthlyTotals[spike.baseline.monthlyTotals.length - 1];
+      monthlyTotals[monthlyTotals.length - 1] ?? spike.amount;
     const avgMonthly =
-      spike.baseline.monthlyTotals.reduce((a, b) => a + b, 0) /
-      spike.baseline.monthlyTotals.length;
+      monthlyTotals.length > 0
+        ? monthlyTotals.reduce((a, b) => a + b, 0) / monthlyTotals.length
+        : lastMonthTotal;
     const pctOver =
       avgMonthly > 0 ? Math.round((lastMonthTotal / avgMonthly - 1) * 100) : 0;
 
@@ -402,7 +404,9 @@ async function runDetection(userId: string) {
       type: "category_spike",
       category: spike.category,
       amount: spike.amount,
-      description: `${spike.category} spending is ${pctOver}% above the 3-month average.`,
+      description: spike.baseline
+        ? `${spike.category} spending is ${pctOver}% above the 3-month average.`
+        : `${spike.category} is a new spending category with ${spike.amount.toLocaleString()} this month.`,
       confidence,
       transactionId:
         spike.transactions[spike.transactions.length - 1]?.id || "",

--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -150,7 +150,7 @@ export function detectCategorySpikes(
 ): Array<{
   category: string;
   amount: number;
-  baseline: CategoryBaseline;
+  baseline: CategoryBaseline | null;
   transactions: Transaction[];
 }> {
   const currentMonth = format(new Date(), "yyyy-MM");
@@ -163,21 +163,41 @@ export function detectCategorySpikes(
     byCategory.set(category, [...(byCategory.get(category) || []), transaction]);
   });
 
+  // Overall per-category average used as a sanity floor for categories with
+  // no prior baseline (i.e. brand-new spending categories).
+  const categoryAverages = Array.from(baseline.values())
+    .map((catBaseline) => {
+      const previousTotals = catBaseline.monthlyTotals.slice(0, -1);
+      return previousTotals.length > 0
+        ? previousTotals.reduce((sum, total) => sum + total, 0) / previousTotals.length
+        : 0;
+    })
+    .filter((avg) => avg > 0);
+  const averageAllCategories =
+    categoryAverages.length > 0
+      ? categoryAverages.reduce((sum, avg) => sum + avg, 0) / categoryAverages.length
+      : 0;
+
   return Array.from(byCategory.entries())
     .map(([category, items]) => {
-      const categoryBaseline = baseline.get(category);
+      const categoryBaseline = baseline.get(category) || null;
       const amount = items.reduce((sum, item) => sum + Math.abs(item.amount), 0);
-      return categoryBaseline
-        ? { category, amount, baseline: categoryBaseline, transactions: items }
-        : null;
+      return { category, amount, baseline: categoryBaseline, transactions: items };
     })
-    .filter((item): item is NonNullable<typeof item> => {
-      if (!item || item.baseline.monthlyTotals.length < 2) return false;
+    .filter((item) => {
+      if (!item.baseline) {
+        return averageAllCategories > 0 && item.amount > averageAllCategories * 2;
+      }
+      if (item.baseline.monthlyTotals.length < 2) return false;
       const previousTotals = item.baseline.monthlyTotals.slice(0, -1);
       const average =
         previousTotals.reduce((sum, total) => sum + total, 0) /
         previousTotals.length;
-      return average > 0 && item.amount > average * 1.5 && item.amount - average > 500;
+      return (
+        average > 0 &&
+        item.amount > average * 1.5 &&
+        item.amount - average > Math.max(20, average * 0.5)
+      );
     });
 }
 


### PR DESCRIPTION
## Problem
`detectCategorySpikes` silently drops brand-new categories that have no prior-period baseline, and its flat `$500` delta gate misses meaningful smaller spikes while flagging noise.

## Fix
- `detectCategorySpikes` now returns `baseline: CategoryBaseline | null`.
- Brand-new categories (no prior-period spending) are flagged when their amount exceeds 2x the average across all categories.
- Existing categories are flagged when `amount - average > Math.max(20, average * 0.5)`.
- `AnomalyDashboard.tsx` guards for a null baseline when computing confidence, percent over, and the description.

## Files changed
- `src/lib/anomalyUtils.ts`
- `src/components/anomaly/AnomalyDashboard.tsx`

## Testing
- Verified new-category and existing-category spike detection with self-contained test cases.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #747
