### PR TITLE
fix: sanitize firestore error logging to prevent PII exposure

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -12,8 +12,6 @@ import {
 import { getStorage } from "firebase/storage";
 import { getAnalytics } from "firebase/analytics";
 
-
-
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY || "AIzaSyCLwFIQVnzSlx4DDycgJhugpty2hbGMCUk",
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || "finsightai-5ef59.firebaseapp.com",
@@ -66,7 +64,7 @@ export interface FirestoreErrorInfo {
   code?: string;
   operationType: OperationType;
   path: string | null;
-  authInfo: {
+  authInfo?: {
     userId?: string | null;
     email?: string | null;
     emailVerified?: boolean | null;
@@ -150,29 +148,30 @@ export function handleFirestoreError(
   path: string | null,
 ) {
   const firebaseError = error instanceof FirebaseError ? error : null;
-  const errInfo: FirestoreErrorInfo = {
+  
+  // 1. Create the clean object without authInfo
+  const errInfo = {
     error: firebaseError
       ? firebaseError.message
       : error instanceof Error
         ? error.message
         : String(error),
     code: firebaseError?.code,
-    authInfo: {
-      userId: auth.currentUser?.uid,
-      email: auth.currentUser?.email,
-      emailVerified: auth.currentUser?.emailVerified,
-      isAnonymous: auth.currentUser?.isAnonymous,
-      tenantId: auth.currentUser?.tenantId,
-      providerInfo:
-        auth.currentUser?.providerData?.map((provider) => ({
-          providerId: provider.providerId,
-          email: provider.email,
-        })) || [],
-    },
     operationType,
     path,
   };
-  console.error("Firestore Error: ", JSON.stringify(errInfo));
+
+  // 2. The new development-only safe logging logic
+  if (process.env.NODE_ENV === "development") {
+    console.error("Firestore Error: ", JSON.stringify({
+      code: firebaseError?.code,
+      operationType,
+      path,
+      hasUser: !!auth.currentUser
+    }));
+  }
+
+  // 3. Return the sanitized error
   return errInfo;
 }
 
@@ -303,4 +302,3 @@ export async function updateDocumentStateAtomic(
     return { docId, version: nextVersion };
   });
 }
-


### PR DESCRIPTION
### Description
This PR addresses a critical privacy concern where sensitive user authentication data (PII) was being leaked into the console during Firestore errors. 

### Changes Made
- Removed the sensitive `authInfo` property (which included emails and user IDs) from the `errInfo` object in `src/lib/firebase.ts`.
- Wrapped the error logging logic in a `process.env.NODE_ENV === "development"` check to ensure logs never run in a production environment.
- Sanitized the development console output to only include safe debugging info (`code`, `operationType`, `path`, and a safe `hasUser` boolean).
- Updated the `FirestoreErrorInfo` TypeScript interface to make `authInfo` optional.

### Related Issue
Closes #498

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security patch

### Checklist
- [x] I have tested these changes locally, and the app compiles successfully.
- [x] I have verified that no PII is leaked in the console when an error occurs.
- [x] This contribution is for GSSoC'26.