### PR TITLE
fix(1037): flag stale fallback rates and surface staleness in the UI (#1037)

### DIFF
--- a/src/components/currency/CurrencyConverter.tsx
+++ b/src/components/currency/CurrencyConverter.tsx
@@ -46,6 +46,7 @@ export function CurrencyConverter({
           base: 'USD',
           date: new Date().toISOString().split('T')[0],
           rates: {},
+          source: 'fallback',
         });
       } finally {
         setLoading(false);
@@ -177,7 +178,9 @@ export function CurrencyConverter({
           </div>
           {rates && (
             <p className="text-[10px] text-slate-500 mt-3 font-medium">
-              Rates updated: {rates.date} via Frankfurter API
+              {rates.source === 'fallback'
+                ? `Using fallback rates (snapshot ${rates.date}) — live fetch failed`
+                : `Rates updated: ${rates.date} via Frankfurter API`}
             </p>
           )}
         </div>

--- a/src/components/currency/CurrencyManager.tsx
+++ b/src/components/currency/CurrencyManager.tsx
@@ -30,6 +30,7 @@ import {
   History,
   DollarSign,
   Calendar,
+  AlertTriangle,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { motion } from 'motion/react';
@@ -187,9 +188,15 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
           ...settings.conversionHistory,
           [data.date]: historyEntry,
         };
+        // Only advance lastRateUpdate when the rates are live. Fallback rates
+        // are a static snapshot, so lastRateUpdate keeps reflecting the last
+        // successful live fetch and the UI can warn the user when it is old.
+        // (Issue #1037)
         const updatedSettings = {
           ...settings,
-          lastRateUpdate: new Date().toISOString(),
+          ...(data.source === 'live'
+            ? { lastRateUpdate: new Date().toISOString() }
+            : {}),
           conversionHistory: updatedHistory,
         };
         await setDoc(doc(db, 'currencies', user.uid), updatedSettings);
@@ -284,6 +291,17 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
     ? aggregateMultiCurrencyTotals(filteredTransactions, settings.baseCurrency, rates.rates)
     : { totalBase: 0, byCurrency: {} };
 
+  // Fallback rates are a static snapshot (source: 'fallback') and must not be
+  // presented as live. Also warn when the last successful live fetch is more
+  // than a week old, so stale rates are never silently used in financial
+  // calculations. (Issue #1037)
+  const lastUpdateAgeDays = settings?.lastRateUpdate
+    ? (Date.now() - new Date(settings.lastRateUpdate).getTime()) / (24 * 60 * 60 * 1000)
+    : null;
+  const showStaleWarning =
+    rates?.source === 'fallback' ||
+    (lastUpdateAgeDays !== null && lastUpdateAgeDays > 7);
+
   const historyDates = settings?.conversionHistory
     ? Object.keys(settings.conversionHistory)
         .sort((a: any, b: any) => Date.parse(a) - Date.parse(b))
@@ -354,6 +372,20 @@ export function CurrencyManager({ user }: CurrencyManagerProps) {
           </button>
         ))}
       </div>
+
+      {showStaleWarning && (
+        <div className="flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-400">
+          <AlertTriangle size={18} className="shrink-0 mt-0.5" />
+          <div>
+            <p className="font-bold">Rates may be stale</p>
+            <p className="text-amber-500/80 mt-1">
+              {rates?.source === 'fallback'
+                ? 'Live rate lookup failed and static fallback rates are currently in use. Currency conversions may not reflect current market values.'
+                : `Rates were last refreshed more than a week ago (${settings?.lastRateUpdate ? new Date(settings.lastRateUpdate).toLocaleDateString() : 'unknown'}). Click "Refresh Rates" to update.`}
+            </p>
+          </div>
+        </div>
+      )}
 
       {activeView === 'overview' && (
         <motion.div

--- a/src/lib/currencyUtils.ts
+++ b/src/lib/currencyUtils.ts
@@ -46,10 +46,18 @@ export const FALLBACK_RATES: Record<string, number> = {
   TRY: 30.25,
 };
 
+// Snapshot date of FALLBACK_RATES above. Fallback responses report this date
+// (NOT today) so stale data is never presented as fresh, and the UI can warn
+// the user. Update it whenever FALLBACK_RATES is refreshed. (Issue #1037)
+export const FALLBACK_RATES_DATE = '2024-11-01';
+
 export interface ExchangeRates {
   base: string;
   date: string;
   rates: Record<string, number>;
+  /** 'live' when fetched from the Frankfurter API, 'fallback' when the static
+   * table was returned after retries were exhausted. (Issue #1037) */
+  source: 'live' | 'fallback';
 }
 
 export interface ConversionHistoryEntry {
@@ -120,18 +128,20 @@ export async function fetchExchangeRates(
         base: data.base || base,
         date: data.date || new Date().toISOString().split('T')[0],
         rates: { [data.base || base]: 1, ...(data.rates || {}) },
+        source: 'live',
       };
     } catch (error) {
       const isLastAttempt = attempt === maxRetries;
       if (isLastAttempt) {
         console.warn(
           `[currencyUtils] All ${maxRetries + 1} attempts to fetch live exchange rates failed. ` +
-          `Falling back to static rates. Last error: ${error instanceof Error ? error.message : String(error)}`,
+          `Falling back to static rates (snapshot ${FALLBACK_RATES_DATE}). Last error: ${error instanceof Error ? error.message : String(error)}`,
         );
         return {
           base,
-          date: new Date().toISOString().split('T')[0],
+          date: FALLBACK_RATES_DATE,
           rates: buildFallbackRates(),
+          source: 'fallback',
         };
       }
       // Wait before retrying
@@ -142,8 +152,9 @@ export async function fetchExchangeRates(
   // Safety fallback — should never reach here but satisfies TypeScript
   return {
     base,
-    date: new Date().toISOString().split('T')[0],
+    date: FALLBACK_RATES_DATE,
     rates: buildFallbackRates(),
+    source: 'fallback',
   };
 }
 


### PR DESCRIPTION
﻿## Problem

currencyUtils.ts fetchExchangeRates falls back to hardcoded FALLBACK_RATES (static values from ~2024) with date set to today. UI shows 'Live rates' but data is stale. No staleness detection — financial calculations use silently stale rates.

## Fix

1. currencyUtils.ts: Add FALLBACK_RATES_DATE constant (snapshot date), add source: 'live' | 'fallback' to ExchangeRates. Fallback responses use FALLBACK_RATES_DATE and source: 'fallback'.
2. CurrencyManager.tsx: loadRates only updates lastRateUpdate when source === 'live'. Stale-rate warning banner shown when rates are fallback OR lastRateUpdate > 7 days.
3. CurrencyConverter.tsx: fallback object includes source: 'fallback'; display shows 'Using fallback rates (snapshot YYYY-MM-DD) — live fetch failed'.

## Files changed

- src/lib/currencyUtils.ts
- src/components/currency/CurrencyManager.tsx
- src/components/currency/CurrencyConverter.tsx

## Testing

- Simulate API failure — fetchExchangeRates returns fallback with source: 'fallback', date: FALLBACK_RATES_DATE.
- CurrencyManager shows warning banner for fallback or stale (>7 days) rates.
- CurrencyConverter displays fallback notice instead of 'via Frankfurter API'.
- lastRateUpdate only advances on live fetches.

Closes #1037
