### PR TITLE
Declare composite Firestore indexes for app queries

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "firestore": {
     "rules": "firestore.rules",
-    "indexes": ""
+    "indexes": "firestore.indexes.json"
   },
   "storage": {
     "rules": "storage.rules"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,220 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "transactions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "transactions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "health_scores",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "month", "order": "DESCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "portfolioHoldings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "symbol", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "portfolioHoldings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "portfolioTransactions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "portfolios",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "portfolioSnapshots",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "portfolioId", "order": "ASCENDING" },
+        { "fieldPath": "snapshotDate", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "forecasts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "month", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "activity_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "analyses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "processedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "chat_conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "lastMessageAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "chat_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "conversationId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "chat_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "conversationId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "anomalies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "dedupKey", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "anomalies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "anomalies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "dismissed", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "anomalies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "dismissed", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "budget_categories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "budget_rollovers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "bills",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "dueDate", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "emergency_funds",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "challenges",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tax_estimates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/tests/firestore-indexes.test.mjs
+++ b/tests/firestore-indexes.test.mjs
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const firebaseJson = JSON.parse(readFileSync(path.join(repoRoot, "firebase.json"), "utf8"));
+const indexesJson = JSON.parse(
+  readFileSync(path.join(repoRoot, "firestore.indexes.json"), "utf8"),
+);
+
+function hasIndex(collectionGroup, fieldPaths) {
+  return indexesJson.indexes.some((index) => {
+    if (index.collectionGroup !== collectionGroup) return false;
+    const declared = index.fields.map((field) => field.fieldPath);
+    return (
+      declared.length === fieldPaths.length &&
+      fieldPaths.every((fp) => declared.includes(fp))
+    );
+  });
+}
+
+const required = [
+  ["transactions", ["userId", "date"]],
+  ["transactions", ["ownerId", "date"]],
+  ["health_scores", ["userId", "month", "createdAt"]],
+  ["portfolioHoldings", ["userId", "symbol"]],
+  ["portfolioHoldings", ["userId", "createdAt"]],
+  ["portfolioTransactions", ["userId", "date"]],
+  ["portfolios", ["userId", "updatedAt"]],
+  ["portfolioSnapshots", ["userId", "portfolioId", "snapshotDate"]],
+  ["forecasts", ["userId", "month"]],
+  ["activity_log", ["userId", "timestamp"]],
+  ["documents", ["ownerId", "createdAt"]],
+  ["documents", ["ownerId", "status", "createdAt"]],
+  ["analyses", ["ownerId", "processedAt"]],
+  ["chat_conversations", ["userId", "lastMessageAt"]],
+  ["chat_messages", ["conversationId", "userId", "timestamp"]],
+  ["anomalies", ["userId", "dedupKey"]],
+  ["anomalies", ["userId", "date"]],
+  ["anomalies", ["userId", "dismissed", "date"]],
+  ["anomalies", ["userId", "dismissed", "createdAt"]],
+  ["budget_categories", ["userId", "name"]],
+  ["budget_rollovers", ["userId", "createdAt"]],
+  ["bills", ["userId", "dueDate"]],
+  ["emergency_funds", ["userId", "createdAt"]],
+  ["challenges", ["userId", "createdAt"]],
+  ["tax_estimates", ["userId", "createdAt"]],
+];
+
+test("firebase.json wires the Firestore indexes file", () => {
+  assert.equal(
+    firebaseJson.firestore.indexes,
+    "firestore.indexes.json",
+    "firebase.json must reference firestore.indexes.json so deploys ship " +
+      "the composite indexes the app queries",
+  );
+});
+
+test("firestore.indexes.json declares every composite index the app queries", () => {
+  const missing = required.filter(([group, fields]) => !hasIndex(group, fields));
+  assert.deepEqual(
+    missing,
+    [],
+    "composite indexes missing for queries that combine where() + orderBy() " +
+      "would fail at runtime with a failed-precondition error",
+  );
+});
+
+test("every declared index is a valid composite index", () => {
+  for (const index of indexesJson.indexes) {
+    assert.equal(typeof index.collectionGroup, "string");
+    assert.ok(Array.isArray(index.fields));
+    assert.ok(index.fields.length >= 2, "single-field indexes need no declaration");
+    for (const field of index.fields) {
+      assert.ok(field.fieldPath.length > 0);
+      assert.ok(
+        ["ASCENDING", "DESCENDING"].includes(field.order),
+        `field ${field.fieldPath} must have ASCENDING/DESCENDING order`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
﻿## Problem
Many app queries combine `where()` + `orderBy()` (transactions, documents, anomalies, portfolios, chat, health scores, etc.) and fail at runtime with `failed-precondition` because the required composite indexes were never declared. `firebase.json` had `"indexes": ""`, so deploys never ship any index file.

## Fix
- Added `firestore.indexes.json` declaring every composite index the app queries (equality field first, then order field, matching the query shapes).
- Wired `firebase.json` to point at the new file.
- Added a regression test that verifies the declared indexes cover all app query combos and that the indexes file is valid.

## Files changed
- `firestore.indexes.json` (new)
- `firebase.json`
- `tests/firestore-indexes.test.mjs` (new)

## Testing
- New test passes (3 tests).
- Existing suite passes.

Closes #860
