### PR TITLE
fix: remove unreachable code in process safeJsonParse (#1072)

### DIFF
--- a/api/process.ts
+++ b/api/process.ts
@@ -320,16 +320,6 @@ function safeJsonParse(text: string): unknown {
     throw new Error(result.error || "JSON parse failed");
   }
   return result.data;
-  const c = (text || "").trim();
-  if (!c) throw new Error("Empty response");
-  let extracted = c;
-  const fo = c.indexOf("{"), lo = c.lastIndexOf("}");
-  const fa = c.indexOf("["), la = c.lastIndexOf("]");
-  if (fo !== -1 && lo !== -1 && (fa === -1 || fo < fa)) extracted = c.slice(fo, lo + 1);
-  else if (fa !== -1 && la !== -1) extracted = c.slice(fa, la + 1);
-  try { return JSON.parse(extracted); } catch { /* ignore - extracted text is not valid JSON */ }
-  const rep = extracted.replace(/,\s*([}\]])/g, "$1");
-  try { return JSON.parse(rep); } catch (e: any) { throw new Error(`JSON parse failed: ${e.message}`); }
 }
 
 function validatePayload(p: any) {


### PR DESCRIPTION
## Problem
`api/process.ts` defines `safeJsonParse`. The issue reported it as dead code that was never called. In the current code it *is* used to parse the Hugging Face model output in `runHfAnalysis` (via `repairTruncatedJSON`), but the function still contained a large block of unreachable code: every statement after the `return result.data;` line (a duplicate, hand-rolled `JSON.parse` fallback with dead branches) could never execute. That dead block is exactly the kind of "code clutter / maintenance burden" and misleading duplicate-parsing logic the issue calls out.

## Fix
Removed the unreachable code after the `return` so `safeJsonParse` is a single, clear code path that delegates to `repairTruncatedJSON` and throws on failure. The function remains wired into the model-output parsing, so the helper is doing its job rather than being dead/duplicated.

## Files changed
- `api/process.ts`

## Testing
- `safeJsonParse` is still invoked by `runHfAnalysis` to parse model responses; behavior (success / throw on invalid) is unchanged.
- No unreachable statements remain in the function.

Closes #1072
