### PR TITLE
fix: replaced hardcoded dollar signs with formatCurrency in notifications

### DIFF
--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -14,6 +14,7 @@ import { Calendar, AlertTriangle, Trash2, RefreshCw } from "lucide-react";
 import { format, differenceInDays } from "date-fns";
 import { toast } from "sonner";
 import { Subscription } from "@/src/lib/subscriptionUtils";
+import { formatCurrency } from "@/src/lib/utils";
 import {
   updateSubscription,
   deleteSubscription,
@@ -74,7 +75,7 @@ export function SubscriptionCard({
       setTimeout(
         () => {
           new Notification("Subscription Renewal Reminder", {
-            body: `${subscription.name} ($${subscription.amount.toFixed(2)}) renews soon.`,
+            body: `${subscription.name} (${formatCurrency(subscription.amount)}) renews soon.`,
             icon: "/vite.svg",
           });
         },
@@ -128,7 +129,7 @@ export function SubscriptionCard({
               <div className="flex items-center gap-3 text-xs text-slate-400">
                 <span className="font-medium">{frequencyLabel}</span>
                 <span className="text-slate-600">|</span>
-                <span>${subscription.amount.toFixed(2)}</span>
+                <span>{formatCurrency(subscription.amount)}</span>
               </div>
             </div>
             <div className="flex items-center gap-1.5">
@@ -181,15 +182,14 @@ export function SubscriptionCard({
                   Annual Cost
                 </span>
                 <span className="text-indigo-400 font-mono font-bold">
-                  $
-                  {(
+                  {formatCurrency(
                     subscription.amount *
                     (subscription.frequency === "monthly"
                       ? 12
                       : subscription.frequency === "yearly"
                         ? 1
                         : 52)
-                  ).toFixed(2)}
+                  )}
                 </span>
               </div>
               <Progress

--- a/src/lib/notificationUtils.ts
+++ b/src/lib/notificationUtils.ts
@@ -4,6 +4,8 @@
  * Uses the Notification API with Firebase Cloud Messaging support
  */
 
+import { formatCurrency } from './utils';
+
 export interface NotificationPermission {
   granted: boolean;
   canRequest: boolean;
@@ -89,7 +91,7 @@ export async function scheduleSubscriptionReminder(
   if (daysUntilRenewal === 1) {
     await showNotification({
       title: '📅 Subscription Renewal Tomorrow',
-      body: `${subscriptionName} renews tomorrow for $${amount.toFixed(2)}`,
+      body: `${subscriptionName} renews tomorrow for ${formatCurrency(amount)}`,
       tag: `subscription-${subscriptionName}`,
       requireInteraction: true,
     });
@@ -99,7 +101,7 @@ export async function scheduleSubscriptionReminder(
   if (daysUntilRenewal === 0) {
     await showNotification({
       title: '🔔 Subscription Due Today',
-      body: `${subscriptionName} renews today for $${amount.toFixed(2)}`,
+      body: `${subscriptionName} renews today for ${formatCurrency(amount)}`,
       tag: `subscription-${subscriptionName}`,
       requireInteraction: true,
     });
@@ -117,7 +119,7 @@ export async function sendBudgetAlert(
   
   return showNotification({
     title: overBudget ? '⚠️ Budget Exceeded!' : '💰 Budget Alert',
-    body: `${category}: $${spent.toFixed(2)} of $${limit.toFixed(2)} (${percentageUsed.toFixed(0)}%)`,
+    body: `${category}: ${formatCurrency(spent)} of ${formatCurrency(limit)} (${percentageUsed.toFixed(0)}%)`,
     tag: `budget-${category}`,
     requireInteraction: overBudget,
   });
@@ -131,7 +133,7 @@ export async function sendAnomalyAlert(
 ): Promise<Notification | null> {
   return showNotification({
     title: '🚨 Unusual Transaction Detected',
-    body: `$${amount.toFixed(2)} ${category}: ${description.substring(0, 50)}...`,
+    body: `${formatCurrency(amount)} ${category}: ${description.substring(0, 50)}...`,
     tag: 'anomaly-alert',
     requireInteraction: true,
   });


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced all hardcoded `$` dollar symbols with the `formatCurrency()` utility function in notification and subscription card display code. The `formatCurrency()` function respects the application's configured default currency, so notifications now display amounts in the user's currency instead of always showing USD.

## Changes Made

- `src/lib/notificationUtils.ts`: Added `import { formatCurrency } from './utils'` and replaced 4 hardcoded `$` string interpolations with `formatCurrency(amount)` calls
- `src/components/subscriptions/SubscriptionCard.tsx`: Added `import { formatCurrency } from '@/src/lib/utils'` and replaced 4 hardcoded `$` displays with `formatCurrency()` calls

## Impact it Made

- Notifications correctly display amounts in the user's configured base currency
- Fixes issue #823

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #823