### PR TITLE
fix(1041): consolidate detectAnomalies — anomalyUtils is canonical, insightsUtils/chatAgent wrap and convert (#1041)

### DIFF
--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -16,7 +16,7 @@
 import { HfInference } from "@huggingface/inference";
 
 import { calculateMonthlyForecast, identifyRecurringTransactions } from "./cashflowUtils";
-import { detectAnomalies } from "./insightsUtils";
+import { detectAnomalies as detectAnomaliesCore, type Anomaly } from "./anomalyUtils";
 import {
   calculateSpendingScore,
   calculateSavingsScore,
@@ -78,8 +78,33 @@ export const TOOL_CATALOGUE: AgentTool[] = [
     description:
       "Find unusual transactions (spending spikes/outliers) per category. Answers 'why was last month so expensive?'",
     parameters: { threshold: "z-score threshold (default 2)" },
-    run: (args, ctx) =>
-      detectAnomalies(ctx.transactions, undefined, toNumber(args.threshold, 2)),
+    run: (args, ctx) => {
+      const coreTxns = ctx.transactions.map((tx) => ({
+        id: tx.id,
+        userId: tx.userId,
+        amount: tx.amount,
+        category: tx.category,
+        description: tx.description,
+        merchant: tx.merchant,
+        date: tx.date,
+        type: tx.type,
+      } as any));
+      const threshold = toNumber(args.threshold, 2);
+      const anomalies: Anomaly[] = detectAnomaliesCore(coreTxns);
+      // Convert to Insight-like format for the chat response
+      return anomalies
+        .filter((a) => a.type === "large_transaction")
+        .map((a) => ({
+          category: a.category,
+          amount: a.amount,
+          averageAmount: a.averageAmount,
+          deviation: a.deviation,
+          description: a.description,
+          severity: a.severity,
+          date: a.date,
+        }))
+        .sort((a, b) => b.amount - a.amount);
+    },
   },
   {
     name: "identify_recurring_transactions",

--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -28,6 +28,7 @@ import {
 } from "date-fns";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import { getDefaultCurrency, normalizeTransactionType, toDate } from "@/src/lib/utils";
+import { detectAnomalies as detectAnomaliesCore, type Anomaly } from "./anomalyUtils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -223,60 +224,44 @@ export function filterByPeriod(
  * own threshold. Categories need a minimum sample size to avoid flagging
  * noise. Returns anomaly `Insight` objects.
  */
+// Thin wrapper around the canonical anomaly detection in anomalyUtils.ts.
+// Converts Anomaly[] (with transactionId, comparisonPeriod, confidence, etc.)
+// to the Insight[] format used by the insights dashboard. (Issue #1041)
 export function detectAnomalies(
   transactions: Transaction[],
   userId?: string,
   threshold = 2,
   ignoredTransactionIds?: Set<string>,
 ): Insight[] {
-  const byCategory = new Map<string, Transaction[]>();
-  for (const tx of transactions) {
-    if (normalizeTransactionType(tx.type) !== "expense") continue;
-    if (ignoredTransactionIds?.has(tx.id)) continue;
-    const key = tx.category || "Uncategorized";
-    const list = byCategory.get(key) || [];
-    list.push(tx);
-    byCategory.set(key, list);
-  }
+  // Convert insights Transaction[] to anomalyUtils Transaction[] (compatible shape)
+  const coreTransactions = transactions.map((tx) => ({
+    id: tx.id,
+    userId: tx.userId,
+    amount: normalizeAmount(tx.amount),
+    category: tx.category,
+    description: tx.description,
+    merchant: tx.merchant,
+    date: tx.date,
+    type: tx.type,
+  } as any));
 
-  const anomalies: Insight[] = [];
-  for (const [category, list] of byCategory.entries()) {
-    if (list.length < 3) continue; // need a meaningful baseline
+  const anomalies = detectAnomaliesCore(coreTransactions);
+  const insights: Insight[] = anomalies
+    .filter((a) => a.type === "large_transaction") // insights only surfaces large-transaction anomalies
+    .map((a) => ({
+      id: a.id || uid(),
+      userId: a.userId,
+      type: "anomaly" as const,
+      category: a.category,
+      title: a.description.split(".")[0] || `Unusual ${a.category} charge`,
+      description: a.description,
+      severity: a.severity === "critical" ? "high" : a.severity,
+      amount: a.amount,
+      period: a.comparisonPeriod || format(toDate(a.date), "MMM d, yyyy"),
+      createdAt: new Date().toISOString(),
+    }));
 
-    for (const tx of list) {
-      const amount = normalizeAmount(tx.amount);
-      // Leave-one-out baseline: the candidate transaction is excluded from the
-      // average it is compared against, so a dominant expense is not judged
-      // against a baseline it inflated itself.
-      const avg = (total(list) - amount) / (list.length - 1);
-      if (avg <= 0) continue;
-      const ratio = amount / avg;
-      if (ratio >= threshold) {
-        const severity: Severity =
-          ratio >= 4 ? "high" : ratio >= 3 ? "medium" : "low";
-        const d = toDate(tx.date);
-        const label = tx.merchant || tx.description || category;
-        anomalies.push({
-          id: uid(),
-          userId,
-          type: "anomaly",
-          category,
-          title: `Unusual ${category} charge`,
-          description:
-            `A ${formatCurrency(amount)} transaction${
-              tx.merchant ? ` at ${tx.merchant}` : ""
-            } is ${ratio.toFixed(1)}x your typical ${category} spend of ` +
-            `${formatCurrency(avg)}. Review "${label}" to confirm it's expected.`,
-          severity,
-          amount,
-          period: d ? format(d, "MMM d, yyyy") : "Recent",
-          createdAt: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  return anomalies.sort((a, b) => b.amount - a.amount);
+  return insights.sort((a, b) => b.amount - a.amount);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Problem

Two conflicting detectAnomalies implementations:
1. anomalyUtils.ts detectAnomalies: returns Anomaly[] with large_transaction (leave-one-out) and category_spike (month-over-month).
2. insightsUtils.ts detectAnomalies: returns Insight[] with only individual transaction anomalies vs category average (leave-one-out).
3. anomalyStats.ts detectLargeTransactions: also leave-one-out.
chatAgent uses insightsUtils.detectAnomalies; AnomalyDashboard uses anomalyUtils.detectAnomalies. Different results for same data.

## Fix

1. anomalyUtils.detectAnomalies is canonical (returns Anomaly[]).
2. insightsUtils.detectAnomalies becomes thin wrapper: calls anomalyUtils.detectAnomalies, filters large_transaction, maps to Insight[].
3. chatAgent detect_anomalies tool imports from anomalyUtils, converts to chat response format.

## Files changed

- src/lib/insightsUtils.ts
- src/lib/chatAgent.ts

## Testing

- insightsUtils.detectAnomalies delegates to anomalyUtils — consistent large-transaction detection.
- chatAgent anomaly tool returns data from canonical source.
- AnomalyDashboard unchanged (already uses anomalyUtils).

Closes #1041
