### PR TITLE
fix: excluded current transaction from category baseline in detectAnomalies

### DIFF
--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -238,9 +238,12 @@ export function detectAnomalies(
     const cat = t.category || "Other";
     const avg = categoryAverages.get(cat);
     if (avg && avg.count > 1) {
-      const mean = avg.total / avg.count;
+      // Exclude the current transaction from the baseline so it cannot inflate the mean
+      const baselineCount = avg.count - 1;
+      const baselineTotal = avg.total - Math.abs(t.amount);
+      const mean = baselineCount > 0 ? baselineTotal / baselineCount : 0;
       const amount = Math.abs(t.amount);
-      if (amount > mean * 3 && amount > 1000) {
+      if (mean > 0 && amount > mean * 3 && amount > 1000) {
         anomalies.push({
           userId: t.userId,
           transactionId: t.id,


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed `detectAnomalies` in `src/lib/anomalyUtils.ts` to compute the category baseline mean excluding the current transaction under evaluation. Previously, the function included the current transaction's amount in both the baseline average and the outlier check, systematically under-detecting large transactions.

## Changes Made

- `src/lib/anomalyUtils.ts`: Added `baselineCount = avg.count - 1`, `baselineTotal = avg.total - Math.abs(t.amount)`, and `mean = baselineCount > 0 ? baselineTotal / baselineCount : 0` before the outlier check. Also added `mean > 0 &&` to the threshold condition.

## Impact it Made

- Anomaly detection now correctly flags truly large transactions by comparing them against a clean baseline
- Eliminates systematic under-detection bias for large single transactions
- Fixes issue #825

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #825