### PR TITLE
fix(docs): include fileUrl in Express local-fallback records and guard client fallback write (#1028)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1093,6 +1093,10 @@ CRITICAL RULES:
         // Signed URLs will be generated on-demand with short expiration (15 minutes)
         const safeFilename = sanitizeStorageFilename(file.originalname);
         const storagePath = `analyses/${ownerId}/${now.getTime()}_${safeFilename}`;
+        // Real Storage object URL, derived after upload. Included in docData and
+        // every response record so client-side Firestore fallback writes pass
+        // firestore.rules isValidDocument (requires a https `fileUrl`).
+        let fileUrl = "";
 
         // Upload file to Firebase Storage before writing document metadata
         if (admin.apps.length) {
@@ -1111,6 +1115,11 @@ CRITICAL RULES:
             console.log(
               `FIREBASE_STORAGE_UPLOAD_COMPLETE: storagePath=${storagePath}, fileSize=${file.size}`,
             );
+            // Derive the real object URL so every returned record (including
+            // local-fallback records) carries a valid `fileUrl`. Without it a
+            // client-side Firestore fallback write is rejected by
+            // firestore.rules isValidDocument (requires `fileUrl`). (Issue #1028)
+            fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media`;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } catch (storageError: any) {
             console.error(
@@ -1138,6 +1147,7 @@ CRITICAL RULES:
           fileName: file.originalname,
           fileType: file.mimetype,
           fileSize: file.size,
+          fileUrl,
           storagePath,
           status: "completed",
           riskLevel,

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -206,8 +206,15 @@ export function FileUpload({ user, onComplete, onCancel }: any) {
         console.error("Failed to cache analysis locally", err);
       }
 
-      // If local persistence mode was used by server, attempt client-side Firestore write as well
-      if (result?.persistenceMode === "local" && user?.uid) {
+      // If local persistence mode was used by server, attempt client-side Firestore write as well.
+      // Skip when the local record has no fileUrl: firestore.rules isValidDocument requires
+      // `fileUrl`, so the write would be rejected and the record would be lost from the cloud.
+      // (Issue #1028)
+      if (
+        result?.persistenceMode === "local" &&
+        user?.uid &&
+        result.record?.fileUrl
+      ) {
         try {
           const { db } = await import("@/src/lib/firebase");
           const { doc, setDoc, serverTimestamp } = await import("firebase/firestore");


### PR DESCRIPTION
﻿## Problem

When the Express server returns a local-fallback document (persistenceMode: "local") due to Firestore permission-denied, the response record lacks a fileUrl field. The client (FileUpload.tsx) then attempts a client-side Firestore write using setDoc with ...result.record. This write is denied by firestore.rules because isValidDocument requires fileUrl (hasAll(['ownerId','fileName','fileUrl','status'])).

## Fix

1. server.ts: Derive the real Storage object URL after upload and include fileUrl in docData and every response record (including local-fallback).
2. FileUpload.tsx: Guard the client-side Firestore fallback write — skip when result.record?.fileUrl is missing (belt-and-suspenders).

## Files changed

- server.ts
- src/components/FileUpload.tsx

## Testing

- Simulate Firestore permission-denied on upload — verify local-fallback response includes fileUrl.
- Verify client fallback write succeeds when fileUrl present, and is skipped when absent.
- firestore.rules isValidDocument passes for local-fallback writes.

Closes #1028
