### PR TITLE
feat: mount 25 previously unreachable feature screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,13 @@ import {
   LineChart,
   Globe,
   Lock,
-  Shield
+  Shield,
+  Repeat,
+  FileBarChart,
+  PieChart,
+  Scale,
+  Sparkles,
+  Target
 } from 'lucide-react';
 import { Toaster, toast } from 'sonner';
 import { motion, AnimatePresence } from 'motion/react';
@@ -188,6 +194,33 @@ import { ThemeProvider } from '@/src/lib/themeContext';
 import { ThemeToggle } from '@/src/components/ThemeToggle';
 import { ScrollToTop } from '@/src/components/ScrollToTop';
 import { purgeApiCaches } from './pwa/registerSW';
+
+// Feature screens that were implemented but never mounted (issue #897)
+import { ReportExport } from "./components/reports/ReportExport";
+import { InsightsDashboard } from "./components/insights/InsightsDashboard";
+import { CurrencyManager } from "./components/currency/CurrencyManager";
+import { CurrencyConverter } from "./components/currency/CurrencyConverter";
+import MultiCurrencyNetWorth from "./components/MultiCurrencyNetWorth";
+import { FxExposureMatrix } from "./components/currency/FxExposureMatrix";
+import { ComplianceAuditDashboard } from "./components/compliance/ComplianceAuditDashboard";
+import TaxLossHarvester from "./components/TaxLossHarvester";
+import { TaxLossHarvesting } from "./components/tax/TaxLossHarvesting";
+import MonteCarloRetirement from "./components/MonteCarloRetirement";
+import SubscriptionAssistant from "./components/SubscriptionAssistant";
+import DripAnalyzer from "./components/DripAnalyzer";
+import NewsSentimentDashboard from "./components/NewsSentimentDashboard";
+import FinancialLiteracyBot from "./components/FinancialLiteracyBot";
+import OptionsStrategyBuilder from "./components/OptionsStrategyBuilder";
+import PlaidLinkConnect from "./components/PlaidLinkConnect";
+import RealEstateTracker from "./components/RealEstateTracker";
+import CryptoPortfolioTracker from "./components/CryptoPortfolioTracker";
+import EsgDashboard from "./components/EsgDashboard";
+import PeerSpendingComparison from "./components/PeerSpendingComparison";
+import { MultiScenarioMatrix } from "./components/forecast/MultiScenarioMatrix";
+import ReceiptUploader from "./components/ReceiptUploader";
+import SmsOptInSettings from "./components/SmsOptInSettings";
+import VoiceExpenseLogger from "./components/VoiceExpenseLogger";
+import BudgetReallocator from "./components/BudgetReallocator";
 
 export default function App() {
   const [user, setUser] = useState<User | null>(null);
@@ -979,6 +1012,48 @@ export default function App() {
             onClick={() => setActiveTab('portfolio')}
           />
           <NavItem
+            icon={<Repeat size={20} />}
+            label="Subscriptions"
+            active={activeTab === 'subscriptions'}
+            onClick={() => setActiveTab('subscriptions')}
+          />
+          <NavItem
+            icon={<Activity size={20} />}
+            label="Cash Flow"
+            active={activeTab === 'cashflow'}
+            onClick={() => setActiveTab('cashflow')}
+          />
+          <NavItem
+            icon={<Target size={20} />}
+            label="Goals"
+            active={activeTab === 'goals'}
+            onClick={() => setActiveTab('goals')}
+          />
+          <NavItem
+            icon={<FileBarChart size={20} />}
+            label="Reports"
+            active={activeTab === 'reports'}
+            onClick={() => setActiveTab('reports')}
+          />
+          <NavItem
+            icon={<PieChart size={20} />}
+            label="Insights"
+            active={activeTab === 'insights'}
+            onClick={() => setActiveTab('insights')}
+          />
+          <NavItem
+            icon={<Scale size={20} />}
+            label="Compliance"
+            active={activeTab === 'compliance'}
+            onClick={() => setActiveTab('compliance')}
+          />
+          <NavItem
+            icon={<Sparkles size={20} />}
+            label="AI Tools"
+            active={activeTab === 'ai-tools'}
+            onClick={() => setActiveTab('ai-tools')}
+          />
+          <NavItem
             icon={<Shield size={20} />}
             label="Privacy & Security"
             active={activeTab === 'privacy'}
@@ -1128,6 +1203,7 @@ export default function App() {
                 className="space-y-6"
               >
                 <BudgetDashboard user={user} />
+                <BudgetReallocator />
               </motion.div>
             )}
 
@@ -1168,6 +1244,7 @@ export default function App() {
                 className="space-y-6"
               >
                 <SubscriptionAnalyzer user={user} />
+                <SubscriptionAssistant />
               </motion.div>
             )}
 
@@ -1314,6 +1391,22 @@ export default function App() {
               </motion.div>
             )}
 
+            {activeTab === 'currencies' && user && (
+              <motion.div 
+                key="currencies"
+                initial={false}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -10 }}
+              >
+                <div className="space-y-6">
+                  <CurrencyManager user={user} />
+                  <CurrencyConverter />
+                  <MultiCurrencyNetWorth />
+                  <FxExposureMatrix />
+                </div>
+              </motion.div>
+            )}
+
             {activeTab === 'trends' && (
               <motion.div 
                 key="trends"
@@ -1354,7 +1447,69 @@ export default function App() {
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -10 }}
               >
-                <TaxEstimation user={user} />
+                <div className="space-y-6">
+                  <TaxEstimation user={user} />
+                  <TaxLossHarvester />
+                  <TaxLossHarvesting />
+                </div>
+              </motion.div>
+            )}
+
+            {activeTab === 'reports' && (
+              <motion.div
+                key="reports"
+                initial={false}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+              >
+                <ReportExport />
+              </motion.div>
+            )}
+
+            {activeTab === 'insights' && user && (
+              <motion.div
+                key="insights"
+                initial={false}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+              >
+                <InsightsDashboard user={user} />
+              </motion.div>
+            )}
+
+            {activeTab === 'compliance' && user && (
+              <motion.div
+                key="compliance"
+                initial={false}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+              >
+                <ComplianceAuditDashboard {...({ user } as any)} />
+              </motion.div>
+            )}
+
+            {activeTab === 'ai-tools' && (
+              <motion.div
+                key="ai-tools"
+                initial={false}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                className="space-y-6"
+              >
+                <MonteCarloRetirement />
+                <DripAnalyzer />
+                <NewsSentimentDashboard />
+                <FinancialLiteracyBot />
+                <OptionsStrategyBuilder />
+                <PeerSpendingComparison />
+                <EsgDashboard />
+                <MultiScenarioMatrix />
+                <PlaidLinkConnect />
+                <RealEstateTracker />
+                <CryptoPortfolioTracker />
+                <ReceiptUploader />
+                <SmsOptInSettings />
+                <VoiceExpenseLogger />
               </motion.div>
             )}
           </AnimatePresence>


### PR DESCRIPTION
## Problem

Many complete, user-facing feature screens are never imported by `src/App.tsx`, so their features are unreachable from the sidebar and they ship as dead weight in the bundle. Affected areas: Reports export, Insights, multi-currency management, compliance audit, tax-loss harvesting, Monte-Carlo retirement, subscription assistant, drip/news/ESG analytics, financial literacy bot, options strategy builder, Plaid/real-estate/crypto, receipt OCR, voice expense logging, SMS opt-in, and budget reallocation. (This is the same wiring gap behind the blank Currencies tab.)

## Fix

Mounted the previously unreachable screens in `src/App.tsx` following the existing `{activeTab === "..." && <Component/>}` pattern, and added sidebar nav items for the new reachable features:

- **New nav items**: Subscriptions, Cash Flow, Goals (these already had render blocks but no nav item), Reports, Insights, Compliance, AI Tools.
- **Reports** tab → `ReportExport` (renders `ReportPreview` internally).
- **Insights** tab → `InsightsDashboard` (real `user` + Firestore data, not mocks).
- **Compliance** tab → `ComplianceAuditDashboard` — the mount passes `user` via spread so it compiles against both the current no-prop signature and the upcoming #904 signature that requires `user`.
- **Currencies** tab (was blank) → `CurrencyManager`, `CurrencyConverter`, `MultiCurrencyNetWorth`, `FxExposureMatrix` (renders `HedgingRecommendations` internally).
- **Tax Estimator** tab → now also `TaxLossHarvester` + `TaxLossHarvesting` (renders `CapitalGainsBreakdown` internally).
- **Budgets** tab → now also `BudgetReallocator`.
- **Subscriptions** tab → `SubscriptionAnalyzer` + `SubscriptionAssistant`.
- **AI Tools** tab → Monte-Carlo retirement, drip analyzer, news sentiment, financial literacy bot, options strategy builder, peer comparison, ESG dashboard, multi-scenario matrix, Plaid link, real estate tracker, crypto tracker, receipt uploader, SMS opt-in, voice expense logger.

Child components that are only reachable through their parent (`ReportPreview`, `HedgingRecommendations`, `ComplianceScorecard`, `CapitalGainsBreakdown`, `ScenarioEditorModal`) are intentionally not mounted separately to avoid rendering them twice.

## Files changed

- `src/App.tsx` — imported 25 components, added 7 sidebar nav items, added/extended render blocks for reports, insights, compliance, currencies, tax, budgets, subscriptions, and a new AI Tools toolbox tab.

## Testing

- `npm run typecheck` passes.
- Every newly mounted screen renders via its sidebar nav item; screens that need real data receive `user`; screens that self-fetch demo `/api/*` routes retain their existing (pre-#895) behavior.

## Notes for the maintainer

- This PR intentionally overlaps with #901 (the Currencies tab render block). If #901 merges first, the currencies block here supersedes it — the region overlaps by design and this version mounts the full currency feature set.
- The Compliance mount uses `{...({ user } as any)}` so it stays compatible whether or not #904 (which changes `ComplianceAuditDashboard` to require a `user` prop) has merged yet.

Closes #897
