### PR TITLE
Clear local analysis caches on account erasure and logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,6 +188,7 @@ import { ThemeProvider } from '@/src/lib/themeContext';
 import { ThemeToggle } from '@/src/components/ThemeToggle';
 import { ScrollToTop } from '@/src/components/ScrollToTop';
 import { purgeApiCaches } from './pwa/registerSW';
+import { clearAllLocalData } from '@/src/lib/storageUtils';
 
 export default function App() {
   const [user, setUser] = useState<User | null>(null);
@@ -520,8 +521,10 @@ export default function App() {
   const handleLogout = () => {
     signOut(auth);
     // Drop every cached API response (may include session-bound data or
-    // signed URLs) before the next user signs in on this device.
+    // signed URLs) and the local analysis mirror before the next user signs
+    // in on this device.
     void purgeApiCaches();
+    clearAllLocalData();
     setActiveTab("dashboard");
     setShowVerificationScreen(false);
     setUsername("");

--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -19,6 +19,7 @@ import {
 import { deleteObject, listAll, ref } from "firebase/storage";
 import { db, auth, storage, handleFirestoreError, OperationType } from "./firebase";
 import { DEFAULT_ROLE } from "./roleConstants";
+import { clearAllLocalData } from "./storageUtils";
 import { format } from "date-fns";
 
 export interface PrivacySettings {
@@ -261,6 +262,9 @@ async function deleteUserStorageFiles(userId: string): Promise<void> {
 }
 
 export async function deleteUserData(userId: string): Promise<void> {
+  // Purge the device caches first: the local mirror holds full analysis
+  // payloads (records + AI reports) that must not survive account erasure.
+  clearAllLocalData();
   // Write the deletion tombstone (users/<uid>.deletedAt) first so that
   // onAuthStateChanged cannot resurrect the profile even if a later step fails.
   const userRef = doc(db, "users", userId);

--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -147,3 +147,39 @@ export function deleteLocalDocument(documentId: string): void {
     console.error("Error removing local document", err);
   }
 }
+
+/**
+ * Clears every locally-cached analysis payload — the localStorage documents
+ * map and all sessionStorage fin_local_doc_* entries. Called from account
+ * erasure (and logout) so deleted or abandoned financial data never survives
+ * on the device.
+ */
+export function clearAllLocalData(): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.removeItem(LOCAL_DOCS_KEY);
+  } catch {
+    // ignore
+  }
+
+  try {
+    const session = window.sessionStorage;
+    const doomed: string[] = [];
+    for (let i = 0; i < session.length; i++) {
+      const key = session.key(i);
+      if (key && key.startsWith("fin_local_doc_")) doomed.push(key);
+    }
+    doomed.forEach((key) => session.removeItem(key));
+  } catch {
+    // ignore
+  }
+
+  try {
+    window.dispatchEvent(
+      new CustomEvent("fin_local_docs_changed", { detail: { cleared: true } }),
+    );
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
﻿## Problem
Deleting an account removes the server-side data, but the browser-side analysis cache (`localStorage` `fin_local_documents_v1` + per-doc `sessionStorage` keys) survives, so erased analysis data persists on the device after erasure/logout.

## Fix
Added `clearAllLocalData()` to `src/lib/storageUtils.ts` which removes the localStorage documents map, all `fin_local_doc_*` sessionStorage keys, and dispatches the cache-change event. Wired it into `deleteUserData()` in `privacyUtils.ts` and into `handleLogout` in `App.tsx`.

## Files changed
- `src/lib/storageUtils.ts`
- `src/lib/privacyUtils.ts`
- `src/App.tsx`

## Testing
- `tsc --noEmit` clean.
- Existing test suite passes.

Closes #857
