### PR TITLE
fix(1038): accept monthlyContribution override in trackContribution to match server computation (#1038)

### DIFF
--- a/src/lib/emergencyUtils.ts
+++ b/src/lib/emergencyUtils.ts
@@ -126,7 +126,12 @@ export interface ContributionResult {
 export function trackContribution(
   fund: EmergencyFund,
   amount: number,
-  note?: string
+  note?: string,
+  /** Optional override for monthlyContribution. Optimistic callers should pass
+   * the freshest value known to them so the estimated completion date computed
+   * here matches what the server transaction (`addContribution`) will compute
+   * from the latest Firestore snapshot. (Issue #1038) */
+  monthlyContributionOverride?: number,
 ): ContributionResult {
   if (!fund || Number.isNaN(amount) || amount <= 0) {
     return { fund: null, contribution: null };
@@ -140,7 +145,10 @@ export function trackContribution(
   };
 
   const currentAmount = Math.max(0, fund.currentAmount + contribution.amount);
-  const monthlyContribution = fund.monthlyContribution || 0;
+  const monthlyContribution =
+    typeof monthlyContributionOverride === "number" && !Number.isNaN(monthlyContributionOverride)
+      ? monthlyContributionOverride
+      : fund.monthlyContribution || 0;
   const estimatedCompletionDate = estimateCompletionDate(
     fund.targetAmount,
     currentAmount,


### PR DESCRIPTION
﻿## Problem

emergencyUtils.ts trackContribution (pure function for optimistic UI) computes estimatedCompletionDate using old monthlyContribution from fund object. addContribution uses a Firestore transaction reading latest fund's monthlyContribution from snapshot. If user changed monthlyContribution between UI render and transaction commit, optimistic UI shows wrong completion date.

## Fix

trackContribution accepts optional monthlyContributionOverride parameter. Optimistic callers can pass the freshest value so estimated completion date matches what addContribution computes from the latest snapshot. UI (EmergencyFundPlanner) already uses addContribution's returned server-computed fund.

## Files changed

- src/lib/emergencyUtils.ts

## Testing

- trackContribution(fund, 100, undefined, 500) uses 500 for completion date calc.
- trackContribution(fund, 100) falls back to fund.monthlyContribution.
- addContribution still uses transaction snapshot's current.monthlyContribution.

Closes #1038
