### PR TITLE
fix : added null guard for empty transactions in calculateCategoryBaseline

### DIFF
--- a/src/lib/anomalyStats.ts
+++ b/src/lib/anomalyStats.ts
@@ -30,7 +30,8 @@ export const MIN_LARGE_TRANSACTION_SAMPLES = 4;
 
 export function calculateCategoryBaseline(
   transactions: Transaction[],
-): Map<string, CategoryBaseline> {
+): Map<string, CategoryBaseline> | null {
+  if (transactions.length === 0) return null;
   const grouped = new Map<string, Transaction[]>();
 
   transactions.forEach((transaction) => {


### PR DESCRIPTION
## Summary of What Has Been Done

Added an early-return null guard to `calculateCategoryBaseline` in `src/lib/anomalyStats.ts` for when the input transactions array is empty.

## Changes Made

- Updated `calculateCategoryBaseline` return type from `Map<string, CategoryBaseline>` to `Map<string, CategoryBaseline> | null`.
- Added `if (transactions.length === 0) return null;` as the first line of the function body, before the grouping logic.

## Impact it Made

Allows callers to explicitly distinguish between "no transactions provided" (null) and "no anomalies found" (empty Map). Improves type safety and prevents downstream code from receiving a seemingly-valid empty Map without knowing it came from an empty input.

Closes #1017

## Note: Please assign this PR to the `tmdeveloper007` account.