### PR TITLE
Stamp anomalies with detection time in createdAt

### DIFF
--- a/src/components/anomaly/AnomalyDashboard.tsx
+++ b/src/components/anomaly/AnomalyDashboard.tsx
@@ -374,7 +374,7 @@ async function runDetection(userId: string) {
       confidence,
       transactionId: tx.id,
       dismissed: false,
-      createdAt: tx.date,
+      createdAt: new Date().toISOString(),
       date: tx.date,
       severity: confidence >= 80 ? "high" : confidence >= 60 ? "medium" : "low",
       averageAmount: catBaseline.mean,
@@ -407,9 +407,7 @@ async function runDetection(userId: string) {
       transactionId:
         spike.transactions[spike.transactions.length - 1]?.id || "",
       dismissed: false,
-      createdAt:
-        spike.transactions[spike.transactions.length - 1]?.date ||
-        new Date().toISOString(),
+      createdAt: new Date().toISOString(),
       date: (spike.transactions[spike.transactions.length - 1]?.date as Date) || new Date(),
       severity: pctOver >= 50 ? "high" : pctOver >= 25 ? "medium" : "low",
       averageAmount: avgMonthly,

--- a/tests/anomaly-createdAt-detection-time.test.mjs
+++ b/tests/anomaly-createdAt-detection-time.test.mjs
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const dashboard = readFileSync(
+  path.join(repoRoot, "src", "components", "anomaly", "AnomalyDashboard.tsx"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("large_transaction anomalies stamp createdAt at detection time", () => {
+  assert.ok(
+    dashboard.includes("createdAt: new Date().toISOString(),"),
+    "createdAt must be the detection timestamp, not the transaction date",
+  );
+  assert.ok(
+    dashboard.includes("date: tx.date,"),
+    "the transaction date must still be stored in the date field",
+  );
+});
+
+test("category_spike anomalies stamp createdAt at detection time", () => {
+  assert.match(
+    dashboard,
+    /createdAt: new Date\(\)\.toISOString\(\),/g,
+    "both branches must use new Date().toISOString() for createdAt",
+  );
+  assert.ok(
+    dashboard.includes(
+      "date: (spike.transactions[spike.transactions.length - 1]?.date as Date) || new Date(),",
+    ),
+    "the last triggering transaction date must still be stored in the date field",
+  );
+});
+
+test("anomaly list still orders by createdAt for detection-time ordering", () => {
+  assert.ok(
+    dashboard.includes('orderBy("createdAt", "desc")'),
+    "the anomalies list must order by createdAt so latest detections sort first",
+  );
+});


### PR DESCRIPTION
﻿## Problem
`AnomalyDashboard` persisted `createdAt` as the triggering transaction date (transaction-level and category-spike branches), so anomalies detected *now* were timestamped weeks/months in the past. `groupByWeek` bucketed them by spend date and `orderBy("createdAt","desc")` sorted by spend date instead of detection time.

## Fix
- Both branches now stamp `createdAt: new Date().toISOString()` at detection time.
- The triggering transaction date stays in the `date` field (`date: tx.date` / `date: spike.transactions[...]?.date`), so timeline and ordering semantics are correct while the transaction reference is preserved.

## Files changed
- `src/components/anomaly/AnomalyDashboard.tsx`
- `tests/anomaly-createdAt-detection-time.test.mjs` (new)

## Testing
- New regression test passes (3 tests).
- `tsc --noEmit` clean.

Closes #863
