### PR TITLE
fix: returned real document id from addDoc for buy transactions in addTransaction

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -297,11 +297,13 @@ export async function addTransaction(userId: string, input: TransactionInput): P
       }
     }
 
+    let transactionId = id;
     if (input.type === 'buy') {
-      await addDoc(collection(db, 'portfolioTransactions'), {
+      const ref = await addDoc(collection(db, 'portfolioTransactions'), {
         ...transaction,
         createdAt: serverTimestamp(),
       });
+      transactionId = ref.id;
     } else {
       await setDoc(doc(db, 'portfolioTransactions', id), {
         ...transaction,
@@ -309,7 +311,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
       });
     }
 
-    return { ...transaction, id: id || '' };
+    return { ...transaction, id: transactionId || '' };
   } catch (error) {
     console.error('Error adding transaction:', error);
     handleFirestoreError(error, OperationType.CREATE, 'portfolioTransactions');


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the `addTransaction` function in `src/lib/portfolioUtils.ts` to capture and return the real Firestore document id when creating buy transactions. Previously, buy transactions used `addDoc()` which returns a `DocumentReference` with an auto-generated id, but this id was discarded. The function always returned `id || ''` (where `id` was only set for non-buy transactions), resulting in phantom empty-string ids for all buy transactions.

## Changes Made

- `src/lib/portfolioUtils.ts`: Introduced `let transactionId = id`, captured `ref.id` from `addDoc` for buy transactions, and returned `{ ...transaction, id: transactionId || '' }`

## Impact it Made

- Buy transactions now return a real, trackable Firestore document id
- Callers can reference the created transaction for UI display or linking
- Fixes issue #826

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #826