### PR TITLE
fix: remove dead duplicate yearly branch in billUtils (#1070)

### DIFF
--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -93,11 +93,6 @@ function advanceByFrequency(
     const safeDay = Math.min(utcDay, lastDayOfNextYearMonth);
     return new Date(Date.UTC(nextYear, utcMonth, safeDay, 12, 0, 0));
   }
-  if (frequency === 'yearly') {
-    const day = originalDueDay ?? date.getDate();
-    const lastDay = new Date(date.getFullYear() + 1, date.getMonth() + 1, 0).getDate();
-    return new Date(date.getFullYear() + 1, date.getMonth(), Math.min(day, lastDay));
-  }
   return date;
 }
 


### PR DESCRIPTION
## Problem
In `src/lib/billUtils.ts` `advanceByFrequency`, the `yearly` case was handled twice. The second `if (frequency === 'yearly')` block was unreachable dead code — it could never run because the first branch already returned. Worse, if it ever had run (e.g. after a refactor), it computed the next due date using local-time `getDate()`/`getFullYear()` while the rest of the function uses UTC (`getUTCDate()`/`Date.UTC(...)`), producing off-by-a-day or off-by-timezone renewal dates.

## Fix
Deleted the second, unreachable `yearly` block. The single remaining UTC-based `yearly` branch is now the only code path, keeping all date math consistently UTC and removing the latent timezone bug.

## Files changed
- `src/lib/billUtils.ts`

## Testing
- `advanceByFrequency(date, 'yearly')` still returns the UTC-consistent next-year due date; no behavior change for reachable inputs.
- The dead/confusing duplicate branch is gone, so future refactors cannot accidentally enable the local-time path.

Closes #1070
