### PR TITLE
fix(cashflow): balance unclosed braces in identifyRecurringTransactions (#967)

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -281,32 +281,7 @@ export function identifyRecurringTransactions(
     } else {
       groups.push({ key, category: t.category, type: t.type, txns: [t] });
     }
-  const categoryMap: Record<
-    string,
-    { amounts: number[]; dates: Date[]; type: "income" | "expense" }
-  > = {};
-  transactions.forEach((t) => {
-    if (!categoryMap[t.category]) {
-      categoryMap[t.category] = { amounts: [], dates: [], type: t.type };
-    }
-    categoryMap[t.category].amounts.push(t.amount);
-    categoryMap[t.category].dates.push(t.date);
   });
-
-  function detectFrequency(dates: Date[]): "weekly" | "monthly" | "quarterly" {
-    if (dates.length < 2) return "monthly";
-    const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
-    const gaps: number[] = [];
-    for (let i = 1; i < sorted.length; i++) {
-      gaps.push(sorted[i].getTime() - sorted[i - 1].getTime());
-    }
-    const medianMs = [...gaps].sort((a, b) => a - b)[Math.floor(gaps.length / 2)];
-    const medianDays = medianMs / (1000 * 60 * 60 * 24);
-    if (Math.abs(medianDays - 7) <= 5) return "weekly";
-    if (Math.abs(medianDays - 30) <= 7) return "monthly";
-    if (Math.abs(medianDays - 91) <= 14) return "quarterly";
-    return "monthly";
-  }
 
   const recurring: RecurringTransaction[] = [];
   groups.forEach((group) => {
@@ -331,21 +306,6 @@ export function identifyRecurringTransactions(
       averageAmount: Math.round(avg * 100) / 100,
       frequency: inferRecurrenceFrequency(group.txns.map((t) => t.date)),
     });
-  Object.entries(categoryMap).forEach(([category, data]) => {
-    if (data.amounts.length >= 3) {
-      const avg = data.amounts.reduce((a, b) => a + b, 0) / data.amounts.length;
-      const variance =
-        data.amounts.reduce((sum, amt) => sum + Math.abs(amt - avg), 0) /
-        data.amounts.length;
-      if (avg === 0 || variance / avg < 0.3) {
-        recurring.push({
-          category,
-          type: data.type,
-          averageAmount: Math.round(avg * 100) / 100,
-          frequency: detectFrequency(data.dates),
-        });
-      }
-    }
   });
 
   return recurring.sort((a, b) => b.averageAmount - a.averageAmount);


### PR DESCRIPTION
## Problem

`src/lib/cashflowUtils.ts` fails to compile: `identifyRecurringTransactions` ends with two unclosed blocks, so `npx tsc --noEmit` reports `src/lib/cashflowUtils.ts(354,1): error TS1005: ',' expected` and `(376,1): error TS1005: '}' expected`. The `calculateConfidenceScore` export is never recognized because the parser is still inside the preceding function.

## Fix

Rebalanced `identifyRecurringTransactions`:

- Closed the `transactions.forEach((t) => {` callback opened by the Group-based pass with `});`.
- Removed the merged-in `categoryMap`/`detectFrequency` implementation and its aggregation block, leaving the single date-aware Group-based implementation (using `inferRecurrenceFrequency`) that was intended by commit `2f341b4` (#892/#907).
- The file now has balanced braces and all exports (`calculateConfidenceScore`, `formatCurrency`) are recognized.

## Files changed

- `src/lib/cashflowUtils.ts`

## Testing

- `npx esbuild src/lib/cashflowUtils.ts --outfile=/dev/null` passes.
- `npx tsc --noEmit` no longer reports `src/lib/cashflowUtils.ts` errors.

Closes #967
