### PR TITLE
fix: enforce tenant isolation in text-to-SQL endpoint (#1068)

### DIFF
--- a/src/api/text-to-sql.ts
+++ b/src/api/text-to-sql.ts
@@ -48,10 +48,54 @@ Output valid JSON only with keys: "collection", "where", "orderBy", "limit".`;
       return res.status(500).json({ error: "Failed to parse LLM response into a valid query" });
     }
 
-    // Attach user constraint for multi-tenant data isolation
-    if (parsedQuery && typeof parsedQuery === 'object') {
-      (parsedQuery as any).tenantId = user?.uid || "unauthenticated";
+    // --- Harden the LLM-produced query before it is returned for execution ---
+    // The model is never trusted to author tenant scoping. We validate the
+    // shape against a strict schema and force the authenticated user's tenant
+    // id into the `where` clause, rejecting any caller/model-supplied tenantId
+    // and any NoSQL-injection operators (keys starting with `$`).
+
+    if (!parsedQuery || typeof parsedQuery !== "object" || Array.isArray(parsedQuery)) {
+      return res.status(422).json({ error: "Model did not return a valid query object" });
     }
+
+    const ALLOWED_KEYS = new Set(["collection", "where", "orderBy", "limit"]);
+    for (const key of Object.keys(parsedQuery)) {
+      if (!ALLOWED_KEYS.has(key)) {
+        delete (parsedQuery as Record<string, unknown>)[key];
+      }
+    }
+
+    if (typeof (parsedQuery as any).collection !== "string") {
+      (parsedQuery as any).collection = "transactions";
+    }
+    if (
+      (parsedQuery as any).limit != null &&
+      (typeof (parsedQuery as any).limit !== "number" || (parsedQuery as any).limit < 0)
+    ) {
+      delete (parsedQuery as any).limit;
+    }
+
+    if (!user?.uid) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const where =
+      (parsedQuery as any).where && typeof (parsedQuery as any).where === "object" && !(parsedQuery as any).where instanceof Array
+        ? (parsedQuery as any).where
+        : {};
+
+    // Strip any tenant scoping or injection operators the model tried to inject.
+    for (const key of Object.keys(where)) {
+      if (key === "tenantId" || key.startsWith("$")) {
+        delete where[key];
+      }
+    }
+    // Force the authenticated user's tenant id — multi-tenant isolation is
+    // guaranteed here, regardless of what the model emitted.
+    where.tenantId = user.uid;
+    (parsedQuery as any).where = where;
+    // Ensure no top-level tenantId override leaks through either.
+    delete (parsedQuery as any).tenantId;
 
     res.json({
       success: true,


### PR DESCRIPTION
## Problem
`src/api/text-to-sql.ts` converted a natural-language query into a JSON query object via the LLM and then attached a tenant id. The `where` clause itself was produced entirely by the model and was never validated, sanitized, or merged safely. A crafted/naive request could make the model emit a `where` that overrides or excludes the tenant filter (e.g. `{ "tenantId": { "$ne": null } }` or a top-level `$or`), and that arbitrary filter was returned for execution against the shared `transactions` collection — breaking multi-tenant isolation and opening a NoSQL-injection surface.

## Fix
- The query object is validated against a strict schema: only `collection`, `where`, `orderBy`, and `limit` are kept; `collection`/`limit` are type-checked; anything unexpected is dropped.
- The model is never allowed to author tenant scoping. Any `tenantId` key or `$`-prefixed operator (e.g. `$or`, `$ne`) inside `where` is stripped, and `where.tenantId` is forced to the authenticated `user.uid`. A top-level `tenantId` override is also removed.
- If the request is unauthenticated (`user.uid` missing) the endpoint returns 401 instead of falling back to the unsafe `"unauthenticated"` tenant.

## Files changed
- `src/api/text-to-sql.ts`

## Testing
- A model response of `{ "where": { "tenantId": { "$ne": null } } }` now returns `where.tenantId = <authenticated uid>` with the `$ne` operator removed.
- An unauthenticated request is rejected with 401 rather than receiving an `"unauthenticated"` tenant filter.

Closes #1068
