### PR TITLE
Bound Firestore reads with server-side orderBy and limit

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -11,6 +11,7 @@ import {
   where,
   orderBy,
   onSnapshot,
+  limit,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 
@@ -175,11 +176,15 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
     if (!currentConversationId || !currentUserId) return;
 
     const messagesRef = collection(db, 'chat_messages');
+    // Read the most recent messages (server-side desc + limit) and reverse for
+    // chronological display, so long conversations never trigger an unbounded
+    // read of the entire chat_messages collection.
     const q = query(
       messagesRef,
       where('conversationId', '==', currentConversationId),
       where('userId', '==', currentUserId),
-      orderBy('timestamp', 'asc')
+      orderBy('timestamp', 'desc'),
+      limit(200)
     );
 
     const unsubscribe = onSnapshot(
@@ -203,7 +208,7 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
             metadata: data.metadata,
           });
         });
-        setMessages(msgs);
+        setMessages(msgs.reverse());
       },
       (error) => {
         console.error('Error listening to messages:', error);

--- a/src/components/tax/TaxEstimation.tsx
+++ b/src/components/tax/TaxEstimation.tsx
@@ -9,6 +9,7 @@ import {
   orderBy,
   getDocs,
   serverTimestamp,
+  limit,
 } from 'firebase/firestore';
 import {
   Calculator,
@@ -87,7 +88,10 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
         const q = query(
           collection(db, 'tax_estimates'),
           where('userId', '==', user.uid),
-          orderBy('createdAt', 'desc')
+          orderBy('createdAt', 'desc'),
+          // Estimates are saved a handful of times a year, so the most recent
+          // 50 records cover years of history while keeping reads bounded.
+          limit(50)
         );
         const snapshot = await getDocs(q);
         // Pick the latest record that matches the current jurisdiction

--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -15,6 +15,7 @@ import {
   updateDoc,
   deleteDoc,
   serverTimestamp,
+  limit,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import { format } from 'date-fns';
@@ -153,14 +154,18 @@ export async function saveMessage(message: Omit<ChatMessage, 'id'>): Promise<Cha
   }
 }
 
-export async function loadMessages(conversationId: string, userId: string): Promise<ChatMessage[]> {
+export async function loadMessages(conversationId: string, userId: string, limitCount: number = 200): Promise<ChatMessage[]> {
   try {
     const ref = collection(db, MESSAGE_COLLECTION);
+    // Read the most recent messages server-side (desc + limit) then reverse
+    // so the returned list is still chronological — avoids unbounded reads of
+    // long conversations.
     const q = query(
       ref,
       where('conversationId', '==', conversationId),
       where('userId', '==', userId),
-      orderBy('timestamp', 'asc')
+      orderBy('timestamp', 'desc'),
+      limit(limitCount)
     );
     const snapshot = await getDocs(q);
     const messages: ChatMessage[] = [];
@@ -179,7 +184,7 @@ export async function loadMessages(conversationId: string, userId: string): Prom
         metadata: data.metadata,
       });
     });
-    return messages;
+    return messages.reverse();
   } catch (error) {
     console.error('Error loading messages:', error);
     handleFirestoreError(error, OperationType.LIST, MESSAGE_COLLECTION);

--- a/src/lib/healthUtils.ts
+++ b/src/lib/healthUtils.ts
@@ -14,6 +14,7 @@ import {
   updateDoc,
   serverTimestamp,
   orderBy,
+  limit,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
 import { Transaction } from './anomalyUtils';
@@ -229,7 +230,8 @@ export async function getHealthScores(userId: string, limitCount: number = 12): 
       ref,
       where('userId', '==', userId),
       orderBy('month', 'desc'),
-      orderBy('createdAt', 'desc')
+      orderBy('createdAt', 'desc'),
+      limit(limitCount)
     );
     const snapshot = await getDocs(q);
     const scores: HealthScore[] = [];
@@ -237,7 +239,7 @@ export async function getHealthScores(userId: string, limitCount: number = 12): 
       const data = docSnap.data();
       scores.push(normalizeScore(docSnap.id, data));
     });
-    return scores.slice(0, limitCount);
+    return scores;
   } catch (error) {
     console.error('Error fetching health scores:', error);
     handleFirestoreError(error, OperationType.LIST, 'health_scores');

--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -14,7 +14,7 @@
  *  - Calculating category trends (week-over-week, month-over-month)
  */
 
-import { collection, getDocs, query, where } from "firebase/firestore";
+import { collection, getDocs, query, where, orderBy, limit } from "firebase/firestore";
 import {
   startOfWeek,
   endOfWeek,
@@ -160,21 +160,25 @@ function total(transactions: Transaction[]): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch all transactions for a user. Reads once from the `transactions`
- * collection filtered by `userId`. Filtering by period is performed
- * client-side so a single read powers every analysis window.
+ * Fetch a user's transactions for the analysis windows. The query is bounded
+ * server-side (orderBy date desc + limit) so reads stay flat as the user's
+ * history grows; the analysis windows all sit inside the most recent
+ * transactions, so a large limit is never exhausted in practice.
  *
  * Returns an empty array (never throws) so the dashboard can render an
  * onboarding/empty state gracefully when no data exists yet.
  */
 export async function fetchTransactions(
   userId: string,
+  limitCount: number = 1000,
 ): Promise<Transaction[]> {
   if (!userId) return [];
   try {
     const q = query(
       collection(db, "transactions"),
       where("userId", "==", userId),
+      orderBy("date", "desc"),
+      limit(limitCount),
     );
     const snap = await getDocs(q);
     return snap.docs.map((doc) => {

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -17,6 +17,7 @@ import {
   orderBy,
   deleteDoc,
   runTransaction,
+  limit,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
 
@@ -643,6 +644,7 @@ export async function fetchPortfolioHistory(
       where('userId', '==', userId),
       where('portfolioId', '==', portfolioId),
       orderBy('snapshotDate', 'desc'),
+      limit(limitCount),
     );
     const snapshot = await getDocs(q);
     const snapshots: PortfolioSnapshot[] = [];
@@ -660,7 +662,7 @@ export async function fetchPortfolioHistory(
         createdAt: data.createdAt || '',
       });
     });
-    return snapshots.slice(0, limitCount);
+    return snapshots;
   } catch (error) {
     console.error('Error fetching portfolio history:', error);
     handleFirestoreError(error, OperationType.LIST, 'portfolioSnapshots');


### PR DESCRIPTION
﻿## Problem
Several Firestore reads load entire collections client-side (transactions, chat messages, documents analyses, health scores, tax estimates), unbounded by `orderBy`/`limit`, causing slow loads and high read costs.

## Fix
Bounded the reads server-side:
- `healthUtils.getHealthScores` – `limit(limitCount)`
- `portfolioUtils.fetchPortfolioHistory` – `limit(limitCount)`
- `insightsUtils.fetchTransactions` – `orderBy("date","desc")` + `limit(1000)`
- `chatUtils.loadMessages` – `orderBy("timestamp","desc")` + `limit(200)`, reversed client-side for chronological display
- `ChatAssistant` chat_messages snapshot – `orderBy("timestamp","desc")` + `limit(200)`, reversed
- `TaxEstimation` – tax_estimates `orderBy("createdAt","desc")` + `limit(50)`
- Confirmed `Dashboard` documents query was already bounded.

## Files changed
- `src/lib/healthUtils.ts`
- `src/lib/portfolioUtils.ts`
- `src/lib/insightsUtils.ts`
- `src/lib/chatUtils.ts`
- `src/components/chat/ChatAssistant.tsx`
- `src/components/tax/TaxEstimation.tsx`

## Testing
- `tsc --noEmit` clean; lint only pre-existing warnings.
- Related node tests 14/14 pass.

Closes #859
