### PR TITLE
fix(1030): infer asset class for new holdings created by buy transactions (#1030)

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -207,6 +207,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
       const result = await addTransaction(user.uid, {
         holdingId,
         symbol: holdings.find((h) => h.id === holdingId)?.symbol || '',
+        assetClass: holdings.find((h) => h.id === holdingId)?.assetClass,
         type: txType,
         quantity: q,
         price,

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -107,6 +107,24 @@ export interface TransactionInput {
   fees: number;
   notes?: string;
   date: string;
+  /** Optional asset class for the new holding created by a first buy. When
+   * omitted, addTransaction infers it from the symbol. (Issue #1030) */
+  assetClass?: AssetClass;
+}
+
+// Well-known symbols that are not equities. Anything unrecognized defaults to
+// 'equities' so stock buys keep working without an explicit asset class.
+const CRYPTO_SYMBOLS = new Set([
+  'BTC', 'ETH', 'SOL', 'XRP', 'ADA', 'DOGE', 'DOT', 'LINK', 'AVAX', 'MATIC',
+  'LTC', 'BNB', 'USDT', 'USDC', 'UNI', 'AAVE', 'SHIB', 'XLM', 'TRX', 'TON',
+]);
+
+/** Infers an asset class for a symbol (e.g. BTC → crypto) when a transaction
+ * does not provide one. Defaults to 'equities'. (Issue #1030) */
+export function inferAssetClass(symbol: string): AssetClass {
+  const upper = (symbol || '').trim().toUpperCase();
+  if (CRYPTO_SYMBOLS.has(upper)) return 'crypto';
+  return 'equities';
 }
 
 export const ASSET_CLASS_LABELS: Record<AssetClass, string> = {
@@ -254,7 +272,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
             userId,
             symbol,
             name: symbol,
-            assetClass: 'equities',
+            assetClass: input.assetClass || inferAssetClass(symbol),
             quantity,
             avgCost,
             currentPrice: input.price,


### PR DESCRIPTION
﻿## Problem

portfolioUtils.ts addTransaction creates new holdings with assetClass: 'equities' hardcoded when buying a symbol for the first time. The HoldingInput interface includes assetClass field, but TransactionInput does not. When a user buys a stock via addTransaction without an existing holding, the asset class defaults to 'equities' regardless of actual asset type (crypto, fixed_income, etc.).

## Fix

1. Add assetClass? to TransactionInput interface.
2. Add inferAssetClass(symbol) helper mapping known crypto symbols (BTC, ETH, SOL, etc.) -> crypto, default equities.
3. In addTransaction, when creating new holding for buy, use input.assetClass || inferAssetClass(symbol).
4. Update PortfolioTracker to pass assetClass from selected holding.

## Files changed

- src/lib/portfolioUtils.ts
- src/components/portfolio/PortfolioTracker.tsx

## Testing

- Buy BTC via addTransaction without existing holding — new holding created with assetClass: 'crypto'.
- Buy AAPL without existing holding — new holding created with assetClass: 'equities'.
- Pass explicit assetClass in TransactionInput — used instead of inference.

Closes #1030
