### PR TITLE
fix: remove redundant groups.set in groupTransactionsIntoSubscriptions (#1074)

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -223,8 +223,6 @@ export function groupTransactionsIntoSubscriptions(
       // Use the full normalized description as the group key: truncating to
       // 20 chars merges distinct subscriptions that share a prefix (e.g.
       // "adobe creative cloud photography plan" vs "... all-apps annual").
-      const newKey = normalized;
-      groups.set(newKey, [transaction]);
       groups.set(normalized, [transaction]);
     } else {
       const existing = groups.get(matchedKey)!;


### PR DESCRIPTION
## Problem
In `src/lib/subscriptionUtils.ts` `groupTransactionsIntoSubscriptions`, when a new subscription group was created the code set the same map key twice with identical values:
```ts
const newKey = normalized;
groups.set(newKey, [transaction]);
groups.set(normalized, [transaction]); // same key again
```
`newKey` is just `normalized`, so the second `set` was pure dead code — a copy/paste leftover from when the key was truncated to 20 chars (the comment above still referenced that old behavior).

## Fix
Removed the duplicate `groups.set(...)` line, keeping the single `groups.set(normalized, [transaction])`. Behavior is unchanged.

## Files changed
- `src/lib/subscriptionUtils.ts`

## Testing
- `groupTransactionsIntoSubscriptions` still creates a new group keyed by the full normalized description; no double write.
- No runtime effect; intent is now clear.

Closes #1074
