### PR TITLE
fix(1033): weight partial current month in forecast averaging divisor (#1033)

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -191,9 +191,21 @@ export function calculateMonthlyForecast(
   // Averages are computed over the full observation window: months without
   // activity are zero-filled so a charge that appears once in the window is
   // projected at its true monthly rate instead of its per-month-with-activity
-  // rate. The divisor is always windowMonths so projections span exactly the
-  // requested window regardless of how many months contain transactions.
-  const divisor = windowMonths > 0 ? windowMonths : 1;
+  // rate.
+  //
+  // The current (still-running) month is part of the observation window but is
+  // only partially elapsed. Weighting it by elapsedDays/daysInMonth stops a
+  // partial month from being counted as a full month in the divisor, which
+  // would inflate/deflate the projected monthly rate. (Issue #1033)
+  const now = new Date();
+  const currentMonthDays = new Date(
+    now.getFullYear(),
+    now.getMonth() + 1,
+    0,
+  ).getDate();
+  const elapsedDays = Math.min(Math.max(now.getDate(), 1), currentMonthDays);
+  const currentMonthWeight = elapsedDays / currentMonthDays;
+  const divisor = Math.max(windowMonths - 1 + currentMonthWeight, 1);
   const avgIncome =
     Object.values(incomeByMonth).length > 0
       ? Object.values(incomeByMonth).reduce((a, b) => a + b, 0) /


### PR DESCRIPTION
﻿## Problem

cashflowUtils.ts calculateMonthlyForecast uses getNextMonths starting from next month, but fetchUserTransactions observation window includes the current partial month. The averaging divisor is windowMonths (6), counting the partial current month as a full month. This inflates projections (e.g., March 15: March spending so far divided by 6 instead of ~5.48).

## Fix

Weight the partially-elapsed current month by elapsedDays/daysInMonth in the averaging divisor: divisor = max(windowMonths - 1 + currentMonthWeight, 1). The current month's contribution is scaled by its completeness.

## Files changed

- src/lib/cashflowUtils.ts

## Testing

- On March 15 (15/31 elapsed): divisor = 5 + 0.484 = 5.484.
- March spending  → projected monthly =  / 5.484 * 6 ≈  (not ).
- Full month (day 31): divisor = 6 → correct.
- windowMonths=1: divisor = currentMonthWeight → partial month annualized correctly.

Closes #1033
