### PR TITLE
fix(1040): timeline projection uses selected contribution level (#1040)

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -69,6 +69,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
+  const [selectedSuggestionLevel, setSelectedSuggestionLevel] = useState<'Recommended' | 'Conservative' | 'Aggressive'>('Recommended');
   const notifiedGoalIds = useRef(new Set<string>());
   const updatingGoalIds = useRef(new Set<string>());
 
@@ -287,15 +288,19 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
           selectedGoal.currentAmount,
           selectedGoal.deadline
         ),
-        timeline: generateTimelineProjection(
-          selectedGoal.targetAmount,
-          selectedGoal.currentAmount,
-          calculateMonthlyContribution(
+        timeline: (() => {
+          const suggestions = generateContributionSuggestions(
             selectedGoal.targetAmount,
             selectedGoal.currentAmount,
             selectedGoal.deadline
-          )
-        ),
+          );
+          const selected = suggestions.find((s) => s.label === selectedSuggestionLevel) ?? suggestions[0];
+          return generateTimelineProjection(
+            selectedGoal.targetAmount,
+            selectedGoal.currentAmount,
+            selected.amount
+          );
+        })(),
       }
     : null;
 
@@ -671,9 +676,14 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                 </h4>
                 <div className="grid grid-cols-3 gap-3">
                   {goalDetail.suggestions.map((suggestion) => (
-                    <div
+                    <button
                       key={suggestion.label}
-                      className="rounded-xl bg-slate-800/50 border border-slate-700/50 p-3 text-center"
+                      onClick={() => setSelectedSuggestionLevel(suggestion.label)}
+                      className={`rounded-xl p-3 text-center transition-all ${
+                        selectedSuggestionLevel === suggestion.label
+                          ? 'bg-indigo-500/20 border-indigo-500 shadow-[0_0_0_1px]_indigo-500/50'
+                          : 'bg-slate-800/50 border-slate-700/50 hover:border-slate-600/50'
+                      }`}
                     >
                       <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">
                         {suggestion.label}
@@ -682,7 +692,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                         {formatCurrency(suggestion.amount, baseCurrency)}
                       </p>
                       <p className="text-[10px] text-slate-500">/month</p>
-                    </div>
+                    </button>
                   ))}
                 </div>
               </div>

--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -111,20 +111,32 @@ export const TOOL_CATALOGUE: AgentTool[] = [
   {
     name: "project_goal",
     description:
-      "Project a savings goal timeline. Given a target amount, current amount, and deadline, returns the monthly contribution needed and a month-by-month projection.",
+      "Project a savings goal timeline. Given a target amount, current amount, deadline, and optional contribution level, returns the monthly contribution needed and a month-by-month projection.",
     parameters: {
       targetAmount: "goal target amount",
       currentAmount: "amount saved so far",
       deadline: "ISO date string deadline",
+      level: "contribution level: 'conservative' (85%), 'recommended' (100%), or 'aggressive' (120%)",
     },
     run: (args, _ctx) => {
       const target = toNumber(args.targetAmount);
       const current = toNumber(args.currentAmount);
       const deadline = String(args.deadline ?? "");
+      const level = String(args.level ?? "recommended").toLowerCase();
       const monthly = calculateMonthlyContribution(target, current, deadline);
+      const conservative = Math.ceil(monthly * 0.85);
+      const aggressive = Math.max(1, Math.floor(monthly * 1.2));
+      const selectedMonthly =
+        level === "conservative"
+          ? conservative
+          : level === "aggressive"
+          ? aggressive
+          : monthly;
       return {
         monthlyContribution: monthly,
-        timeline: generateTimelineProjection(target, current, monthly),
+        conservative,
+        aggressive,
+        timeline: generateTimelineProjection(target, current, selectedMonthly),
       };
     },
   },


### PR DESCRIPTION
﻿## Problem

goalUtils.ts generateContributionSuggestions returns Recommended, Conservative (85%), Aggressive (120%). generateTimelineProjection accepts specific monthly amount, but GoalPlanner calls it with Recommended only. chatAgent project_goal tool uses calculateMonthlyContribution -> generateTimelineProjection, ignores suggestion levels.

## Fix

1. GoalPlanner: add selectedSuggestionLevel state (default 'Recommended'); suggestion cards clickable with visual selection; timeline recomputed from selected suggestion's amount.
2. chatAgent project_goal: accepts optional level parameter ('conservative'|'recommended'|'aggressive'); returns all three suggestion amounts plus timeline for selected level.

## Files changed

- src/components/goals/GoalPlanner.tsx
- src/lib/chatAgent.ts

## Testing

- Click 'Conservative' card — timeline updates with Conservative amount.
- Click 'Aggressive' — timeline updates with Aggressive amount.
- chatAgent project_goal with level: 'aggressive' returns aggressive timeline.

Closes #1040
