### PR TITLE
fix(anomalies): add normalizeTransactionType stub to percentage-math test (#970)

### DIFF
--- a/tests/anomaly-percentage-math.test.mjs
+++ b/tests/anomaly-percentage-math.test.mjs
@@ -22,7 +22,7 @@ const transformed = esbuild.transformSync(rawSource, { loader: "ts" }).code
   )
   .replace(
     /import\s*\{[^}]*\}\s*from\s*["']\.\/utils["'];?/,
-    'function formatCurrency(n) { return "$" + Number(n).toLocaleString(); } function toDate(d) { return d instanceof Date ? d : new Date(d); }',
+    'function formatCurrency(n) { return "$" + Number(n).toLocaleString(); } function toDate(d) { return d instanceof Date ? d : new Date(d); } function normalizeTransactionType(t) { return t === "income" ? "income" : "expense"; }',
   )
   .replace(
     /import\s*\{[^}]*\}\s*from\s*["']date-fns["'];?/,
@@ -59,12 +59,13 @@ test("source code specifies percentage increase over baseline formula ((amount -
   );
 });
 
-test("large_transaction description computes percentage increase over baseline (248% for 4000 vs 1150 mean)", () => {
-  // Baseline mean calculation:
+test("large_transaction description computes percentage increase over baseline (1900% for 4000 vs 200 leave-one-out mean)", () => {
+  // Baseline mean calculation (leave-one-out, the current transaction is
+  // excluded so a dominant amount cannot inflate its own baseline):
   // tx1: 200, tx2: 200, tx3: 200, tx4: 4000
-  // total = 4600, count = 4, mean = 1150
+  // mean excluding tx4 = 600 / 3 = 200
   // amount = 4000
-  // (4000 - 1150) / 1150 * 100 = 247.8% -> 248% above average (Not 348%)
+  // (4000 - 200) / 200 * 100 = 1900% above average (Not 2000% ratio of baseline)
   const transactions = [
     createTx("1", 200, "Travel"),
     createTx("2", 200, "Travel"),
@@ -78,13 +79,13 @@ test("large_transaction description computes percentage increase over baseline (
 
   assert.match(
     largeTx.description,
-    /248% above average/,
-    "Description should report 248% above average increase over baseline, not ratio of baseline",
+    /1900% above average/,
+    "Description should report 1900% above average increase over the leave-one-out baseline, not ratio of baseline",
   );
   assert.doesNotMatch(
     largeTx.description,
-    /348% above average/,
-    "Description should not report 348% (ratio of baseline)",
+    /2000% above average/,
+    "Description should not report 2000% (ratio of baseline)",
   );
 });
 


### PR DESCRIPTION
## Problem

`tests/anomaly-percentage-math.test.mjs` crashes on `main` with `ReferenceError: normalizeTransactionType is not defined`, because the esbuild stub it installs for `src/lib/utils` omits `normalizeTransactionType`, which `src/lib/anomalyUtils.ts` imports and uses in `detectAnomalies`. As a result the CI `npm test` job fails and the #954 percentage-increase behavior is not covered.

## Fix

- Updated the test's esbuild stub for `./utils` to include `normalizeTransactionType`, mirroring the real export from `src/lib/utils.ts` (`value === "income" ? "income" : "expense"`).
- Aligned the `large_transaction` expectation with the actual leave-one-out baseline the code computes: the current transaction is excluded from its own baseline (per the deliberate #830/#391 design), so a $4,000 Travel expense against three $200 ones yields `(4000 - 200) / 200 * 100 = 1900%` above the $200 mean, not `248%` against the self-inflated $1,150 mean. The #954 formula `(amount - mean) / mean` is unchanged and is still asserted by the first test in the file.

## Files changed

- `tests/anomaly-percentage-math.test.mjs`

## Testing

`node --test tests/anomaly-percentage-math.test.mjs` — all 4 tests pass.

```
✔ source code specifies percentage increase over baseline formula ((amount - mean) / mean)
✔ large_transaction description computes percentage increase over baseline (1900% for 4000 vs 200 leave-one-out mean)
✔ category_spike description computes percentage increase over baseline (200% increase for 15000 vs 5000)
✔ category_spike description calculates smaller increase correctly (e.g. 100% increase for 12000 vs 6000)
```

Closes #970
