### PR TITLE
fix(cashflow): remove duplicate loadCashFlowData implementation in CashFlowDashboard (#957)

### DIFF
--- a/src/components/cashflow/CashFlowDashboard.tsx
+++ b/src/components/cashflow/CashFlowDashboard.tsx
@@ -66,17 +66,6 @@ export function CashFlowDashboard({ user }: { user: any }) {
     if (!user) return;
     setLoading(true);
     try {
-      const stored = Number(localStorage.getItem("finsight_starting_balance") || 0);
-      const starting = Number.isFinite(stored) ? stored : 0;
-      setStartingBalance(starting);
-      const transactions = await fetchUserTransactions(
-        user.uid,
-        FORECAST_WINDOW_MONTHS,
-      );
-      const forecastData = calculateMonthlyForecast(
-        transactions,
-        FORECAST_WINDOW_MONTHS,
-      );
       const userBalanceKey = startingBalanceKey(user.uid);
       let stored = localStorage.getItem(userBalanceKey);
       if (stored === null) {


### PR DESCRIPTION
## Problem

`src/components/cashflow/CashFlowDashboard.tsx` fails to parse, breaking the production build and `npm run typecheck` on `main`. `loadCashFlowData` contains two merged implementations concatenated inside the same function body, declaring `stored`, `starting`, and `transactions` twice in the same scope:

- Lines 69-79: a window-aligned pass reading the device-global `finsight_starting_balance` key and forecasting with `FORECAST_WINDOW_MONTHS`.
- Lines 80-105: the per-user implementation (user-scoped key with legacy-key migration) resumes mid-function.

`esbuild` fails with `The symbol "stored" has already been declared`.

## Fix

Kept the intended per-user implementation and deleted the merged-in window-aligned pass. `loadCashFlowData` now runs a single, coherent load: resolve the per-user starting balance from the user-scoped key (with legacy-key migration), then fetch and forecast once.

## Files changed

- `src/components/cashflow/CashFlowDashboard.tsx`

## Testing

- `npx esbuild src/components/cashflow/CashFlowDashboard.tsx --outfile=/dev/null` passes.
- `npx tsc --noEmit` no longer reports errors for this file.

Closes #957
