### PR TITLE
fix: use endOfDay boundary so final day transactions are included in report presets

### DIFF
--- a/src/components/reports/ReportExport.tsx
+++ b/src/components/reports/ReportExport.tsx
@@ -34,7 +34,7 @@ import {
   FileSpreadsheet,
   Printer,
 } from "lucide-react";
-import { format, subDays, startOfMonth, endOfMonth } from "date-fns";
+import { format, subDays, startOfMonth, endOfMonth, endOfDay } from "date-fns";
 import {
   fetchTransactionsForDateRange,
   generateExpenseSummary,
@@ -97,7 +97,7 @@ function getDateRange(
 
   if (preset === "Last 3 Months") {
     const start = startOfMonth(subDays(today, 90));
-    return { start, end: today };
+    return { start, end: endOfDay(today) };
   }
 
   if (preset === "Custom" && customStart && customEnd) {
@@ -105,7 +105,7 @@ function getDateRange(
   }
 
   const days = preset === "Last 7 Days" ? 7 : 30;
-  return { start: subDays(today, days), end: today };
+  return { start: subDays(today, days), end: endOfDay(today) };
 }
 
 export function ReportExport() {


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed `getDateRange` in `src/components/reports/ReportExport.tsx` to use `endOfDay(today)` as the end boundary instead of `today` (which is midnight). This ensures that transactions occurring on the final day of a date preset range are included in the report.

## Changes Made

1. Added `endOfDay` import from `date-fns`
2. Changed `"Last 3 Months"` preset: `end: today` -> `end: endOfDay(today)`
3. Changed `"Last 7 Days"` and `"Last 30 Days"` presets: `end: today` -> `end: endOfDay(today)`

The `"This Month"` preset already correctly uses `endOfMonth(today)`.

## Impact it Made

- Transactions on the current day are now included in "Last 7 Days", "Last 30 Days", and "Last 3 Months" report presets
- Report exports are no longer missing the final day's transactions
- Users get complete, accurate financial reports

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #888
