### PR TITLE
fix(fx): label FxExposureMatrix recommendations as sample data (#974)

### DIFF
--- a/src/components/currency/FxExposureMatrix.tsx
+++ b/src/components/currency/FxExposureMatrix.tsx
@@ -4,7 +4,10 @@ import { Globe, DollarSign, ArrowUpRight } from "lucide-react";
 import { HedgingRecommendations, HedgingRecommendation } from "./HedgingRecommendations";
 
 export const FxExposureMatrix: React.FC = () => {
-  const mockRecommendations: HedgingRecommendation[] = [
+  // Sample recommendations used for demo purposes only. They are not derived
+  // from the user's holdings, so the widget is labeled as sample data instead
+  // of presenting them as personalized hedging advice.
+  const sampleRecommendations: HedgingRecommendation[] = [
     {
       id: "fx-01",
       currencyPair: "EUR/USD",
@@ -52,7 +55,11 @@ export const FxExposureMatrix: React.FC = () => {
           </div>
         </div>
 
-        <HedgingRecommendations recommendations={mockRecommendations} />
+        <HedgingRecommendations recommendations={sampleRecommendations} />
+        <p className="text-xs text-slate-500">
+          Sample/demo exposure figures shown for illustration — not derived from
+          your actual holdings or currency positions.
+        </p>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Problem

`src/components/currency/FxExposureMatrix.tsx` takes no props and makes no API/data call. Its entire recommendation set is a hardcoded `mockRecommendations` constant (EUR/USD $145,000 HIGH, GBP/USD $82,000 MEDIUM) with invented hedge costs, and the three stat cards are hardcoded figures too. Every user who opens the currencies screen is shown the same fabricated FX exposure presented as actionable, personalized hedging advice.

## Fix

Since the widget is a demo with no holdings/FX data source, it is now explicitly labeled as sample data instead of presenting it as personalized recommendations:

- Renamed `mockRecommendations` → `sampleRecommendations`.
- Added a visible note under the recommendations: "Sample/demo exposure figures shown for illustration — not derived from your actual holdings or currency positions."

## Files changed

- `src/components/currency/FxExposureMatrix.tsx`

## Testing

Verified the file transforms cleanly with esbuild (no syntax/type errors introduced). The change is presentational only.

Closes #974
