### PR TITLE
fix: include activity_log in data export/erasure and add per-user rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -225,6 +225,18 @@ service cloud.firestore {
       allow delete: if isOwner(existing().userId) || isAdmin();
     }
 
+    match /activity_log/{logId} {
+      // Per-user action history. Append-only: clients create and read their
+      // own entries; no updates. Delete is owner-scoped so account erasure
+      // (deleteUserData) can purge the audit history with the rest of the
+      // user's data. Matches the userId field fetchActivityLog queries on.
+      allow get: if isOwner(existing().userId) || isAdmin();
+      allow list: if request.auth != null && (request.query.userId == request.auth.uid || isAdmin());
+      allow create: if isSignedIn() && isOwner(incoming().userId);
+      allow update: if false;
+      allow delete: if isOwner(existing().userId) || isAdmin();
+    }
+
     match /portfolios/{portfolioId} {
       allow read: if isOwner(existing().userId) || isAdmin();
       allow create: if isSignedIn() && isOwner(incoming().userId);

--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -130,6 +130,7 @@ const USER_COLLECTIONS = [
   "portfolios",
   "tax_estimates",
   "bills",
+  "activity_log",
 ];
 
 export async function exportUserData(


### PR DESCRIPTION
## Problem

`activity_log` is missing from the privacy utilities' user-data handling:

- `USER_COLLECTIONS` in `src/lib/privacyUtils.ts` lists 18 collections but not `activity_log`, so `exportUserData` produces no `activity_log` key and `deleteUserData` never queries or deletes the entries.
- After "Delete My Account" succeeds, the user's `activity_log` documents remain in Firestore (surviving orphaned PII), and the export JSON has no action/audit history.
- `firestore.rules` has no `match /activity_log/{logId}` block, so the collection falls through to the default `allow read, write: if false` — meaning the client-side reads/deletes in export/erasure (and `fetchActivityLog`) would be denied even after adding the collection to `USER_COLLECTIONS`.

## Fix

- **`src/lib/privacyUtils.ts`** — added `"activity_log"` to `USER_COLLECTIONS`, so both `exportUserData` and `deleteUserData` handle it uniformly via the existing `where("userId", "==", userId)` queries (matching how `fetchActivityLog` reads it).
- **`firestore.rules`** — added a `match /activity_log/{logId}` block (append-only, modeled on the `chat_messages`/`reports` patterns): owner-scoped `get`/`list` (with the `request.query.userId` guard that the export/erasure/fetch queries satisfy), `create` for the owner, no `update`, and owner-scoped `delete` so account erasure can purge the entries.

## Files changed

- `src/lib/privacyUtils.ts` — `"activity_log"` added to `USER_COLLECTIONS`.
- `firestore.rules` — new `match /activity_log/{logId}` block.

## Testing

- `npm run typecheck` passes.
- Grep confirms the only `activity_log` reference in the app is `fetchActivityLog` (`privacyUtils.ts:93`); there is no client write path in the repo to audit for a missing `userId`, so the create rule requires `incoming().userId == request.auth.uid` to enforce ownership when a writer is added.
- `exportUserData` and `deleteUserData` both iterate `USER_COLLECTIONS` with `where("userId", "==", userId)`, which the new `list` rule accepts (`request.query.userId == request.auth.uid`), and `delete` is owner-scoped so erasure works.

Closes #894
