### PR TITLE
Fix process.ts to use modular getFirestore API with named database

### DIFF
--- a/api/process.ts
+++ b/api/process.ts
@@ -30,7 +30,17 @@ function getEnv(key: string, fallback = ""): string {
 function getFirebaseProjectId(): string {
   return getEnv("FIREBASE_PROJECT_ID") || getEnv("VITE_FIREBASE_PROJECT_ID");
 }
-
+// Mirrors api/analyze.ts's resolution exactly, so both serverless handlers
+// agree on which Firestore database they read/write — a mismatch here would
+// mean /api/process silently persists to a different database than
+// /api/analyze and server.ts read from.
+function getFirestoreDatabaseId(): string {
+  return (
+    getEnv("FIREBASE_FIRESTORE_DATABASE_ID") ||
+    getEnv("VITE_FIREBASE_FIRESTORE_DATABASE_ID") ||
+    "(default)"
+  );
+}
 // Strip path separators and traversal segments from client-supplied filenames
 // before they become part of a Storage object path. Without this, a raw
 // filename such as "team/Q3.pdf" or "report_.._final.pdf" produces an object
@@ -364,6 +374,7 @@ async function getAdminApp(): Promise<any | null> {
 
   try {
     const { default: admin } = await import("firebase-admin");
+    const { getFirestore } = await import("firebase-admin/firestore");
 
     if (!admin.apps.length) {
       const storageBucket = getEnv("VITE_FIREBASE_STORAGE_BUCKET") || `${projectId}.firebasestorage.app`;
@@ -390,7 +401,7 @@ async function getAdminApp(): Promise<any | null> {
 
     _adminApp = {
       admin,
-      getFirestore: () => admin.firestore(),
+      getFirestore: () => getFirestore(admin.app(), getFirestoreDatabaseId()),
     };
     return _adminApp;
   } catch (err: any) {

--- a/tests/firestore-database-consistency.test.mjs
+++ b/tests/firestore-database-consistency.test.mjs
@@ -39,7 +39,7 @@ test("server.ts routes Firestore calls through firestoreDatabaseId", () => {
 
 test("serverless handlers persist to the configured Firestore database", () => {
   assert.ok(
-    processApi.includes("admin.firestore(getFirestoreDatabaseId())"),
+    processApi.includes("getFirestore(admin.app(), getFirestoreDatabaseId())"),
     "api/process.ts must resolve Firestore with getFirestoreDatabaseId()",
   );
   assert.ok(


### PR DESCRIPTION
Fixes #703

## Problem
`api/process.ts` was calling `admin.firestore()` with no argument, so it
always read/wrote the default Firestore database regardless of the
configured database ID env var — unlike `api/analyze.ts`, which already
resolved the correct named database.

## Fix
- Added `getFirestoreDatabaseId()` usage in `api/process.ts`, switching
  from the namespaced `admin.firestore()` call to the modular
  `getFirestore(admin.app(), getFirestoreDatabaseId())` API, since the
  namespaced API has no overload that accepts a database ID string.
- Updated the assertion in
  `tests/firestore-database-consistency.test.mjs` to match — the
  original literal string it checked for (`admin.firestore(getFirestoreDatabaseId())`)
  described a call shape that doesn't type-check and isn't safe at
  runtime. Flagging this since it touches test logic, not just
  coverage tooling.

## Testing
`npm run test:coverage` — 26/26 passing, no threshold regressions.