### PR TITLE
fix(1035): remove duplicate anomaly/opportunity calls in buildInsights (#1035)

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -664,10 +664,11 @@ export function buildInsights(
     weeklySummary,
     monthlySummary,
     monthlyDeltas: computeCategoryDeltas(thisMonth, lastMonth),
-    anomalies: detectAnomalies(expenseTransactions, userId),
+    // Pass the expense-only slice (both functions filter internally anyway) so
+    // `ignoredTransactionIds` from the caller is applied and no duplicate call
+    // overwrites the result. (Issue #1035)
+    anomalies: detectAnomalies(expenseTransactions, userId, undefined, ignoredTransactionIds),
     opportunities: identifyOpportunities(expenseTransactions, userId),
-    anomalies: detectAnomalies(transactions, userId, undefined, ignoredTransactionIds),
-    opportunities: identifyOpportunities(transactions, userId),
     trends,
     trendCategories: categories,
     transactionCount: expenseTransactions.length,


### PR DESCRIPTION
﻿## Problem

insightsUtils.ts buildInsights calls detectAnomalies and identifyOpportunities twice with different arguments, second call overwrites first. First calls use expenseTransactions (filtered), second use all transactions (includes income). ignoredTransactionIds only applied in overwritten call.

## Fix

Remove duplicate calls at lines 667-668. Keep single calls at 669-670 but pass expenseTransactions (since both functions filter internally) with ignoredTransactionIds.

## Files changed

- src/lib/insightsUtils.ts

## Testing

- buildInsights returns anomalies/opportunities from single call with expenseTransactions.
- ignoredTransactionIds from caller is applied.
- No wasted computation from duplicate detection.

Closes #1035
