### PR TITLE
fix: align weekly trend buckets to Monday-start ISO weeks (issue #755)

### DIFF
--- a/src/lib/trendsUtils.ts
+++ b/src/lib/trendsUtils.ts
@@ -88,7 +88,7 @@ export function formatMonthKey(date: Date): string {
 }
 
 export function formatWeekKey(date: Date): string {
-  return format(date, "yyyy-'W'II");
+  return format(date, "RRRR-'W'II");
 }
 
 export function formatPeriodLabel(period: string, type: TrendPeriod): string {
@@ -163,7 +163,7 @@ export function groupByCategoryAndPeriod(
         key: formatMonthKey(d),
         label: format(d, 'MMM yyyy'),
       }))
-    : eachWeekOfInterval({ start: config.startDate, end: config.endDate }).map((d) => ({
+    : eachWeekOfInterval({ start: config.startDate, end: config.endDate }, { weekStartsOn: 1 as const }).map((d) => ({
         key: formatWeekKey(d),
         label: format(d, "'W'II MMM"),
       }));
@@ -227,7 +227,7 @@ export function generateWeeklyComparison(
   start: Date,
   end: Date,
 ): { data: CategoryPeriodDatum[]; periods: { key: string; label: string }[] } {
-  const periods = eachWeekOfInterval({ start, end }).map((d) => ({
+  const periods = eachWeekOfInterval({ start, end }, { weekStartsOn: 1 as const }).map((d) => ({
     key: formatWeekKey(d),
     label: format(d, "'W'II MMM"),
   }));
@@ -321,13 +321,15 @@ export function buildPeriodConfig(
   customEnd?: Date,
 ): PeriodConfig {
   switch (type) {
-    case 'week':
+    case 'week': {
+      const weekStart = startOfWeek(now, { weekStartsOn: 1 as const });
       return {
         type,
-        startDate: startOfWeek(now),
-        endDate: endOfWeek(now),
-        label: `Week of ${format(startOfWeek(now), 'MMM d')}`,
+        startDate: weekStart,
+        endDate: endOfWeek(now, { weekStartsOn: 1 as const }),
+        label: `Week of ${format(weekStart, 'MMM d')}`,
       };
+    }
     case 'quarter': {
       const qStartMonth = Math.floor(now.getMonth() / 3) * 3;
       const qStart = startOfMonth(new Date(now.getFullYear(), qStartMonth, 1));


### PR DESCRIPTION
## Problem
Weekly trend buckets drop Monday through Saturday data. Period boundaries use Sunday-start weeks (`eachWeekOfInterval` / `startOfWeek` defaults) while the bucket keys use ISO week numbers (`yyyy-'W'II`, Monday-start), so transactions from Mon-Sat land on keys that never match a generated period and are lost from the chart.

## Fix
- All weekly bucketing now uses Monday-start weeks via `weekStartsOn: 1` in `eachWeekOfInterval` and `buildPeriodConfig`.
- `formatWeekKey` uses the ISO week year (`RRRR` instead of `yyyy`) so weeks that cross a year boundary are keyed consistently.

## Files changed
- `src/lib/trendsUtils.ts`

## Testing
- Verified with a Mon-Sun window that all seven days' transactions now land in the generated period (Sunday 10 + Mon-Sat 270 = 280 preserved).
- Verified a week spanning Dec 29 2025 - Jan 4 2026 buckets into a single `2026-W01` key instead of splitting.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #755
