### PR TITLE
fix(1039): awardBadge respects stored template badge, only derives for legacy (#1039)

### DIFF
--- a/src/lib/challengeUtils.ts
+++ b/src/lib/challengeUtils.ts
@@ -314,6 +314,11 @@ export function generateRecommendations(spending: SpendingPattern): ChallengeRec
 }
 
 export function awardBadge(challenge: Challenge): BadgeTier {
+  // Respect the badge stored on the challenge (templates hardcode their own
+  // tier) so the badge shown during the challenge is the one awarded on
+  // completion. Only derive a tier from targetAmount for legacy challenges
+  // that never stored a badge. (Issue #1039)
+  if (challenge.badge) return challenge.badge;
   if (challenge.targetAmount >= 300) return 'platinum';
   if (challenge.targetAmount >= 150) return 'gold';
   if (challenge.targetAmount >= 50) return 'silver';


### PR DESCRIPTION
﻿## Problem

challengeUtils.ts generateWeekly/MonthlyChallenges hardcode badge per template (e.g., 'silver' for 'Save  This Week'). awardBadge recomputes badge solely from targetAmount (>=300 platinum, >=150 gold, >=50 silver, else bronze). Challenge 'Save ' shows silver during challenge, but awardBadge sees 43 -> awards bronze on completion.

## Fix

awardBadge now respects challenge.badge if set (template-defined). Only derives from targetAmount for legacy challenges without stored badge. UI (ChallengesDashboard) already uses challenge.badge ?? awardBadge(challenge).

## Files changed

- src/lib/challengeUtils.ts

## Testing

- Challenge with badge: 'silver', targetAmount: 43 — awardBadge returns 'silver'.
- Legacy challenge without badge, targetAmount: 200 — awardBadge returns 'gold'.
- Template badges preserved; no downgrade on completion.

Closes #1039
