### PR TITLE
Allow erasure tombstones for privileged roles via dedicated rules path

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,19 @@ service cloud.firestore {
              data.role in ['junior_analyst', 'senior_pm', 'cro', 'compliance', 'admin'];
     }
 
+    // Right-to-erasure tombstone: a user may recreate their just-deleted
+    // profile as a deleted marker. This is the dedicated `deleted: true`
+    // path so erasure never depends on the strict profile-create gate
+    // (which rejects non-default roles and non-string emails). The tombstone
+    // must always carry the default non-privileged role. (Issue #862)
+    function isValidTombstone(data) {
+      return data.keys().hasAll(['uid', 'role', 'deleted', 'deletedAt']) &&
+             data.uid == request.auth.uid &&
+             data.role == 'junior_analyst' &&
+             data.deleted == true &&
+             data.deletedAt is string;
+    }
+
     function isValidDocument(data) {
       return data.keys().hasAll(['ownerId', 'fileName', 'fileUrl', 'status']) &&
              data.ownerId == request.auth.uid &&
@@ -66,7 +79,9 @@ service cloud.firestore {
       // non-privileged role. Privileged roles (senior_pm, cro, compliance,
       // admin) must be granted server-side (Admin SDK) and can never be
       // self-assigned at account creation. (Issues #505, #603)
-      allow create: if isAuthenticatedOwner(userId) && isValidUser(incoming()) && incoming().role == 'junior_analyst';
+      // A deletion tombstone (`deleted: true`) is also allowed so account
+      // erasure completes for privileged roles. (Issue #862)
+      allow create: if (isAuthenticatedOwner(userId) && isValidUser(incoming()) && incoming().role == 'junior_analyst') || (isAuthenticatedOwner(userId) && isValidTombstone(incoming()));
       // Owners may only update non-privilege fields; role changes require admin.
       allow update: if (isOwner(userId) && incoming().diff(existing()).affectedKeys().hasOnly(['displayName', 'photoURL'])) || isAdmin();
       allow delete: if isOwner(userId) || isAdmin();

--- a/tests/erasure-tombstone-privileged-roles.test.mjs
+++ b/tests/erasure-tombstone-privileged-roles.test.mjs
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const firestoreRules = readFileSync(
+  path.join(repoRoot, "firestore.rules"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+const privacyUtils = readFileSync(
+  path.join(repoRoot, "src/lib/privacyUtils.ts"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("rules define a dedicated tombstone validator for account erasure", () => {
+  assert.match(
+    firestoreRules,
+    /function isValidTombstone\(data\)/,
+    "a dedicated isValidTombstone helper must exist",
+  );
+  assert.ok(
+    firestoreRules.includes("data.role == 'junior_analyst'"),
+    "tombstone must carry the default non-privileged role",
+  );
+  assert.ok(
+    firestoreRules.includes("data.deleted == true"),
+    "tombstone must require deleted == true",
+  );
+  assert.ok(
+    firestoreRules.includes("data.uid == request.auth.uid"),
+    "tombstone must be bound to the caller's own uid",
+  );
+  assert.ok(
+    firestoreRules.includes("data.deletedAt is string"),
+    "tombstone must accept the ISO-string deletedAt written by deleteUserData",
+  );
+});
+
+test("users create allows the tombstone path for privileged-role erasure", () => {
+  const match = firestoreRules.match(/allow create:[\s\S]*?;/);
+  assert.ok(match, "users create rule must exist");
+  assert.ok(
+    match[0].includes("isValidTombstone(incoming())"),
+    "users create must OR in the tombstone path so senior_pm/cro/compliance " +
+      "erasure is not blocked by the strict profile gate",
+  );
+});
+
+test("deleteUserData writes a tombstone that satisfies isValidTombstone", () => {
+  assert.ok(
+    privacyUtils.includes("role: DEFAULT_ROLE"),
+    "tombstone must always use DEFAULT_ROLE regardless of prior role",
+  );
+  assert.ok(
+    privacyUtils.includes("deleted: true"),
+    "tombstone must set deleted: true",
+  );
+  assert.ok(
+    privacyUtils.includes("deletedAt: new Date().toISOString()"),
+    "tombstone must stamp a string deletedAt accepted by isValidTombstone",
+  );
+  assert.ok(
+    privacyUtils.includes("await setDoc(userRef, {"),
+    "tombstone is recreated after deleteDoc as a create",
+  );
+});

--- a/tests/signup-role-escalation.test.mjs
+++ b/tests/signup-role-escalation.test.mjs
@@ -66,7 +66,7 @@ test("account-deletion tombstone does not preserve privileged roles", () => {
 test("Firestore rules force junior_analyst on user create and lock role on update", () => {
   assert.match(
     firestoreRules,
-    /allow create:\s*if isAuthenticatedOwner\(userId\) && isValidUser\(incoming\(\)\) && incoming\(\)\.role == 'junior_analyst'/,
+    /isAuthenticatedOwner\(userId\) && isValidUser\(incoming\(\)\) && incoming\(\)\.role == 'junior_analyst'/,
     "create must require junior_analyst (blocks cro/senior_pm/compliance/admin)",
   );
   assert.ok(


### PR DESCRIPTION
﻿## Problem
Account erasure recreates the `users/<uid>` doc as a deletion tombstone (a `create` after `deleteDoc`). The strict profile-create gate requires `role == 'junior_analyst'` and `isValidUser` (email + role). For `senior_pm`/`cro`/`compliance` users the erasure depends on the tombstone passing that gate, and any divergence (e.g. a non-string email) blocks the tombstone — the account then resurrects on next sign-in because no `deletedAt` exists.

## Fix
- Added a dedicated `isValidTombstone()` validator in `firestore.rules`: tombstone create requires `uid == request.auth.uid`, `deleted == true`, `role == 'junior_analyst'`, and `deletedAt` is a string — it no longer rides on the strict profile gate.
- OR-ed this tombstone path into the `users` create rule.
- The existing tombstone writer already uses `DEFAULT_ROLE`, `deleted: true`, and an ISO-string `deletedAt`, so it satisfies the new rule without client changes.
- Relaxed the #845 rules assertion to still enforce the `junior_analyst` gate while accepting the tombstone OR-path.

## Files changed
- `firestore.rules`
- `tests/erasure-tombstone-privileged-roles.test.mjs` (new)
- `tests/signup-role-escalation.test.mjs` (assertion updated for the new rule shape)

## Testing
- New regression tests pass (3 tests).
- Updated `signup-role-escalation` tests pass.

Closes #862
