### PR TITLE
fix(cashflow): restore balanced identifyRecurringTransactions implementation (#956)

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -281,32 +281,7 @@ export function identifyRecurringTransactions(
     } else {
       groups.push({ key, category: t.category, type: t.type, txns: [t] });
     }
-  const categoryMap: Record<
-    string,
-    { amounts: number[]; dates: Date[]; type: "income" | "expense" }
-  > = {};
-  transactions.forEach((t) => {
-    if (!categoryMap[t.category]) {
-      categoryMap[t.category] = { amounts: [], dates: [], type: t.type };
-    }
-    categoryMap[t.category].amounts.push(t.amount);
-    categoryMap[t.category].dates.push(t.date);
   });
-
-  function detectFrequency(dates: Date[]): "weekly" | "monthly" | "quarterly" {
-    if (dates.length < 2) return "monthly";
-    const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
-    const gaps: number[] = [];
-    for (let i = 1; i < sorted.length; i++) {
-      gaps.push(sorted[i].getTime() - sorted[i - 1].getTime());
-    }
-    const medianMs = [...gaps].sort((a, b) => a - b)[Math.floor(gaps.length / 2)];
-    const medianDays = medianMs / (1000 * 60 * 60 * 24);
-    if (Math.abs(medianDays - 7) <= 5) return "weekly";
-    if (Math.abs(medianDays - 30) <= 7) return "monthly";
-    if (Math.abs(medianDays - 91) <= 14) return "quarterly";
-    return "monthly";
-  }
 
   const recurring: RecurringTransaction[] = [];
   groups.forEach((group) => {
@@ -331,21 +306,6 @@ export function identifyRecurringTransactions(
       averageAmount: Math.round(avg * 100) / 100,
       frequency: inferRecurrenceFrequency(group.txns.map((t) => t.date)),
     });
-  Object.entries(categoryMap).forEach(([category, data]) => {
-    if (data.amounts.length >= 3) {
-      const avg = data.amounts.reduce((a, b) => a + b, 0) / data.amounts.length;
-      const variance =
-        data.amounts.reduce((sum, amt) => sum + Math.abs(amt - avg), 0) /
-        data.amounts.length;
-      if (avg === 0 || variance / avg < 0.3) {
-        recurring.push({
-          category,
-          type: data.type,
-          averageAmount: Math.round(avg * 100) / 100,
-          frequency: detectFrequency(data.dates),
-        });
-      }
-    }
   });
 
   return recurring.sort((a, b) => b.averageAmount - a.averageAmount);


### PR DESCRIPTION
## Problem

`src/lib/cashflowUtils.ts` fails to parse, breaking the production build and `npm run typecheck` on `main`. `identifyRecurringTransactions` contains two merged implementations concatenated inside the same function body: the `transactions.forEach((t) => {` of the Group-based pass (lines 254-283) is never closed, so the older `categoryMap`/`detectFrequency` pass and `calculateConfidenceScore` are lexically inside the unclosed block.

## Fix

Restored `identifyRecurringTransactions` to the single, balanced Group-based implementation intended by commit `2f341b4` (#892/#907):

- Closed the `transactions.forEach((t) => {` callback with `});` after the grouping pass.
- Removed the abandoned `categoryMap`/`detectFrequency` implementation and its aggregation block, keeping only the date-aware `groups.forEach` aggregation that uses `inferRecurrenceFrequency`.
- The function now has balanced braces and `calculateConfidenceScore` is recognized as a top-level export.

## Files changed

- `src/lib/cashflowUtils.ts`

## Testing

- `npx esbuild src/lib/cashflowUtils.ts --outfile=/dev/null` now passes.
- `npx tsc --noEmit` no longer reports `src/lib/cashflowUtils.ts(354,1): error TS1005` / `(376,1)`.

Closes #956
