### PR TITLE
fix: remove dead unreachable branch in cashflow getNextMonths (#1073)

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -9,7 +9,6 @@ import {
 } from "firebase/firestore";
 import { db, handleFirestoreError, OperationType } from "@/src/lib/firebase";
 import { toDate, normalizeTransactionType } from "@/src/lib/utils";
-import { getForecastMonths } from "@/src/lib/forecastMonthUtils";
 
 export interface Transaction {
   id: string;
@@ -104,10 +103,6 @@ function getNextMonths(count: number): string[] {
     months.push(getMonthKey(d));
   }
   return months;
-  // Shared forecast-window convention: forecast months start at the NEXT
-  // calendar month so the cash-flow engine agrees with the Forecast
-  // Comparison engine (issue #900).
-  return getForecastMonths(count);
 }
 
 export async function fetchUserTransactions(


### PR DESCRIPTION
## Problem
`src/lib/cashflowUtils.ts` `getNextMonths` ended with `return months;` *followed* by a commented block and a second `return getForecastMonths(count);`. Because the first `return` already exited the function, the trailing return (and its explanatory comment) was unreachable dead code. It misled readers into thinking the branch shaped the output when it never executed, and left an unused `getForecastMonths` import.

## Fix
Removed the unreachable comment + `return getForecastMonths(count);` so `getNextMonths` has a single, clear exit path, and dropped the now-unused `getForecastMonths` import (it is still used by `forecastUtils.ts`, so no shared functionality was lost).

## Files changed
- `src/lib/cashflowUtils.ts`

## Testing
- `getNextMonths(count)` returns the same month list as before (the dead branch never ran).
- No unused imports remain; the function's actual behavior (forecast starting at the next calendar month) is now the only behavior.

Closes #1073
