### PR TITLE
fix(cashflow): keep current month at real balance in calculateBalanceProjection (#971)

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -234,13 +234,14 @@ export function calculateBalanceProjection(
   // Seed with the user's real current account balance. Past net cash flow is
   // NOT used as the seed (it is a cumulative figure, not a balance) so the
   // projection reflects an actual account balance rather than a fabricated
-  // sum of up to six months of activity. The forecast starts at the month
-  // after the current one, so every projected month advances the balance and
-  // the displayed balance is consistent with the displayed projected net.
+  // sum of up to six months of activity. The current month is pinned to the
+  // real balance; only future months advance it, so the displayed balance is
+  // consistent with the displayed projected net.
   let currentBalance = startingBalance;
+  const currentMonth = getMonthKey(new Date());
 
   return forecast.map((f) => {
-    currentBalance += f.projectedNet;
+    if (f.month !== currentMonth) currentBalance += f.projectedNet;
     return {
       month: f.month,
       projectedBalance: Math.round(currentBalance * 100) / 100,


### PR DESCRIPTION
## Problem

`tests/cashflow-balance-projection.test.mjs` fails the "reports today's real balance for the current month" assertion because `calculateBalanceProjection` in `src/lib/cashflowUtils.ts` advances the projected balance for **every** forecast month. If the forecast ever contains the current (still-running) month, the chart shows a projected balance instead of the account's real balance today — contradicting the function's own "seed with the real balance" comment.

## Fix

Computed the current month key once (`const currentMonth = getMonthKey(new Date())`) and only advanced `currentBalance` for future months (`if (f.month !== currentMonth) currentBalance += f.projectedNet;`), matching the contract the test pins. The current month stays at the user's real starting balance.

## Files changed

- `src/lib/cashflowUtils.ts`

## Testing

`node --test tests/cashflow-balance-projection.test.mjs` — all 3 tests pass.

```
✔ projection seeds from the real starting balance, not cumulative net flow
✔ projection reports today's real balance for the current month
✔ projection only advances the balance on future months
```

Closes #971
