### PR TITLE
fix: format By Currency totals with the base currency symbol (#890)

### DIFF
--- a/src/components/currency/CurrencyManager.tsx
+++ b/src/components/currency/CurrencyManager.tsx
@@ -458,7 +458,7 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
                         </Badge>
                       </div>
                       <span className="text-sm font-bold text-white tabular-nums">
-                        {formatCurrencyDisplay(total, currency)}
+                        {formatCurrencyDisplay(total, settings?.baseCurrency || 'USD')}
                       </span>
                     </div>
                   ))}


### PR DESCRIPTION
## Problem

`aggregateMultiCurrencyTotals` in `src/lib/currencyUtils.ts` converts every transaction to the base currency but keys the per-currency buckets by the transaction's **original** currency code while storing the **converted** (base-currency) amount. `CurrencyManager` then rendered each bucket with `formatCurrencyDisplay(total, currency)`, which formats the base-currency value with the **source currency's symbol** — e.g. with base INR, a $100 (= ₹8,500) transaction displayed `$8,500.00` in the USD row, mislabeled with the wrong symbol.

## Fix

- `src/components/currency/CurrencyManager.tsx`: the "By Currency" rows now format with `formatCurrencyDisplay(total, settings?.baseCurrency || 'USD')` (Option A in the issue), so the base-currency value is displayed with the base-currency symbol. The per-currency breakdown now agrees with the "Total in {baseCurrency}" header.

## Files changed

- `src/components/currency/CurrencyManager.tsx`

## Testing

- `npm run typecheck` passes.
- With base currency INR and a $100 USD transaction, the USD row now renders `₹8,500.00` (base-currency value with base-currency symbol) instead of the misleading `$8,500.00`.

Closes #890
