### PR TITLE
fix(ci): resolve conflict markers in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,8 @@ jobs:
   ci:
     name: CI Checks
     runs-on: ubuntu-latest
-<<<<<<< HEAD
-=======
     permissions:
       contents: read
->>>>>>> origin/main
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
@@ -27,11 +24,8 @@ jobs:
     needs: ci
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-<<<<<<< HEAD
-=======
     permissions:
       contents: read
->>>>>>> origin/main
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
## Problem

`.github/workflows/deploy.yml` on `main` contains two unresolved conflict-marker blocks, so GitHub Actions cannot parse the workflow and the production deploy pipeline never runs:

- Block 1 (lines 12–16) inside the `ci` job.
- Block 2 (lines 30–34) inside the `deploy` job.

A `<<<<<<<`/`=======`/`>>>>>>>` marker line is a scalar that breaks the workflow's map structure, so GitHub does not even register the workflow.

## Fix

Removed the marker lines and restored the intended `permissions: contents: read` block on both the `ci` and `deploy` jobs (the side the merged-in branch added as part of the protected-production-deployment work). The workflow now parses as valid YAML and both jobs declare explicit read-only permissions.

## Files changed

- `.github/workflows/deploy.yml`

## Testing

- Scanned the file for `<<<<<<<`, `=======`, `>>>>>>>` — 0 marker lines remain.
- Reviewed the resulting YAML structure: `name`/`on`/`jobs` → `ci` (with `permissions`, `steps`) and `deploy` (with `needs`, `if`, `permissions`, `environment`, `steps`) — all properly nested.

Closes #964
