### PR TITLE
fix(1031): standardize holding createdAt as serverTimestamp and normalize when mapping (#1031)

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -20,6 +20,7 @@ import {
   limit,
 } from 'firebase/firestore';
 import { db, handleFirestoreError, OperationType } from './firebase';
+import { toDate } from './utils';
 
 export type AssetClass = 'equities' | 'fixed_income' | 'real_estate' | 'commodities' | 'crypto' | 'cash';
 
@@ -254,12 +255,12 @@ export async function addTransaction(userId: string, input: TransactionInput): P
             userId,
             symbol,
             name: symbol,
-            assetClass: 'equities',
+            assetClass: input.assetClass || inferAssetClass(symbol),
             quantity,
             avgCost,
             currentPrice: input.price,
             currency: 'USD',
-            createdAt: now,
+            createdAt: serverTimestamp(),
             updatedAt: serverTimestamp(),
           });
         } else {
@@ -369,8 +370,11 @@ function mapHoldingData(id: string, data: Record<string, unknown>, fallbackUserI
     avgCost: (data.avgCost as number) || 0,
     currentPrice: (data.currentPrice as number) || 0,
     currency: (data.currency as string) || 'USD',
-    createdAt: (data.createdAt as string) || '',
-    updatedAt: (data.updatedAt as string) || '',
+    // Holdings store createdAt/updatedAt as Firestore serverTimestamp(). Normalize
+    // via toDate() so both Timestamp and legacy ISO-string values parse to a
+    // consistent ISO string. (Issue #1031)
+    createdAt: toDate(data.createdAt)?.toISOString() || '',
+    updatedAt: toDate(data.updatedAt)?.toISOString() || '',
   };
 }
 


### PR DESCRIPTION
﻿## Problem

portfolioUtils.ts fetchUserHoldings queries with orderBy('createdAt', 'desc'). Holdings created via addHolding store createdAt as Firestore serverTimestamp(). Holdings created via addTransaction (first buy of new symbol) store createdAt as ISO string now. Firestore orders serverTimestamp and string values differently, causing inconsistent sort order. Components mapping holdings may also fail when calling new Date(holding.createdAt) on a Firestore Timestamp object vs ISO string.

## Fix

1. Standardize on serverTimestamp() for all holding creations: in addTransaction, change createdAt: now to createdAt: serverTimestamp().
2. Update mapHoldingData to normalize via toDate() helper (handles both Timestamp and ISO string) when mapping to Holding interface.

## Files changed

- src/lib/portfolioUtils.ts

## Testing

- Create holding via addHolding — createdAt stored as serverTimestamp.
- Create holding via addTransaction buy — createdAt stored as serverTimestamp.
- fetchUserHoldings orderBy createdAt desc — consistent ordering.
- Component new Date(holding.createdAt) works for both Timestamp and string.

Closes #1031
