### PR TITLE
fix(auth): drop stale emailVerified from signup setDoc (#866 follow-up)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -469,7 +469,6 @@ export default function App() {
           uid: newUser.uid,
           username: username,
           email: email,
-          emailVerified: newUser.emailVerified,
           role: DEFAULT_ROLE,
           createdAt: new Date().toISOString(),
         });


### PR DESCRIPTION
## Summary

Follow-up to #937 (merged). The original PR removed the stale `emailVerified` field from `getDefaultProfile`, but the **signup `setDoc` write path was missed** — it still persists `emailVerified: newUser.emailVerified` into the `users/{uid}` document on signup. This PR completes the fix by dropping that one line.

Closes the remaining half of #866.

## Why this matters

The `emailVerified` field stored in the Firestore `users` profile is a **stale copy** of Firebase Auth's source-of-truth token claim. Persisting it on signup means the profile can disagree with the Auth token after a user verifies their email (the profile keeps `false` until rewritten), which is exactly the drift bug #866 targeted. #937 removed it from `getDefaultProfile`; the signup write path still had it, so the bug was only half-fixed on `main`.

## Change

`src/App.tsx` — remove `emailVerified: newUser.emailVerified,` from the `setDoc(doc(db, "users", newUser.uid), { ... })` block on signup. One line deleted; the rest of the profile payload (`uid`, `username`, `email`, `role`, `createdAt`) is unchanged. Verification state continues to be read from the Auth token elsewhere in the file (`currentUser.emailVerified`, `auth.currentUser.emailVerified`), and the `firestore.rules` gate on `request.auth.token.email_verified` is untouched.

## Verification

- `node --test tests/email-verified-profile.test.mjs` — **4/4 pass** (including test #2 "signup setDoc does not write emailVerified", which fails on `main` and passes with this change)
- `tsc --noEmit` — 74 errors, identical to the `main` baseline (no new type errors introduced; the 74 are pre-existing in `ComplianceAuditDashboard.tsx` / `cashflowUtils.ts` / `complianceUtils.ts` / `api/analyze.ts`, all unrelated to this change)
- Branch is a single clean commit on top of `main` (no merge commits, no `package-lock.json` churn, no drift)

## Test added

`tests/email-verified-profile.test.mjs` — asserts (1) `getDefaultProfile` has no `emailVerified`, (2) the signup `setDoc` block has no `emailVerified`, (3) the Auth-token reads still exist, (4) `firestore.rules` still ties `isSignedIn()` to `request.auth.token.email_verified`. Test #2 is the regression guard for this specific follow-up.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
