### PR TITLE
Make localStorage the single analysis cache source

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -101,27 +101,6 @@ export function FileUpload({ user, onComplete, onCancel }: any) {
     return `Analysis failed with status ${statusCode}`;
   };
 
-  const cacheLocalAnalysis = (payload: any) => {
-    if (typeof window === "undefined") return;
-    if (!payload?.documentId) return;
-
-    const cached = {
-      record: payload.record || null,
-      analysis: payload.analysis || null,
-      persistenceMode: payload.persistenceMode || "local",
-      storedAt: new Date().toISOString(),
-    };
-
-    try {
-      window.sessionStorage.setItem(
-        `fin_local_doc_${payload.documentId}`,
-        JSON.stringify(cached),
-      );
-    } catch (error) {
-      console.warn("Could not cache local analysis result", error);
-    }
-  };
-
   const startAnalysis = async () => {
     if (!file || !user) return;
 

--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -11,8 +11,9 @@ export interface CachedAnalysisPayload {
 }
 
 /**
- * Persists an analysis result locally in both localStorage (for long-term persistence across tabs/sessions)
- * and sessionStorage (for instant retrieval).
+ * Persists an analysis result locally in the localStorage documents map.
+ * The localStorage map is the single source of truth for the local/offline
+ * document list, so there is no divergent sessionStorage mirror.
  */
 export function saveLocalAnalysis(payload: CachedAnalysisPayload): void {
   if (typeof window === "undefined" || !payload?.documentId) return;
@@ -26,17 +27,7 @@ export function saveLocalAnalysis(payload: CachedAnalysisPayload): void {
     storedAt: now,
   };
 
-  // 1. Store in sessionStorage for fast session retrieval
-  try {
-    window.sessionStorage.setItem(
-      `fin_local_doc_${payload.documentId}`,
-      JSON.stringify(cached),
-    );
-  } catch (err) {
-    console.warn("Could not cache in sessionStorage", err);
-  }
-
-  // 2. Store in localStorage documents map
+  // Store in localStorage documents map
   try {
     const rawMap = window.localStorage.getItem(LOCAL_DOCS_KEY);
     const docMap: Record<string, CachedAnalysisPayload> = rawMap
@@ -96,25 +87,18 @@ export function getLocalDocuments(ownerId?: string): any[] {
 }
 
 /**
- * Retrieves a single cached analysis by documentId (checks localStorage first, then sessionStorage).
+ * Retrieves a single cached analysis by documentId from the localStorage map.
  */
 export function getLocalDocumentById(documentId: string): CachedAnalysisPayload | null {
   if (typeof window === "undefined" || !documentId) return null;
 
   try {
-    // Check localStorage map first
     const rawMap = window.localStorage.getItem(LOCAL_DOCS_KEY);
     if (rawMap) {
       const docMap: Record<string, CachedAnalysisPayload> = JSON.parse(rawMap);
       if (docMap[documentId]) {
         return docMap[documentId];
       }
-    }
-
-    // Check sessionStorage backup
-    const rawSession = window.sessionStorage.getItem(`fin_local_doc_${documentId}`);
-    if (rawSession) {
-      return JSON.parse(rawSession);
     }
   } catch (err) {
     console.error("Error reading local document by id", err);
@@ -124,16 +108,10 @@ export function getLocalDocumentById(documentId: string): CachedAnalysisPayload 
 }
 
 /**
- * Deletes a local document from both localStorage and sessionStorage.
+ * Deletes a local document from the localStorage map.
  */
 export function deleteLocalDocument(documentId: string): void {
   if (typeof window === "undefined" || !documentId) return;
-
-  try {
-    window.sessionStorage.removeItem(`fin_local_doc_${documentId}`);
-  } catch {
-    // ignore
-  }
 
   try {
     const rawMap = window.localStorage.getItem(LOCAL_DOCS_KEY);

--- a/tests/session-cache-single-source.test.mjs
+++ b/tests/session-cache-single-source.test.mjs
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const storageUtils = readFileSync(
+  path.join(repoRoot, "src/lib/storageUtils.ts"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+const fileUpload = readFileSync(
+  path.join(repoRoot, "src/components/FileUpload.tsx"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+const analysisDetail = readFileSync(
+  path.join(repoRoot, "src/components/AnalysisDetail.tsx"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("sessionStorage is no longer a cache writer in storageUtils", () => {
+  assert.doesNotMatch(
+    storageUtils,
+    /sessionStorage\.setItem\(`fin_local_doc_/,
+    "saveLocalAnalysis must not write a divergent sessionStorage mirror",
+  );
+});
+
+test("the dead reader fallback is removed", () => {
+  assert.doesNotMatch(
+    storageUtils,
+    /sessionStorage\.getItem\(`fin_local_doc_/,
+    "getLocalDocumentById must read only the localStorage map",
+  );
+  assert.doesNotMatch(
+    storageUtils,
+    /sessionStorage\.removeItem\(`fin_local_doc_/,
+    "deleteLocalDocument must not need a sessionStorage cleanup path",
+  );
+});
+
+test("FileUpload no longer defines a divergent session cache writer", () => {
+  assert.doesNotMatch(
+    fileUpload,
+    /cacheLocalAnalysis/,
+    "the dead cacheLocalAnalysis writer must be removed in favor of saveLocalAnalysis",
+  );
+  assert.doesNotMatch(
+    fileUpload,
+    /fin_local_doc_/,
+    "FileUpload must not write the sessionStorage key directly",
+  );
+});
+
+test("a single working read path remains via the localStorage map", () => {
+  assert.ok(
+    storageUtils.includes("export function getLocalDocumentById("),
+    "getLocalDocumentById must remain exported as the single reader",
+  );
+  assert.ok(
+    analysisDetail.includes("getLocalDocumentById(docId)"),
+    "AnalysisDetail must keep consuming the single read path",
+  );
+});


### PR DESCRIPTION
﻿## Problem
The session-level analysis cache had two writers and divergent shapes on the same `fin_local_doc_<id>` key: `saveLocalAnalysis` (documentId + record + analysis) and `FileUpload.cacheLocalAnalysis` (no documentId), which was dead code. The sessionStorage mirror duplicated the localStorage map, wasting quota, and the reader fallback was never exercised.

## Fix
- Made the `fin_local_documents_v1` localStorage map the single source of truth.
- Removed the sessionStorage mirror writes from `saveLocalAnalysis`, the sessionStorage read fallback from `getLocalDocumentById`, and the sessionStorage cleanup from `deleteLocalDocument`.
- Removed the dead `cacheLocalAnalysis` from `FileUpload` (the success path already uses `saveLocalAnalysis`).

## Files changed
- `src/lib/storageUtils.ts`
- `src/components/FileUpload.tsx`
- `tests/session-cache-single-source.test.mjs` (new)

## Testing
- New regression test passes (4 tests).
- `tsc --noEmit` clean; lint no errors.

Closes #865
