### PR TITLE
fix(csv): quote/escape fields and neutralise formula injection (#861)

### DIFF
--- a/src/lib/forecastUtils.ts
+++ b/src/lib/forecastUtils.ts
@@ -15,6 +15,7 @@ import { db, handleFirestoreError, OperationType } from './firebase';
 import { format, isWithinInterval } from 'date-fns';
 import { toDate } from './utils';
 import { getForecastMonths } from './forecastMonthUtils';
+import { csvEscape } from './reportUtils';
 
 export interface ForecastData {
   id: string;
@@ -201,12 +202,13 @@ export function applyFilters<T extends { month: string }>(
 }
 
 export function exportForecastChart(data: MonthlyForecast[]): string {
+  const esc = (v: unknown) => csvEscape(v);
   const lines = [
     'FinSight AI — Forecast Export',
     '============================',
     '',
     'Month,Income,Expenses,Net Balance,Confidence',
-    ...data.map((d) => `${d.month},${d.income},${d.expenses},${d.net},${d.confidence}%`),
+    ...data.map((d) => [esc(d.month), esc(d.income), esc(d.expenses), esc(d.net), esc(d.confidence + '%')].join(',')),
     '',
     `Generated: ${format(new Date(), 'yyyy-MM-dd HH:mm')}`,
   ];

--- a/src/lib/reportUtils.ts
+++ b/src/lib/reportUtils.ts
@@ -18,6 +18,24 @@ import { format, startOfDay, endOfDay } from "date-fns";
 import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
 
+/**
+ * RFC 4180 CSV field escaping. Wraps values containing a comma, double quote,
+ * or newline in double quotes (doubling any inner quotes) and neutralises
+ * CSV-injection by prefixing a single quote to values that Excel/Sheets would
+ * otherwise interpret as a formula (=, +, -, @, Tab, Carriage Return). Pure
+ * numbers (e.g. negative amounts like -50.00) are left untouched.
+ */
+export function csvEscape(value: unknown): string {
+  const str = value == null ? "" : String(value);
+  const needsQuote = /[",\n\r]/.test(str);
+  let escaped = str.replace(/"/g, '""');
+  const isNumeric = str.trim() !== "" && Number.isFinite(Number(str));
+  if (!isNumeric && /^[=+\-@\t\r]/.test(str)) {
+    escaped = "'" + escaped;
+  }
+  return needsQuote ? `"${escaped}"` : escaped;
+}
+
 export interface ReportTransaction {
   id: string;
   userId: string;
@@ -163,25 +181,37 @@ export function generateCSV(reportData: ReportData): string {
   lines.push("Expenses");
   reportData.expenseSummary.forEach((item) => {
     lines.push(
-      `${item.category},Expense,${item.total.toFixed(2)},${item.count}`,
+      [csvEscape(item.category), csvEscape("Expense"), csvEscape(item.total.toFixed(2)), csvEscape(item.count)].join(","),
     );
   });
   lines.push("");
   lines.push("Income");
   reportData.incomeSummary.forEach((item) => {
-    lines.push(`${item.source},Income,${item.total.toFixed(2)},${item.count}`);
+    lines.push(
+      [csvEscape(item.source), csvEscape("Income"), csvEscape(item.total.toFixed(2)), csvEscape(item.count)].join(","),
+    );
   });
   lines.push("");
   lines.push(
-    `Summary,,Total Income:${reportData.totalIncome.toFixed(2)},Total Expenses:${reportData.totalExpenses.toFixed(2)}`,
+    [
+      csvEscape("Summary"),
+      csvEscape(""),
+      csvEscape(`Total Income:${reportData.totalIncome.toFixed(2)}`),
+      csvEscape(`Total Expenses:${reportData.totalExpenses.toFixed(2)}`),
+    ].join(","),
   );
   lines.push("");
   lines.push("Transaction Details");
   lines.push("Date,Description,Category,Amount,Type");
   reportData.transactions.forEach((t) => {
-    const desc = (t.description || "").replace(/,/g, ";");
     lines.push(
-      `${formatDateShort(t.date)},${desc},${t.category},${t.amount.toFixed(2)},${t.type || "expense"}`,
+      [
+        csvEscape(formatDateShort(t.date)),
+        csvEscape(t.description || ""),
+        csvEscape(t.category),
+        csvEscape(t.amount.toFixed(2)),
+        csvEscape(t.type || "expense"),
+      ].join(","),
     );
   });
   return lines.join("\n");

--- a/tests/csv-escape.test.mjs
+++ b/tests/csv-escape.test.mjs
@@ -1,0 +1,153 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+function csvEscape(value) {
+  const str = value == null ? "" : String(value);
+  const needsQuote = /[",\n\r]/.test(str);
+  let escaped = str.replace(/"/g, '""');
+  const isNumeric = str.trim() !== "" && Number.isFinite(Number(str));
+  if (!isNumeric && /^[=+\-@\t\r]/.test(str)) {
+    escaped = "'" + escaped;
+  }
+  return needsQuote ? `"${escaped}"` : escaped;
+}
+
+function parseCsvLine(line) {
+  const out = [];
+  let cur = "";
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQ) {
+      if (c === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else inQ = false;
+      } else cur += c;
+    } else {
+      if (c === ",") {
+        out.push(cur);
+        cur = "";
+      } else if (c === '"') inQ = true;
+      else cur += c;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+test("simple values are not quoted", () => {
+  assert.equal(csvEscape("Groceries"), "Groceries");
+});
+
+test("comma values are quoted", () => {
+  assert.equal(csvEscape("Food, Dining"), '"Food, Dining"');
+});
+
+test("double quotes are doubled and wrapped", () => {
+  assert.equal(csvEscape('Say "hi"'), '"Say ""hi"""');
+});
+
+test("newline values are quoted", () => {
+  assert.equal(csvEscape("a\nb"), '"a\nb"');
+});
+
+test("formula injection with = is neutralised", () => {
+  const out = csvEscape("=HYPERLINK(http://evil)");
+  assert.equal(out, "'=HYPERLINK(http://evil)");
+  // a formula containing a comma is both quoted and neutralised
+  const out2 = csvEscape("=HYPERLINK(\"http://evil\", \"x\")");
+  assert.equal(out2, '"\'=HYPERLINK(""http://evil"", ""x"")"');
+  const parsed = parseCsvLine(out2)[0];
+  assert.equal(parsed, "'=HYPERLINK(\"http://evil\", \"x\")");
+});
+
+test("@-prefixed formula is neutralised", () => {
+  assert.equal(csvEscape("@SUM(A1)"), "'@SUM(A1)");
+});
+
+test("text-prefixed + is neutralised", () => {
+  assert.equal(csvEscape("+abc"), "'+abc");
+});
+
+test("negative numbers are NOT treated as formulas", () => {
+  assert.equal(csvEscape("-50.00"), "-50.00");
+});
+
+test("positive numbers untouched", () => {
+  assert.equal(csvEscape("42"), "42");
+});
+
+test("numeric input untouched", () => {
+  assert.equal(csvEscape(42), "42");
+});
+
+test("null and undefined become empty", () => {
+  assert.equal(csvEscape(null), "");
+  assert.equal(csvEscape(undefined), "");
+});
+
+test("comma-containing row round-trips through a CSV parse", () => {
+  const row = [
+    csvEscape("Food, Dining"),
+    csvEscape("Expense"),
+    csvEscape("100.00"),
+    csvEscape(3),
+  ].join(",");
+  const parsed = parseCsvLine(row);
+  assert.equal(parsed.length, 4);
+  assert.equal(parsed[0], "Food, Dining");
+  assert.equal(parsed[1], "Expense");
+});
+
+test("a full generateCSV-style row with injection round-trips safely", () => {
+  const row = [
+    csvEscape("=cmd|/c calc"),
+    csvEscape("Expense"),
+    csvEscape("100.00"),
+  ].join(",");
+  const parsed = parseCsvLine(row);
+  assert.equal(parsed.length, 3);
+  assert.equal(parsed[0], "'=cmd|/c calc");
+});
+
+test("generateCSV uses csvEscape on every field (source wiring)", async () => {
+  const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const path = await import("node:path");
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const src = readFileSync(
+    path.join(repoRoot, "src", "lib", "reportUtils.ts"),
+    "utf8",
+  );
+  assert.match(src, /export function csvEscape/);
+  const genStart = src.indexOf("export function generateCSV");
+  const genBody = src.slice(genStart, src.indexOf("return lines.join", genStart));
+  // generateCSV must reference csvEscape, not raw interpolation.
+  assert.match(genBody, /csvEscape/);
+  assert.doesNotMatch(genBody, /\$\{item\.category\},/);
+  assert.doesNotMatch(genBody, /\$\{t\.description\|\|/);
+});
+
+test("exportForecastChart uses csvEscape (source wiring)", async () => {
+  const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const path = await import("node:path");
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const src = readFileSync(
+    path.join(repoRoot, "src", "lib", "forecastUtils.ts"),
+    "utf8",
+  );
+  assert.match(src, /import \{ csvEscape \} from ['"]\.\/reportUtils['"]/);
+  const fnStart = src.indexOf("export function exportForecastChart");
+  const fnBody = src.slice(fnStart, src.indexOf("return lines.join", fnStart));
+  assert.match(fnBody, /csvEscape/);
+  assert.doesNotMatch(fnBody, /\$\{d\.month\},/);
+});


### PR DESCRIPTION
## What

Fixes #861

`generateCSV` (`src/lib/reportUtils.ts`) and `exportForecastChart` (`src/lib/forecastUtils.ts`) built CSV rows with raw template interpolation (`${item.category},...`) and a `description.replace(/,/g, ';')` hack. This caused two defects: (1) comma/quote/newline-containing fields corrupt columns, and (2) values starting with `=`, `+`, `-`, `@` become live formulas in Excel/Sheets (CSV injection) — a real risk for an exported financial report a user opens in Excel.

## Fix

Added a `csvEscape(value)` helper in `reportUtils.ts` (imported by `forecastUtils.ts`):

- Wraps values containing `,`, `"`, or `\n`/`\r` in double quotes, doubling inner quotes (RFC 4180).
- Prefixes a single quote `'` to values starting with `=`, `+`, `-`, `@`, `\t`, `\r` to neutralise formula injection.
- Leaves pure numbers (e.g. `-50.00` amounts) untouched, so negative transaction totals aren't mangled.

Applied it to **every field** in `generateCSV` (expense/income/summary/transaction rows — removed the old `description.replace(/,/g, ';')` hack in favor of proper quoting) and to the data rows in `exportForecastChart`.

## Verification

New test `tests/csv-escape.test.mjs` (15 tests, all pass):
- Simple values unquoted; comma/quote/newline values quoted correctly.
- `=HYPERLINK(...)`, `@SUM(A1)`, `+abc` neutralised with leading `'`.
- Negative numbers (`-50.00`) NOT treated as formulas.
- `null`/`undefined` → empty.
- Round-trip parse: a comma-containing category parses back to one field (no column corruption).
- Source-wiring assertions confirming `generateCSV` and `exportForecastChart` use `csvEscape` (no raw `${item.category},` interpolation remains).

Existing tests unaffected (`cashflow-balance-projection.test.mjs` still 3/3).

## Impact

- CSV exports are now RFC 4180-compliant — comma-containing categories/descriptions no longer shift columns.
- Formula injection is neutralised, so a malicious category/merchant value can't execute a formula when the report is opened in a spreadsheet.
- No behavior change for clean numeric values.

## Files changed

- `src/lib/reportUtils.ts` — added `csvEscape` helper; rewrote `generateCSV` to escape every field.
- `src/lib/forecastUtils.ts` — import `csvEscape`; `exportForecastChart` escapes data rows.
- `tests/csv-escape.test.mjs` — new, 15 tests.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._