### PR TITLE
fix: keep remote documents visible when local documents change (#891)

### DIFF
--- a/src/components/AnalysisList.tsx
+++ b/src/components/AnalysisList.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, react-hooks/immutability, react-hooks/purity, react-hooks/refs, react-hooks/set-state-in-effect */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import {
   collection,
@@ -50,6 +50,7 @@ export function AnalysisList({ type, user, onSelect }: any) {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const latestRemoteRef = useRef<any[]>([]);
 
   useEffect(() => {
     if (!user) return;
@@ -104,17 +105,19 @@ export function AnalysisList({ type, user, onSelect }: any) {
       docsQuery,
       (snapshot) => {
         const remoteDocs = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+        latestRemoteRef.current = remoteDocs;
         updateCombinedDocuments(remoteDocs);
       },
       (error) => {
         handleFirestoreError(error, OperationType.LIST, "documents");
         // Even if Firestore fails, show local documents
+        latestRemoteRef.current = [];
         updateCombinedDocuments([]);
       },
     );
 
     const handleLocalDocsChanged = () => {
-      updateCombinedDocuments(documents.filter((d) => !d.id?.startsWith("local-")));
+      updateCombinedDocuments(latestRemoteRef.current);
     };
     window.addEventListener("fin_local_docs_changed", handleLocalDocsChanged);
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, react-hooks/immutability, react-hooks/purity, react-hooks/refs, react-hooks/set-state-in-effect */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import {
   collection,
@@ -59,6 +59,7 @@ export function Dashboard({ user, userProfile, onAction, onDocSelect }: any) {
   });
   const [recentDocs, setRecentDocs] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const latestRemoteRef = useRef<DashboardDocument[]>([]);
 
   useEffect(() => {
     if (!user) return;
@@ -209,16 +210,18 @@ export function Dashboard({ user, userProfile, onAction, onDocSelect }: any) {
         const docs = snapshot.docs.map(
           (doc) => ({ id: doc.id, ...doc.data() }) as DashboardDocument,
         );
+        latestRemoteRef.current = docs;
         processDocuments(docs);
       },
       (error) => {
         handleFirestoreError(error, OperationType.LIST, "documents");
+        latestRemoteRef.current = [];
         processDocuments([]);
       },
     );
 
     const handleLocalDocsChanged = () => {
-      processDocuments([]);
+      processDocuments(latestRemoteRef.current);
     };
     window.addEventListener("fin_local_docs_changed", handleLocalDocsChanged);
 


### PR DESCRIPTION
## Problem

`saveLocalAnalysis` and `deleteLocalDocument` in `src/lib/storageUtils.ts` dispatch a `fin_local_docs_changed` event after any local-cache write. Both `Dashboard` and `AnalysisList` handled that event by merging with an **empty remote list**:

- `Dashboard.handleLocalDocsChanged` called `processDocuments([])`, rebuilding stats/charts/recent docs from local documents alone — all Firestore documents were dropped.
- `AnalysisList.handleLocalDocsChanged` filtered the stale `documents` closure and passed the wrong list to the merge.

Because the change is purely local, Firestore's `onSnapshot` doesn't refire, so the remote documents stayed hidden until an unrelated Firestore mutation.

## Fix

- `src/components/Dashboard.tsx`: track the latest remote snapshot in `latestRemoteRef` (a `useRef`, updated in the `onSnapshot` callback) and have the local-docs handler call `processDocuments(latestRemoteRef.current)` instead of `processDocuments([])`.
- `src/components/AnalysisList.tsx`: track the latest remote snapshot in `latestRemoteRef` and have the local-docs handler call `updateCombinedDocuments(latestRemoteRef.current)` — removing the reliance on the stale `documents` closure.

Now saving or deleting a local document refreshes the local portion of the list while keeping the remote (Firestore) documents already on screen.

## Files changed

- `src/components/Dashboard.tsx`
- `src/components/AnalysisList.tsx`

## Testing

- `npm run typecheck` passes.
- Saving/deleting a local analysis no longer wipes Firestore documents from the Dashboard stats, charts, recent list, or the AnalysisList.

Closes #891
