### PR TITLE
fix(1034): compare complete months in category spike detection to avoid boundary false positives (#1034)

### DIFF
--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -295,8 +295,13 @@ export function detectAnomalies(
     }
   });
 
-  const thisMonth = format(new Date(), "yyyy-MM");
+  // Category spike detection compares two COMPLETE calendar months: the last
+  // fully-elapsed month against the one before it. Comparing against the
+  // current, still-running month would flag false spikes at month boundaries,
+  // when the current month has little or no data yet (e.g. on the 1st the
+  // current month is nearly empty while last month is full). (Issue #1034)
   const lastMonth = format(subMonths(new Date(), 1), "yyyy-MM");
+  const priorMonth = format(subMonths(new Date(), 2), "yyyy-MM");
   const monthlySpend = new Map<string, Map<string, number>>();
   transactions.forEach((t) => {
     if (normalizeTransactionType(t.type) !== "expense") return;
@@ -310,41 +315,41 @@ export function detectAnomalies(
     catMap.set(cat, (catMap.get(cat) || 0) + Math.abs(t.amount));
   });
 
-  const thisMonthData = monthlySpend.get(thisMonth);
   const lastMonthData = monthlySpend.get(lastMonth);
-  if (thisMonthData && lastMonthData) {
-    thisMonthData.forEach((amount, cat) => {
-      const lastAmount = lastMonthData.get(cat) || 0;
-      const minDelta = Math.max(50, lastAmount * 0.5);
+  const priorMonthData = monthlySpend.get(priorMonth);
+  if (lastMonthData && priorMonthData) {
+    lastMonthData.forEach((amount, cat) => {
+      const priorAmount = priorMonthData.get(cat) || 0;
+      const minDelta = Math.max(50, priorAmount * 0.5);
       if (
-        lastAmount > 0 &&
-        amount > lastAmount * 1.5 &&
-        amount - lastAmount > minDelta
+        priorAmount > 0 &&
+        amount > priorAmount * 1.5 &&
+        amount - priorAmount > minDelta
       ) {
         anomalies.push({
           userId: transactions[0]?.userId || "",
           transactionId: "",
           type: "category_spike",
-          severity: amount > lastAmount * 2.5 ? "critical" : "medium",
+          severity: amount > priorAmount * 2.5 ? "critical" : "medium",
           category: cat,
           amount: Math.round(amount * 100) / 100,
-          averageAmount: Math.round(lastAmount * 100) / 100,
-          deviation: Math.round((amount / lastAmount) * 100) / 100,
+          averageAmount: Math.round(priorAmount * 100) / 100,
+          deviation: Math.round((amount / priorAmount) * 100) / 100,
           description:
             cat +
             " spending spike: " +
             formatCurrency(amount) +
-            " this month vs " +
-            formatCurrency(lastAmount) +
-            " last month (" +
-            Math.round(((amount - lastAmount) / lastAmount) * 100) +
+            " last month vs " +
+            formatCurrency(priorAmount) +
+            " the month before (" +
+            Math.round(((amount - priorAmount) / priorAmount) * 100) +
             "% increase)",
           date: new Date(),
           dismissed: false,
-          comparisonPeriod: "vs " + lastMonth,
+          comparisonPeriod: "vs " + priorMonth,
           confidence: Math.min(
             90,
-            Math.round((amount / lastAmount - 1) * 30 + 60),
+            Math.round((amount / priorAmount - 1) * 30 + 60),
           ),
         });
       }


### PR DESCRIPTION
﻿## Problem

anomalyUtils.ts detectAnomalies category_spike detection compares current month total per category vs last month total. On the 1st of a month, current month has near-zero data while last month has full data — false spikes. detectCategorySpikes has same issue (uses format(new Date(), 'yyyy-MM') for current month).

## Fix

Category spike detection now compares two COMPLETE calendar months: last fully-elapsed month vs the one before it (subMonths(now, 1) vs subMonths(now, 2)). Eliminates partial-current-month boundary false positives entirely.

## Files changed

- src/lib/anomalyUtils.ts

## Testing

- On March 1: compares Feb vs Jan (both complete) instead of Mar (empty) vs Feb.
- On March 15: still compares Feb vs Jan — no mid-month false spikes.
- minDelta = max(50, priorAmount * 0.5) still applies.

Closes #1034
