### PR TITLE
fix(compliance): remove spliced mock implementation from ComplianceAuditDashboard (#966)

### DIFF
--- a/src/components/compliance/ComplianceAuditDashboard.tsx
+++ b/src/components/compliance/ComplianceAuditDashboard.tsx
@@ -1,69 +1,3 @@
-import React, { useState } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/src/components/ui/card";
-import { ShieldCheck, ShieldAlert, FileText, CheckCircle2, AlertOctagon } from "lucide-react";
-import { ComplianceScorecard } from "./ComplianceScorecard";
-import { auditFinancialData } from "@/src/lib/complianceUtils";
-
-export const ComplianceAuditDashboard: React.FC = () => {
-  // Sample transactions for compliance demonstration
-  const [mockTransactions] = useState([
-    { amount: 9850, description: "Consulting Fee Deposit", date: "2026-08-01", category: "Revenue" },
-    { amount: 9900, description: "Vendor Wire Transfer", date: "2026-08-02", category: "Vendor" },
-    { amount: -65000, description: "Unclassified Special Transfer", date: "2026-08-03", category: "Other" },
-    { amount: 30000, description: "Inbound Wire Co", date: "2026-08-04", category: "Revenue" },
-    { amount: -28000, description: "Outbound Immediate Transfer", date: "2026-08-05", category: "Withdrawal" },
-  ]);
-
-  const auditResult = auditFinancialData(mockTransactions);
-
-  return (
-    <div className="space-y-6">
-      <ComplianceScorecard data={auditResult} />
-
-import React, { useState, useEffect } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/src/components/ui/card";
-import { ShieldCheck, ShieldAlert, FileText, CheckCircle2 } from "lucide-react";
-import { ComplianceScorecard } from "./ComplianceScorecard";
-import { auditFinancialData } from "@/src/lib/complianceUtils";
-import { fetchUserTransactions } from "@/src/lib/cashflowUtils";
-
-interface ComplianceAuditDashboardProps {
-  user: any;
-}
-
-export const ComplianceAuditDashboard: React.FC<ComplianceAuditDashboardProps> = ({ user }) => {
-  const [transactions, setTransactions] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let active = true;
-    const load = async () => {
-      if (!user) return;
-      try {
-        const data = await fetchUserTransactions(user.uid, 12);
-        if (active) setTransactions(data);
-      } catch (error) {
-        console.error("Failed to load transactions for compliance audit:", error);
-      } finally {
-        if (active) setLoading(false);
-      }
-    };
-    load();
-    return () => {
-      active = false;
-    };
-  }, [user]);
-
-  const auditResult = auditFinancialData(
-    transactions.map((t) => ({
-      amount: t.amount,
-      description: t.description || "",
-      date: t.date,
-      category: t.category,
-      type: t.type,
-    })),
-  );
-  const auditResult = auditFinancialData(mockTransactions);
 import React, { useState, useEffect } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/src/components/ui/card";
 import { ShieldAlert, FileText, CheckCircle2, AlertOctagon, Loader2 } from "lucide-react";
@@ -134,25 +68,8 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
 
   return (
     <div className="space-y-6">
-      {loading ? (
-        <Card className="bg-slate-900 border-slate-800 text-slate-100">
-          <CardContent className="p-8 text-center text-slate-500 text-sm">
-            Loading transactions for compliance audit...
-          </CardContent>
-        </Card>
-      ) : (
-        <>
-          <ComplianceScorecard data={auditResult} />
+      <ComplianceScorecard data={auditResult} />
 
-          <Card className="bg-slate-900 border-slate-800 text-slate-100">
-            <CardHeader className="flex flex-row items-center justify-between pb-4 border-b border-slate-800">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-xl bg-amber-500/10 border border-amber-500/20 flex items-center justify-center text-amber-400">
-                  <ShieldAlert size={22} />
-                </div>
-                <div>
-                  <CardTitle className="text-lg font-bold text-white">Flagged Red-Flag Violations</CardTitle>
-                  <p className="text-xs text-slate-400">Detected compliance exceptions requiring officer sign-off</p>
       <Card className="bg-slate-900 border-slate-800 text-slate-100">
         <CardHeader className="flex flex-row items-center justify-between pb-4 border-b border-slate-800">
           <div className="flex items-center gap-3">
@@ -166,7 +83,6 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
           </div>
         </CardHeader>
         <CardContent className="pt-6 space-y-4">
-          {auditResult.violations.length === 0 ? (
           {auditResult?.violations.length === 0 ? (
             <div className="flex flex-col items-center justify-center p-8 text-center bg-slate-950/40 rounded-xl border border-slate-800">
               <CheckCircle2 size={40} className="text-emerald-400 mb-2" />
@@ -174,7 +90,6 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
               <p className="text-xs text-slate-500">All ledger items comply with AML thresholds & SOX directives.</p>
             </div>
           ) : (
-            auditResult.violations.map((v) => (
             auditResult?.violations.map((v) => (
               <div
                 key={v.id}
@@ -190,7 +105,6 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
                       }`}
                     >
                       {v.category} • {v.severity}
-                      {v.category} - {v.severity}
                     </span>
                     <h4 className="text-sm font-bold text-white">{v.title}</h4>
                   </div>
@@ -205,47 +119,6 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
           )}
         </CardContent>
       </Card>
-              </div>
-            </CardHeader>
-            <CardContent className="pt-6 space-y-4">
-              {auditResult.violations.length === 0 ? (
-                <div className="flex flex-col items-center justify-center p-8 text-center bg-slate-950/40 rounded-xl border border-slate-800">
-                  <CheckCircle2 size={40} className="text-emerald-400 mb-2" />
-                  <p className="text-sm font-semibold text-slate-200">No Regulatory Violations Detected</p>
-                  <p className="text-xs text-slate-500">All ledger items comply with AML thresholds & SOX directives.</p>
-                </div>
-              ) : (
-                auditResult.violations.map((v) => (
-                  <div
-                    key={v.id}
-                    className="p-4 rounded-xl bg-slate-950/60 border border-slate-800 hover:border-slate-700 transition-colors flex flex-col md:flex-row items-start md:items-center justify-between gap-4"
-                  >
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <span
-                          className={`text-[10px] font-black uppercase px-2 py-0.5 rounded ${
-                            v.severity === "high"
-                              ? "bg-red-500/20 text-red-400 border border-red-500/30"
-                              : "bg-amber-500/20 text-amber-400 border border-amber-500/30"
-                          }`}
-                        >
-                          {v.category} • {v.severity}
-                        </span>
-                        <h4 className="text-sm font-bold text-white">{v.title}</h4>
-                      </div>
-                      <p className="text-xs text-slate-400">{v.description}</p>
-                      <p className="text-xs text-indigo-400 font-medium">Action: {v.recommendedAction}</p>
-                    </div>
-                    <button className="px-3 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-xs font-semibold text-slate-200 border border-slate-700 flex items-center gap-1.5">
-                      <FileText size={14} /> File Report
-                    </button>
-                  </div>
-                ))
-              )}
-            </CardContent>
-          </Card>
-        </>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Problem

`src/components/compliance/ComplianceAuditDashboard.tsx` does not parse. Two complete component implementations are spliced back-to-back in one file: an old mock-fixture version (hardcoded `mockTransactions`, `auditResult = auditFinancialData(mockTransactions)`) with its JSX left unclosed at line 22, followed by a second, real-data copy starting with a fresh `import React, { useState, useEffect } ...`, a second `auditFinancialData` import, `fetchUserTransactions` (line 28), `ComplianceAuditDashboardProps` (line 30) and a re-export of `ComplianceAuditDashboard` (line 34).

`npx tsc --noEmit` fails with dozens of errors in this file (TS17008 unclosed `div`/`ComplianceAuditDashboardProps`, TS1381, TS1005), and the file blocks the whole app build.

## Fix

Kept only the `fetchUserTransactions`-based real-data implementation (the intended one per #889) and deleted the leftover mock-fixture copy and all spliced duplicates:

- Single `import React, { useState, useEffect }`; single import of `auditFinancialData` and `fetchUserTransactions`.
- `ComplianceAuditDashboard` declared once as `React.FC<{ user?: any }>`; removed the extra `ComplianceAuditDashboardProps` interface and duplicate export.
- Rebuilt the render block as one balanced structure: sign-in gate, loading spinner, error state, `ComplianceScorecard`, and the "Flagged Red-Flag Violations" card mapping `auditResult.violations`.
- Brace balance now 36 `{` / 36 `}`.

## Files changed

- `src/components/compliance/ComplianceAuditDashboard.tsx`

## Testing

- `npx esbuild src/components/compliance/ComplianceAuditDashboard.tsx --outfile=/dev/null` exits 0.
- `npx tsc --noEmit` no longer reports errors in this file (the two `auditFinancialData` declarations on line 42/71 noted in #968 are unrelated and resolved separately).

Closes #966
