### PR TITLE
fix: scale category_spike delta threshold to category history (issue #748)

### DIFF
--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -286,10 +286,11 @@ export function detectAnomalies(
   if (thisMonthData && lastMonthData) {
     thisMonthData.forEach((amount, cat) => {
       const lastAmount = lastMonthData.get(cat) || 0;
+      const minDelta = Math.max(50, lastAmount * 0.5);
       if (
         lastAmount > 0 &&
         amount > lastAmount * 1.5 &&
-        amount - lastAmount > 5000
+        amount - lastAmount > minDelta
       ) {
         anomalies.push({
           userId: transactions[0]?.userId || "",


### PR DESCRIPTION
## Problem
A `category_spike` anomaly requires a delta of more than $5,000 (`lastAmount - average > 5000`), so most legitimate spikes are never reported regardless of the category's normal spend level.

## Fix
- Replaced the flat `> 5000` gate with a threshold derived from the category's own history: `minDelta = Math.max(50, lastAmount * 0.5)`.

## Files changed
- `src/lib/anomalyUtils.ts`

## Testing
- Verified spikes are now flagged proportionally (e.g., a small category with a >50% jump, and a large category with a >50% jump) and flat thresholds no longer suppress valid spikes.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #748
