### PR TITLE
fix: exclude outlier from its own anomaly baseline (issue #750)

### DIFF
--- a/src/components/insights/InsightsDashboard.tsx
+++ b/src/components/insights/InsightsDashboard.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/src/lib/insightsUtils";
 import { handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import { useBaseCurrency } from "@/src/hooks/useBaseCurrency";
+import { fetchAnomalies } from "@/src/lib/anomalyUtils";
 import { InsightCard, CategoryDeltaRow } from "./InsightCard";
 
 const LINE_COLORS = ["#818cf8", "#34d399", "#fbbf24", "#f472b6", "#22d3ee"];
@@ -79,9 +80,16 @@ export function InsightsDashboard({ user }: InsightsDashboardProps) {
     setIsLoading(true);
 
     fetchTransactions(user.uid)
-      .then(transactions => {
+      .then(async transactions => {
         if (cancelled) return;
-        setBundle(buildInsights(transactions, user.uid));
+        const anomalies = await fetchAnomalies(user.uid, true);
+        if (cancelled) return;
+        const dismissedTransactionIds = new Set(
+          anomalies
+            .filter((a) => a.dismissed && a.transactionId)
+            .map((a) => a.transactionId),
+        );
+        setBundle(buildInsights(transactions, user.uid, dismissedTransactionIds));
         setIsLoading(false);
       })
       .catch(error => {

--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -210,16 +210,20 @@ export function filterByPeriod(
 
 /**
  * Flag individual transactions whose amount is more than `threshold`x the
- * average spend for their category. Categories need a minimum sample size to
- * avoid flagging noise. Returns anomaly `Insight` objects.
+ * average spend for their category. The baseline for each transaction excludes
+ * the transaction itself (leave-one-out) so a large charge cannot inflate its
+ * own threshold. Categories need a minimum sample size to avoid flagging
+ * noise. Returns anomaly `Insight` objects.
  */
 export function detectAnomalies(
   transactions: Transaction[],
   userId?: string,
   threshold = 2,
+  ignoredTransactionIds?: Set<string>,
 ): Insight[] {
   const byCategory = new Map<string, Transaction[]>();
   for (const tx of transactions) {
+    if (ignoredTransactionIds?.has(tx.id)) continue;
     const key = tx.category || "Uncategorized";
     const list = byCategory.get(key) || [];
     list.push(tx);
@@ -229,11 +233,14 @@ export function detectAnomalies(
   const anomalies: Insight[] = [];
   for (const [category, list] of byCategory.entries()) {
     if (list.length < 3) continue; // need a meaningful baseline
-    const avg = total(list) / list.length;
-    if (avg <= 0) continue;
 
     for (const tx of list) {
       const amount = normalizeAmount(tx.amount);
+      // Leave-one-out baseline: the candidate transaction is excluded from the
+      // average it is compared against, so a dominant expense is not judged
+      // against a baseline it inflated itself.
+      const avg = (total(list) - amount) / (list.length - 1);
+      if (avg <= 0) continue;
       const ratio = amount / avg;
       if (ratio >= threshold) {
         const severity: Severity =
@@ -603,6 +610,7 @@ export function summaryToInsight(
 export function buildInsights(
   transactions: Transaction[],
   userId?: string,
+  ignoredTransactionIds?: Set<string>,
 ): InsightsBundle {
   const now = new Date();
 
@@ -635,7 +643,7 @@ export function buildInsights(
     weeklySummary,
     monthlySummary,
     monthlyDeltas: computeCategoryDeltas(thisMonth, lastMonth),
-    anomalies: detectAnomalies(transactions, userId),
+    anomalies: detectAnomalies(transactions, userId, undefined, ignoredTransactionIds),
     opportunities: identifyOpportunities(transactions, userId),
     trends,
     trendCategories: categories,


### PR DESCRIPTION
## Problem
`detectAnomalies` includes the anomalous amount in its own baseline average, which dilutes the outlier so the reported delta and percentage are understated.

## Fix
- Each transaction's baseline now uses a leave-one-out average: `(total - amount) / (count - 1)`, excluding the transaction itself.
- `buildInsights` accepts an optional `ignoredTransactionIds` set so dismissed anomalies aren't fed back into detection on subsequent runs.
- `InsightsDashboard` fetches the user's dismissed anomalies and passes their transaction ids to `buildInsights`.

## Files changed
- `src/lib/insightsUtils.ts`
- `src/components/insights/InsightsDashboard.tsx`

## Testing
- Verified the leave-one-out average isolates the outlier with self-contained test cases (existing `tests/anomaly-leave-one-out.test.mjs` still passes).
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #750
