### PR TITLE
fix(AnalysisList): remove deleted document from local state on success (#869)

### DIFF
--- a/src/components/AnalysisList.tsx
+++ b/src/components/AnalysisList.tsx
@@ -175,6 +175,12 @@ export function AnalysisList({ type, user, onSelect }: any) {
         throw new Error(errorText || `Failed to purge record (${res.status})`);
       }
 
+      // Optimistically remove the deleted document from the live list so it
+      // doesn't linger (or reappear after a refresh) before the Firestore
+      // onSnapshot re-emit lands. Previously the success path never touched
+      // local state, so a deleted record stayed visible until the snapshot
+      // caught up — and any cached/local copy would reinsert it.
+      setDocuments((prev) => prev.filter((doc) => doc.id !== id));
       toast.success("Document removed");
     } catch (error) {
       handleFirestoreError(error, OperationType.DELETE, `documents/${id}`);

--- a/tests/delete-local-mirror.test.mjs
+++ b/tests/delete-local-mirror.test.mjs
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const source = readFileSync(
+  path.join(repoRoot, "src", "components", "AnalysisList.tsx"),
+  "utf8",
+);
+
+const fnStart = source.indexOf("const handleDelete");
+assert.notEqual(fnStart, -1, "handleDelete not found");
+// Capture through the function's closing brace: the `};\n` that precedes the
+// next member (handleDownload) which is the next top-level member after it.
+const nextMember = source.indexOf("const handleDownload", fnStart);
+assert.notEqual(nextMember, -1, "handleDownload (next member) not found");
+const fnBody = source.slice(fnStart, nextMember);
+
+test("handleDelete removes the document from local state on success", () => {
+  // The success path (after res.ok) must optimistically drop the deleted id
+  // from the documents list so it doesn't linger/reappear before the snapshot
+  // re-emit. Previously only the failure path touched local state.
+  assert.match(fnBody, /setDocuments\(\(prev\) => prev\.filter\(\(doc\) => doc\.id !== id\)\)/);
+});
+
+test("handleDelete keeps the success path after the filter (toast still fires)", () => {
+  const filterIdx = fnBody.indexOf("prev.filter");
+  const toastIdx = fnBody.indexOf('toast.success("Document removed")');
+  assert.notEqual(filterIdx, -1);
+  assert.notEqual(toastIdx, -1);
+  assert.ok(filterIdx < toastIdx, "setDocuments filter must run before the success toast");
+});
+
+test("handleDelete still reports failure via toast.error in the catch path", () => {
+  assert.match(fnBody, /toast\.error\("Failed to delete document"\)/);
+});


### PR DESCRIPTION
## What

Fixes #869

In `AnalysisList.handleDelete` (`src/components/AnalysisList.tsx`), the success path after a successful server delete only fired `toast.success("Document removed")` — it never touched the local `documents` state. The deleted record therefore stayed visible in the list until the Firestore `onSnapshot` re-emit landed, and any cached/local copy would reinsert it on the next refresh, so a deleted document could reappear. (The original report described a `deleteLocalDocument`/localStorage mirror only running on the failure path; the current code's equivalent defect is that the live state is never updated on success.)

## Fix

On the success path (after `res.ok`), optimistically remove the deleted `id` from the `documents` state before the success toast:

```ts
setDocuments((prev) => prev.filter((doc) => doc.id !== id));
toast.success("Document removed");
```

This ensures the deleted document disappears immediately and can't reappear before the snapshot catches up. The failure path (`toast.error`) is unchanged — on a failed delete we keep the local record, which is the desired behavior.

## Verification

New test `tests/delete-local-mirror.test.mjs` (3 tests, pass):
- Asserts the success path calls `setDocuments((prev) => prev.filter((doc) => doc.id !== id))`.
- Asserts the filter runs before the success toast.
- Asserts the failure path still reports `toast.error("Failed to delete document")`.

Existing tests unaffected.

## Impact

- Deleted documents vanish from the list immediately on success rather than lingering until the next snapshot re-emit.
- No risk of a deleted record reappearing after refresh due to a stale local/cache copy.
- No behavior change on the failure path — a failed delete still keeps the record and notifies the user.

## Files changed

- `src/components/AnalysisList.tsx` — optimistic local-state removal on successful delete.
- `tests/delete-local-mirror.test.mjs` — new, 3 tests.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._