### PR TITLE
fix: remove duplicate anomalies/opportunities keys in buildInsights (#1069)

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -630,8 +630,10 @@ export function buildInsights(
     weeklySummary,
     monthlySummary,
     monthlyDeltas: computeCategoryDeltas(thisMonth, lastMonth),
-    anomalies: detectAnomalies(expenseTransactions, userId),
-    opportunities: identifyOpportunities(expenseTransactions, userId),
+    // Detect over the full transaction set (not just expenses) so ignored
+    // transactions are excluded consistently. The earlier expense-scoped pair
+    // was dead code: duplicate keys in an object literal keep only the last
+    // assignment, so the all-transactions computation is the intended one.
     anomalies: detectAnomalies(transactions, userId, undefined, ignoredTransactionIds),
     opportunities: identifyOpportunities(transactions, userId),
     trends,


### PR DESCRIPTION
## Problem
In `src/lib/insightsUtils.ts` `buildInsights` returned an object literal that declared `anomalies` and `opportunities` twice. In a JS object literal the later key wins, so the first computation (from `expenseTransactions`) was dead code — the values derived from `expenseTransactions` were discarded in favor of the ones computed from the full `transactions` set, and the all-transactions pass also ran an extra, wasted detection.

## Fix
Removed the duplicate, expense-scoped `anomalies`/`opportunities` keys and kept the single intentional computation over the full transaction set (`detectAnomalies(transactions, userId, undefined, ignoredTransactionIds)` / `identifyOpportunities(transactions, userId)`), which is the one that honors `ignoredTransactionIds`. This removes the wasted detection and the misleading duplicate keys.

## Files changed
- `src/lib/insightsUtils.ts`

## Testing
- The returned `InsightsBundle` now declares each key exactly once; `anomalies`/`opportunities` reflect the full transaction set with ignored ids excluded.
- No other callers relied on the removed expense-scoped computation.

Closes #1069
