### PR TITLE
Require cadence evidence before annualizing charges as subscriptions

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -341,10 +341,17 @@ export function identifyOpportunities(
       }
       avgInterval = intervalCount > 0 ? intervalTotal / intervalCount : 0;
     }
+    // A realistic annual figure requires cadence evidence: at least two
+    // charges with a measurable interval (>= 1 day). A single one-time charge
+    // — even one whose merchant matches a subscription keyword — is not a
+    // recurring subscription and must never be annualized at a fixed 12x.
+    // (Issue #868)
+    if (sorted.length < 2 || avgInterval < 1) continue;
     // Weekly cadence ≈ 52 charges/year, monthly ≈ 12, quarterly ≈ 4. Charges
     // bunched closer than a week are capped at the weekly rate rather than
-    // inflating the annual figure.
-    const chargesPerYear = avgInterval >= 1 ? Math.min(52, 365 / avgInterval) : 12;
+    // inflating the annual figure. The factor is always derived from the
+    // measured cadence, never a hardcoded default.
+    const chargesPerYear = Math.min(52, 365 / Math.max(1, avgInterval));
     const annualized = monthly * chargesPerYear;
     const display = list[0].merchant || list[0].description || key;
     opportunities.push({

--- a/tests/opportunity-single-charge-cadence.test.mjs
+++ b/tests/opportunity-single-charge-cadence.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const insightsUtils = readFileSync(
+  path.join(repoRoot, "src/lib/insightsUtils.ts"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("annualizing requires cadence evidence of at least two charges", () => {
+  assert.ok(
+    insightsUtils.includes("if (sorted.length < 2 || avgInterval < 1) continue;"),
+    "identifyOpportunities must skip merchants with fewer than two charges or " +
+      "charges bunched within a day",
+  );
+});
+
+test("chargesPerYear is never a hardcoded 12x fallback", () => {
+  assert.doesNotMatch(
+    insightsUtils,
+    /chargesPerYear = [^;]*: 12/,
+    "a single keyword-matched charge must not be annualized at 12x",
+  );
+  assert.ok(
+    insightsUtils.includes("Math.min(52, 365 / Math.max(1, avgInterval))"),
+    "chargesPerYear must be derived purely from the measured interval",
+  );
+});
+
+test("the single-charge keyword path cannot fabricate an annualized claim", () => {
+  const block = insightsUtils.match(
+    /const chargesPerYear[\s\S]*?annualized = monthly \* chargesPerYear;/,
+  );
+  assert.ok(block, "annualized must be computed after cadence evidence");
+  assert.ok(
+    block[0].includes("365 /") && !block[0].includes(": 12"),
+    "annualization must use the measured cadence, not a fixed 12",
+  );
+});


### PR DESCRIPTION
﻿## Problem
`identifyOpportunities` annualized a single, one-time charge at 12x whenever its merchant matched a subscription keyword (e.g. a one-off `Apple.com/bill` hardware purchase). With `avgInterval = 0` the code fell through to a hardcoded `: 12`, fabricating a "$12,000/year savings" claim with zero cadence evidence.

## Fix
- Require real cadence evidence before annualizing: merchants with fewer than 2 charges, or charges bunched within the same day (`avgInterval < 1`), are skipped entirely.
- `chargesPerYear` is now always derived from the measured interval (`Math.min(52, 365 / Math.max(1, avgInterval))`) — no hardcoded 12x fallback.

## Files changed
- `src/lib/insightsUtils.ts`
- `tests/opportunity-single-charge-cadence.test.mjs` (new)

## Testing
- New regression test passes (3 tests).
- Existing insights-related tests pass (14/14).

Closes #868
