### PR TITLE
fix: skip empty-description expenses in subscription auto-grouping

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -192,6 +192,10 @@ export function groupTransactionsIntoSubscriptions(
   for (const transaction of transactions) {
     if (transaction.type !== "expense") continue;
     const normalized = normalizeText(transaction.description);
+    // Empty/punctuation-only/emoji-only/foreign descriptions normalize to ""
+    // and would match every group via `key.includes("")`. Exclude them from
+    // auto-detection instead of folding them into an unrelated merchant.
+    if (!normalized) continue;
     const category = transaction.category.toLowerCase();
 
     let matchedKey: string | null = null;


### PR DESCRIPTION
## Problem

In `groupTransactionsIntoSubscriptions` (`src/lib/subscriptionUtils.ts`), `normalizeText` can return an empty string for empty, punctuation-only, emoji-only, or non-Latin descriptions (e.g. `"$&*#@"`, `"🍕"`, `"“"`). The matching loop then runs `key.includes("")`, which is always `true`, so:

- Every such transaction is folded into the first existing group (e.g. `netflix` absorbs a cafe, an ATM fee, or a foreign-language merchant).
- If an empty description is the first expense, a group keyed by `""` is created and then matches all subsequent empty/foreign descriptions.
- This corrupts the average amount and frequency reported by `analyzeSubscriptionPattern` and shown in the Subscription Analyzer.

## Fix

- In `groupTransactionsIntoSubscriptions`, skip transactions whose normalized description is empty (`if (!normalized) continue;`) before the matching loop, per the issue's proposed fix. Such expenses are excluded from subscription auto-detection rather than merged into an unrelated merchant's group.
- Because `normalized` is guaranteed non-empty after the skip, `newKey` can no longer be an empty string, so an empty key can never be created or matched.

## Files changed

- `src/lib/subscriptionUtils.ts` — added the `if (!normalized) continue;` guard in `groupTransactionsIntoSubscriptions`.

## Testing

- `npm run typecheck` passes.
- Standalone test: a `netflix` group with `netflix`, `NETFLIX`, and `Netflix Subscription` charges stays exactly 3 entries; `"$&*#@"`, `"🍕"`, and `""` descriptions are excluded entirely and no group ever contains an empty-keyed transaction.

Closes #896
