### PR TITLE
fix: align both forecast engines on shared next-month window

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -9,6 +9,7 @@ import {
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import { toDate, normalizeTransactionType } from "@/src/lib/utils";
+import { getForecastMonths } from "@/src/lib/forecastMonthUtils";
 
 export interface Transaction {
   id: string;
@@ -57,13 +58,10 @@ function parseTransactionDate(raw: unknown): Date {
 }
 
 function getNextMonths(count: number): string[] {
-  const months: string[] = [];
-  const now = new Date();
-  for (let i = 0; i < count; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-    months.push(getMonthKey(d));
-  }
-  return months;
+  // Shared forecast-window convention: forecast months start at the NEXT
+  // calendar month so the cash-flow engine agrees with the Forecast
+  // Comparison engine (issue #900).
+  return getForecastMonths(count);
 }
 
 export async function fetchUserTransactions(

--- a/src/lib/forecastMonthUtils.ts
+++ b/src/lib/forecastMonthUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared forecast-month conventions (issue #900).
+ *
+ * Both forecast engines (cash flow vs forecast comparison) must agree on what
+ * counts as a "forecast" month. The single convention used across the app:
+ * forecast months start at the NEXT calendar month — a partial current month is
+ * never projected; the current month is always treated as history.
+ */
+
+export const FORECAST_WINDOW_MONTHS = 6;
+
+export function monthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * Returns the next `count` calendar-month keys ("yyyy-MM"), starting one month
+ * after `now`. The current calendar month is intentionally excluded so a
+ * partially-elapsed month is never labelled "projected".
+ */
+export function getForecastMonths(
+  count: number = FORECAST_WINDOW_MONTHS,
+): string[] {
+  const months: string[] = [];
+  const now = new Date();
+  for (let i = 0; i < count; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() + 1 + i, 1);
+    months.push(monthKey(d));
+  }
+  return months;
+}

--- a/src/lib/forecastUtils.ts
+++ b/src/lib/forecastUtils.ts
@@ -12,8 +12,9 @@ import {
   orderBy,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
-import { format, addMonths, isWithinInterval } from 'date-fns';
+import { format, isWithinInterval } from 'date-fns';
 import { toDate } from './utils';
+import { getForecastMonths } from './forecastMonthUtils';
 
 export interface ForecastData {
   id: string;
@@ -95,8 +96,9 @@ export function generateMonthlyForecast(
   const volatilityPenalty = (incomeCV + expenseCV) * 100;
 
   const forecasts: MonthlyForecast[] = [];
+  const forecastMonths = getForecastMonths(monthsAhead);
   for (let i = 0; i < monthsAhead; i++) {
-    const month = format(addMonths(new Date(), i + 1), 'yyyy-MM');
+    const month = forecastMonths[i];
     const income = avgIncome;
     const expenses = avgExpenses;
     const confidence = Math.max(


### PR DESCRIPTION
## Problem

The two forecast engines disagree about which months are "forecast" months:

- **Cash Flow page** — `calculateMonthlyForecast` (`src/lib/cashflowUtils.ts`) builds its output from `getNextMonths`, which **starts at the current calendar month**, so `2026-08` is labelled "projected".
- **Forecast Comparison page** — `generateMonthlyForecast` (`src/lib/forecastUtils.ts`) starts one month ahead (`i + 1`), so the current month is treated as history and projections begin at `2026-09`.

The same user therefore sees the current month labeled "projected" in one tab and "history" in another.

## Fix

Adopted the single convention recommended in the issue — **forecast months start at the next calendar month, so a partial current month is never projected** — and factored the month-window logic into one shared utility so the two engines cannot drift apart again:

- **New `src/lib/forecastMonthUtils.ts`** — the single source of truth:
  - `FORECAST_WINDOW_MONTHS = 6`
  - `monthKey(date)` — `yyyy-MM` label
  - `getForecastMonths(count)` — next `count` calendar-month keys starting **one month after now**.
- **`src/lib/forecastUtils.ts`** — `generateMonthlyForecast` now derives its month labels from the shared `getForecastMonths(monthsAhead)` instead of an inline `format(addMonths(...), 'yyyy-MM')`.
- **`src/lib/cashflowUtils.ts`** — `getNextMonths` now delegates to the shared `getForecastMonths`, so the cash-flow engine uses the exact same month window as the forecast-comparison engine.

Both engines now report `2026-09 … 2027-02` for a 6-month projection in August 2026, and the current month (`2026-08`) is treated as history everywhere.

## Files changed

- `src/lib/forecastMonthUtils.ts` (new) — shared forecast-window helper.
- `src/lib/forecastUtils.ts` — `generateMonthlyForecast` uses the shared helper (dropped now-unused `addMonths` import).
- `src/lib/cashflowUtils.ts` — `getNextMonths` delegates to the shared helper.

## Testing

- `npm run typecheck` passes.
- Standalone test: `getForecastMonths()` returns `[2026-09 … 2027-02]` in Aug 2026 — never includes the current month, always contiguous, count honored; static check confirms both `cashflowUtils` and `forecastUtils` reference the single shared helper.

## Note for the maintainer

This PR intentionally overlaps with #908 (issue #893), which already aligns the cash-flow engine's `getNextMonths` on its own branch. Here the same function delegates to the new shared helper, so if #908 merges first the only conflict is the one `getNextMonths` function, and this version's delegation is the intended end state (single shared source).

Closes #900
