### PR TITLE
test : added test coverage for quarterly frequency detection in detectFrequency

### DIFF
--- a/tests/cashflow-quarterly-frequency.test.mjs
+++ b/tests/cashflow-quarterly-frequency.test.mjs
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const source = readFileSync(
+  path.join(repoRoot, "src", "lib", "cashflowUtils.ts"),
+  "utf8",
+);
+
+const start = source.indexOf("function detectFrequency(dates: Date[])");
+assert.ok(
+  start !== -1,
+  "detectFrequency not found in src/lib/cashflowUtils.ts",
+);
+
+const bodyStart = source.indexOf("{", start);
+const bodyEnd = source.lastIndexOf("}", source.length);
+const body = source.slice(bodyStart, bodyEnd + 1);
+
+test("detectFrequency returns quarterly for median gap near 91 days", () => {
+  assert.match(body, /quarterly/);
+  assert.match(body, /91/);
+  assert.match(body, /Math\.abs\(median.*91\)/);
+});
+
+test("detectFrequency has explicit quarterly check before monthly fallback", () => {
+  const quarterlyIdx = body.indexOf("quarterly");
+  const monthlyIdx = body.lastIndexOf("monthly");
+  assert.ok(
+    quarterlyIdx !== -1 && quarterlyIdx < monthlyIdx,
+    "quarterly check should appear before monthly fallback in detectFrequency",
+  );
+});
+
+test("detectFrequency accepts quarterly in its return type union", () => {
+  assert.match(source, /detectFrequency.*:.*"weekly".*"monthly".*"quarterly"/);
+});


### PR DESCRIPTION
## Summary of What Has Been Done

Added test coverage for the quarterly frequency detection logic in `detectFrequency` within `src/lib/cashflowUtils.ts`.

## Changes Made

- Created `tests/cashflow-quarterly-frequency.test.mjs` with three tests:
  1. Verifies that `detectFrequency` body includes the quarterly check with the 91-day constant.
  2. Verifies the quarterly check appears before the monthly fallback in the function body.
  3. Verifies the function return type union includes `"quarterly"`.

## Impact it Made

Ensures the quarterly frequency detection logic remains in place and is not accidentally removed in future refactors. All three tests pass against the current codebase.

Closes #1020

## Note: Please assign this PR to the `tmdeveloper007` account.