### PR TITLE
fix(process): resolve committed merge-conflict markers in getAdminApp (#961)

### DIFF
--- a/api/process.ts
+++ b/api/process.ts
@@ -478,18 +478,10 @@ async function getAdminApp(): Promise<any | null> {
       }
     }
 
-    const { getFirestore } = await import("firebase-admin/firestore");
-    const databaseId = getFirestoreDatabaseId();
     _adminApp = {
       admin,
-<<<<<<< HEAD
-      getFirestore: () => getFirestore(databaseId),
-      getFirestore: () => admin.firestore(getFirestoreDatabaseId()),
-=======
->>>>>>> feature/protected-production-deployment-v2
       getFirestore: () => getFirestore(admin.app(), getFirestoreDatabaseId()),
     };
-    // admin.firestore(getFirestoreDatabaseId())
     return _adminApp;
   } catch (err: any) {
     console.warn("[process] Firebase Admin init failed:", err?.message);


### PR DESCRIPTION
## Problem

`api/process.ts` fails to parse, breaking `npm run build` and `npx tsc --noEmit` on `main`:

```
X [ERROR] Expected identifier but found "<<"
  api/process.ts:485:0:
    485 │ <<<<<<< HEAD
X [ERROR] The symbol "getFirestore" has already been declared
  api/process.ts:481:12
```

TypeScript additionally reports `TS1185: Merge conflict marker encountered.` at lines 485, 488, 489. Raw git conflict markers were committed to `main` in the `_adminApp` object of `getAdminApp` (leftover from the merge of `feature/protected-production-deployment-v2`), the block declared `getFirestore` as an object key three times, and a second `const { getFirestore }` was destructured in the same scope.

## Fix

- Deleted the conflict marker block (lines 485–489) entirely — both discarded HEAD variants (`getFirestore(databaseId)` and `admin.firestore(...)`) and the marker lines.
- Kept the single surviving implementation: `getFirestore: () => getFirestore(admin.app(), getFirestoreDatabaseId())`.
- Removed the duplicate `const { getFirestore }` import and the now-unused `databaseId` variable and stray comment.
- `api/process.ts` now contains no `<<<<<<<` / `=======` / `>>>>>>>` text.

## Files changed

- `api/process.ts`

## Testing

- `npx esbuild api/process.ts --outfile=/dev/null` exits 0 (previously failed with the marker/duplicate-symbol errors).
- `npx tsc --noEmit` no longer reports any errors in `api/process.ts` (markers only; `package-lock.json` handled separately in #963).

Closes #961
