### PR TITLE
fix : added guard against zero-width price range to prevent infinite loop

### DIFF
--- a/src/components/OptionsStrategyBuilder.tsx
+++ b/src/components/OptionsStrategyBuilder.tsx
@@ -40,11 +40,13 @@ export default function OptionsStrategyBuilder() {
   // Generate PnL curve data points
   const chartData = useMemo(() => {
     const data = [];
+    if (legs.length === 0) return data;
     const minStrike = Math.min(...legs.map(l => l.strike)) * 0.7;
     const maxStrike = Math.max(...legs.map(l => l.strike)) * 1.3;
     
     // Generate 50 points between min and max
     const step = (maxStrike - minStrike) / 50;
+    if (step <= 0) return data;
 
     for (let price = minStrike; price <= maxStrike; price += step) {
       let netPnL = 0;


### PR DESCRIPTION
## Summary of What Has Been Done

Guarded `OptionsStrategyBuilder.tsx` against an infinite loop in the PnL chart-data generation when all option legs have a strike price of 0.

## Changes Made

- Added `if (legs.length === 0) return data;` guard before computing strike prices.
- Added `if (step <= 0) return data;` guard after computing the step size. When all strikes are 0, `minStrike` and `maxStrike` both equal 0, making `step = 0`. The guard prevents the `for` loop from running indefinitely with `step = 0`.

## Impact it Made

Prevents the browser tab from freezing when a user sets all option legs to a strike of 0. The chart gracefully returns an empty dataset instead of locking up the main thread. This is a UX stability improvement for edge-case inputs.

Closes #1018

## Note: Please assign this PR to the `tmdeveloper007` account.