### PR TITLE
fix: exclude partial current month from budget suggestion average (issue #756)

### DIFF
--- a/src/lib/budgetUtils.ts
+++ b/src/lib/budgetUtils.ts
@@ -360,7 +360,8 @@ async function fetchUserTransactionsInRange(
 export async function fetchLast3MonthsTransactions(userId: string): Promise<Transaction[]> {
   const now = new Date();
   const startDate = new Date(now.getFullYear(), now.getMonth() - 2, 1);
-  return fetchUserTransactionsInRange(userId, startDate, null);
+  const endDate = new Date(now.getFullYear(), now.getMonth(), 1);
+  return fetchUserTransactionsInRange(userId, startDate, endDate);
 }
 
 export async function fetchPreviousMonthTransactions(userId: string): Promise<Transaction[]> {


### PR DESCRIPTION
## Problem
Budget suggestions average the partial current month as if it were a full month, dragging category averages (and therefore suggested budgets) downward.

## Fix
- `fetchLast3MonthsTransactions` now caps the fetch window at the first of the current month (`endDate`), matching the existing `fetchPreviousMonthTransactions` pattern, so only complete months are included in the average.

## Files changed
- `src/lib/budgetUtils.ts`

## Testing
- Verified the window is now `[first of month-2, first of current month)`; `fetchUserTransactionsInRange` already excludes any transaction on or after the end date.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #756
