### PR TITLE
fix(crypto): mount CryptoWebSocketProvider and fix Binance combined-stream URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,6 +216,7 @@ import OptionsStrategyBuilder from "./components/OptionsStrategyBuilder";
 import PlaidLinkConnect from "./components/PlaidLinkConnect";
 import RealEstateTracker from "./components/RealEstateTracker";
 import CryptoPortfolioTracker from "./components/CryptoPortfolioTracker";
+import { CryptoWebSocketProvider } from "./components/CryptoWebSocketProvider";
 import EsgDashboard from "./components/EsgDashboard";
 import PeerSpendingComparison from "./components/PeerSpendingComparison";
 import { MultiScenarioMatrix } from "./components/forecast/MultiScenarioMatrix";
@@ -1518,7 +1519,9 @@ export default function App() {
                 <MultiScenarioMatrix />
                 <PlaidLinkConnect />
                 <RealEstateTracker />
-                <CryptoPortfolioTracker />
+                <CryptoWebSocketProvider>
+                  <CryptoPortfolioTracker />
+                </CryptoWebSocketProvider>
                 <ReceiptUploader />
                 <SmsOptInSettings />
                 <VoiceExpenseLogger />

--- a/src/components/CryptoWebSocketProvider.tsx
+++ b/src/components/CryptoWebSocketProvider.tsx
@@ -24,7 +24,7 @@ export const CryptoWebSocketProvider: React.FC<{ children: React.ReactNode }> = 
   useEffect(() => {
     // Connect to Binance WebSocket for real-time trade streams
     // We listen to BTC, ETH, and SOL for this example
-    const wsUrl = 'wss://stream.binance.com:9443/ws/btcusdt@trade/ethusdt@trade/solusdt@trade';
+    const wsUrl = 'wss://stream.binance.com:9443/stream?streams=btcusdt@trade/ethusdt@trade/solusdt@trade';
     
     const connect = () => {
       setConnectionStatus('connecting');


### PR DESCRIPTION
## Problem

The crypto live-feed feature is dead on arrival for two independent reasons:

1. **`CryptoWebSocketProvider` is never mounted.** `src/App.tsx` renders `<CryptoPortfolioTracker />`, which calls `useCryptoPrices()` → `useContext(CryptoWebSocketContext)`. The only component that sets context values is `CryptoWebSocketProvider`, and a repo-wide grep shows it is never rendered. So `useCryptoPrices()` always returns the default `{ prices: {}, connectionStatus: 'disconnected' }` and the tracker permanently shows the yellow connecting pulse, `$---` total, and `Loading...` on every row.

2. **The WebSocket URL is invalid.** `wss://stream.binance.com:9443/ws/btcusdt@trade/ethusdt@trade/solusdt@trade` uses the `/ws/<streamName>` endpoint, which only accepts a **single** stream. Combined streams require the `/stream?streams=...` endpoint, so Binance rejects/closes the connection and `onmessage` never fires.

## Fix

- Mounted `<CryptoWebSocketProvider>` around `<CryptoPortfolioTracker />` in `App.tsx` (import added, tracker wrapped).
- Changed the stream URL to the combined-stream form: `wss://stream.binance.com:9443/stream?streams=btcusdt@trade/ethusdt@trade/solusdt@trade`.

## Files changed

- `src/App.tsx`
- `src/components/CryptoWebSocketProvider.tsx`

## Testing

- `npx esbuild src/components/CryptoWebSocketProvider.tsx` — parses (exit 0).
- `npx esbuild src/App.tsx` — the added import and provider wrapper parse cleanly (the only remaining parse error in `App.tsx` is the unrelated pre-existing Currencies-tab JSX corruption tracked separately in issues #962/#965; verified by temporarily applying that fix, confirming the whole file then parses, then reverting it so this PR contains only the #969 change).
- Grep confirms `<CryptoWebSocketProvider>` is now rendered in `App.tsx`.

Closes #969
