### PR TITLE
fix(portfolio): keep single atomic addTransaction implementation (#960)

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -219,19 +219,6 @@ export async function addTransaction(userId: string, input: TransactionInput): P
     const holdings = collection(db, 'portfolioHoldings');
     const symbol = input.symbol.trim();
     const now = new Date().toISOString();
-    const id = doc(collection(db, 'portfolioTransactions')).id;
-    const transaction: Omit<Transaction, 'id'> = {
-      userId,
-      holdingId: input.holdingId,
-      symbol: input.symbol.trim(),
-      type: input.type,
-      quantity: input.quantity,
-      price: input.price,
-      fees: input.fees,
-      notes: input.notes?.trim() || '',
-      date: input.date,
-      createdAt: new Date().toISOString(),
-    };
 
     // Queries are not allowed inside client transactions — resolve the holding
     // document ref first, then lock/update it atomically with the ledger write.
@@ -321,21 +308,6 @@ export async function addTransaction(userId: string, input: TransactionInput): P
     });
 
     return transaction;
-    let transactionId = id;
-    if (input.type === 'buy') {
-      const ref = await addDoc(collection(db, 'portfolioTransactions'), {
-        ...transaction,
-        createdAt: serverTimestamp(),
-      });
-      transactionId = ref.id;
-    } else {
-      await setDoc(doc(db, 'portfolioTransactions', id), {
-        ...transaction,
-        createdAt: serverTimestamp(),
-      });
-    }
-
-    return { ...transaction, id: transactionId || '' };
   } catch (error) {
     console.error('Error adding transaction:', error);
     handleFirestoreError(error, OperationType.CREATE, 'portfolioTransactions');


### PR DESCRIPTION
## Problem

`src/lib/portfolioUtils.ts` fails to parse, breaking `npm run build` and `npx tsc --noEmit` on `main`:

```
X [ERROR] The symbol "transaction" has already been declared
  src/lib/portfolioUtils.ts:252:10
  The symbol "transaction" was originally declared here:
  src/lib/portfolioUtils.ts:223:10
```

`addTransaction` (line 216) contains two merged implementations concatenated inside the same function body: the older non-atomic implementation (`transactionRef = doc(...)`, `const transaction: Omit<Transaction,'id'> = {...}`, holding-ref resolution via `getDocs`/`query`) is followed by the newer atomic implementation (`const transaction = await runTransaction(...)`) which redeclares the same name, followed by **dead trailing legacy code** after the `return` (unreachable `addDoc`/`setDoc` block). The splice comes from `8f21d26` "fix: make portfolio transactions atomic (#644)".

## Fix

Kept the atomic `runTransaction` implementation exactly once and deleted the merged-in legacy parts:

- Removed the pre-transaction legacy `const transaction` object declaration and the unused `const id` (both only referenced by the unreachable dead code).
- Deleted the unreachable legacy block after the `return` (`addDoc`/`setDoc` fallback and second return).
- `addTransaction` now has a single `transaction` declaration, runs the atomic `runTransaction` path once, and returns its result.

## Files changed

- `src/lib/portfolioUtils.ts`

## Testing

- `npx esbuild src/lib/portfolioUtils.ts --outfile=/dev/null` exits 0 (previously failed with `The symbol "transaction" has already been declared`).
- `npx tsc --noEmit` no longer reports errors in this file.

Closes #960
