### PR TITLE
fix(categorization): ignore empty and whitespace keywords in auto-categorization rules 

### DIFF
--- a/src/lib/categorizationUtils.ts
+++ b/src/lib/categorizationUtils.ts
@@ -18,6 +18,8 @@ export interface TransactionRule {
  * It checks each active rule to see if the transaction description
  * contains the rule's keyword (case-insensitive).
  *
+ * Empty or whitespace-only keywords are ignored and never match.
+ *
  * @param description The transaction description text
  * @param rules Array of categorization rules configured by the user
  * @returns The assigned category if a rule matches, or null if no match is found
@@ -35,7 +37,8 @@ export function applyCategorizationRules(
   for (const rule of rules) {
     if (!rule.isActive) continue;
 
-    if (normalizedDesc.includes(rule.keyword.toLowerCase())) {
+    const normalizedKeyword = rule.keyword.trim().toLowerCase();
+    if (normalizedKeyword.length > 0 && normalizedDesc.includes(normalizedKeyword)) {
       return rule.assignedCategory;
     }
   }

--- a/tests/categorization-rules.test.mjs
+++ b/tests/categorization-rules.test.mjs
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyCategorizationRules } from "../src/lib/categorizationUtils.ts";
+
+function rule(keyword, assignedCategory, isActive = true) {
+  return {
+    id: "rule-1",
+    userId: "user-1",
+    keyword,
+    assignedCategory,
+    isActive,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// 1. Empty keyword: rule does not match
+test("empty keyword does not match any description", () => {
+  const rules = [rule("", "Software")];
+  assert.equal(applyCategorizationRules("STARBUCKS COFFEE", rules), null);
+  assert.equal(applyCategorizationRules("ANY TRANSACTION", rules), null);
+  assert.equal(applyCategorizationRules("GAS STATION", rules), null);
+});
+
+// 2. Whitespace-only keyword: rule does not match
+test("whitespace-only keyword does not match any description", () => {
+  const rules = [rule("   ", "Software")];
+  assert.equal(applyCategorizationRules("STARBUCKS COFFEE", rules), null);
+  assert.equal(applyCategorizationRules("GAS STATION", rules), null);
+});
+
+// 3. Whitespace around a valid keyword: trimmed keyword matches
+test("keyword with surrounding whitespace is trimmed and matches", () => {
+  const rules = [rule("  coffee  ", "Coffee & Dining")];
+  assert.equal(
+    applyCategorizationRules("STARBUCKS COFFEE", rules),
+    "Coffee & Dining",
+  );
+});
+
+// 4. Valid keyword continues to match (case-insensitive)
+test("valid keyword matches case-insensitively", () => {
+  const rules = [rule("Coffee", "Coffee & Dining")];
+  assert.equal(
+    applyCategorizationRules("STARBUCKS COFFEE", rules),
+    "Coffee & Dining",
+  );
+  assert.equal(
+    applyCategorizationRules("starbucks coffee", rules),
+    "Coffee & Dining",
+  );
+});
+
+// 5. Rule priority/order is preserved (first matching rule wins)
+test("rule priority: first matching active rule wins", () => {
+  const rules = [
+    rule("starbucks", "Coffee"),
+    rule("coffee", "General Dining"),
+  ];
+  assert.equal(applyCategorizationRules("STARBUCKS COFFEE", rules), "Coffee");
+});
+
+// 6. Inactive rules are skipped
+test("inactive rules do not match", () => {
+  const rules = [rule("starbucks", "Coffee", false)];
+  assert.equal(applyCategorizationRules("STARBUCKS COFFEE", rules), null);
+});
+
+// 7. No rules: returns null
+test("empty rules array returns null", () => {
+  assert.equal(applyCategorizationRules("STARBUCKS COFFEE", []), null);
+});
+
+// 8. Valid keyword does not match unrelated descriptions
+test("valid keyword does not match unrelated descriptions", () => {
+  const rules = [rule("coffee", "Coffee & Dining")];
+  assert.equal(applyCategorizationRules("GAS STATION", rules), null);
+  assert.equal(applyCategorizationRules("SUPERMARKET", rules), null);
+  assert.equal(applyCategorizationRules("SALARY DEPOSIT", rules), null);
+});


### PR DESCRIPTION
## Summary
Fixes #841 by ignoring empty and whitespace-only keywords during automatic transaction categorization.

### Root Cause
JavaScript's `String.prototype.includes()` returns `true` when evaluated against an empty string (`"".includes("") === true`). Rules configured with empty (`""`) or whitespace-only (`"   "`) keywords matched all incoming transaction descriptions, improperly re-assigning their categories.

### Changes
* Trim surrounding whitespace and normalize keywords before containment matching in `src/lib/categorizationUtils.ts`.
* Ignore empty (`""`) and whitespace-only (`"   "`) keywords so they never match transactions.
* Preserve rule priority/order, case-insensitivity, and inactive-rule behavior.
* Added regression unit tests in `tests/categorization-rules.test.mjs`.

### Testing
* `node --experimental-strip-types --test tests/categorization-rules.test.mjs` (8/8 tests passed)

### Scope
Intentionally limited to `src/lib/categorizationUtils.ts` and its targeted regression test file.
