### PR TITLE
fix: remove 20-char truncation in subscription group key generation

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -215,9 +215,7 @@ export function groupTransactionsIntoSubscriptions(
     }
 
     if (!matchedKey) {
-      const newKey =
-        normalized.length > 20 ? normalized.substring(0, 20) : normalized;
-      groups.set(newKey, [transaction]);
+      groups.set(normalized, [transaction]);
     } else {
       const existing = groups.get(matchedKey)!;
       existing.push(transaction);
@@ -512,15 +510,14 @@ export async function detectAndSaveSubscriptions(
     if (!analysis || analysis.confidence < 0.4) continue;
 
     const name = txns[0].description || key;
-    const normalized = name.length > 20 ? name.substring(0, 20) : name;
 
-    if (existingNames.has(normalized.toLowerCase())) continue;
+    if (existingNames.has(name.toLowerCase())) continue;
 
     const nextRenewal = predictNextRenewalDate(txns, analysis.frequency);
 
     try {
       const id = await saveSubscription(userId, {
-        name: normalized,
+        name: name,
         amount: txns[0].amount,
         frequency: analysis.frequency,
         category: txns[0].category || "Other",
@@ -532,7 +529,7 @@ export async function detectAndSaveSubscriptions(
       createdSubs.push({
         id,
         userId,
-        name: normalized,
+        name: name,
         amount: txns[0].amount,
         frequency: analysis.frequency,
         category: txns[0].category || "Other",


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the 20-character truncation from `groupTransactionsIntoSubscriptions` and `createSubscriptionsFromGroups` in `src/lib/subscriptionUtils.ts`. Distinct subscriptions that share a description prefix longer than 20 characters are no longer incorrectly merged.

## Changes Made

1. In `groupTransactionsIntoSubscriptions`: use the full `normalized` string as the group key instead of `normalized.substring(0, 20)`
2. In `createSubscriptionsFromGroups`: use the full `name` variable instead of a truncated copy for both the duplicate-check and the saved subscription name

## Impact it Made

- Subscription grouping correctly distinguishes between related but different subscription plans
- Revenue and expense analysis are more accurate
- Users with multiple subscriptions sharing a prefix (e.g., "Netflix Premium Monthly" vs "Netflix Premium Yearly") are no longer incorrectly aggregated

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #917
