### PR TITLE
fix: load 6-month transaction history in chat assistant (issue #757)

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -45,7 +45,7 @@ import {
   Cell,
   Legend,
 } from 'recharts';
-import { format } from 'date-fns';
+import { format, startOfMonth, subMonths } from 'date-fns';
 
 import { Card, CardContent } from '@/src/components/ui/card';
 import { Button } from '@/src/components/ui/button';
@@ -71,7 +71,6 @@ import {
   fetchTransactionsForPeriod,
   buildPeriodConfig,
   type Transaction,
-  type TrendPeriod,
 } from '@/src/lib/trendsUtils';
 import { fetchBudgetCategories } from '@/src/lib/budgetUtils';
 
@@ -108,17 +107,15 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
 
   const currentUserId = user?.uid || '';
 
-  const period = useMemo<TrendPeriod>(() => 'month', []);
-
   const periodConfig = useMemo(
     () =>
       buildPeriodConfig(
-        period,
+        'custom',
         new Date(),
-        undefined,
-        undefined,
+        startOfMonth(subMonths(new Date(), 5)),
+        new Date(),
       ),
-    [period],
+    [],
   );
 
   useEffect(() => {

--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -286,7 +286,7 @@ export function generateSpendingSummary(context: FinancialContext): ChatResponse
   const { totalSpending, totalIncome, monthlySpending, spendingByMonth, topCategories } = context;
   const currentMonth = format(new Date(), 'yyyy-MM');
   const currentMonthSpending = monthlySpending[currentMonth] || 0;
-  const avgMonthly = spendingByMonth.length > 0
+  const avgMonthly = spendingByMonth.length > 1
     ? Math.round(spendingByMonth.reduce((sum, m) => sum + m.amount, 0) / spendingByMonth.length)
     : 0;
 


### PR DESCRIPTION
## Problem
The chat assistant only ever loads the current month's transactions, so `analyzeSpendingPatterns` always answers "I need more transaction data" and `generateSpendingSummary` compares this month against itself (diff is always $0).

## Fix
- `ChatAssistant` now fetches a real history window via `buildPeriodConfig('custom', now, startOfMonth(subMonths(now, 5)), now)` instead of the hard-coded `'month'` period, so the context spans 6 months.
- `generateSpendingSummary` only computes the "higher/lower than your average" comparison when `spendingByMonth.length > 1`; with a single data point it omits the meaningless comparison.

## Files changed
- `src/components/chat/ChatAssistant.tsx`
- `src/lib/chatUtils.ts`

## Testing
- Verified `spendingByMonth` now spans multiple months so pattern analysis and month-over-month comparison produce real results.
- `npm run typecheck` reports only the 4 pre-existing errors in `api/analyze.ts` / `api/process.ts` (unrelated to this change).

Closes #757
