### PR TITLE
fix: apiFetch 401 retry uses fresh controller and clears caller listener (#1075)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,26 +31,32 @@ export async function apiFetch(
     throw new Error("Fetch API is not available in this environment");
   }
 
-  // Create a new controller for this request
+  // Build a controller for this request and wire the caller's AbortSignal into
+  // it. We keep a handle on the listener so it can be detached on cleanup and
+  // never leak on the (possibly unmounted) caller's signal.
   const controller = new AbortController();
-
-  // Respect an existing AbortSignal provided by the caller
+  let callerAbortListener: (() => void) | null = null;
   if (init?.signal) {
     if (init.signal.aborted) {
       controller.abort(init.signal.reason);
     } else {
-      init.signal.addEventListener(
-        "abort",
-        () => controller.abort(init.signal?.reason),
-        { once: true },
-      );
+      callerAbortListener = () => controller.abort(init.signal?.reason);
+      init.signal.addEventListener("abort", callerAbortListener, { once: true });
     }
   }
 
-  // Abort the request after the timeout
   const timeoutId = setTimeout(() => {
     controller.abort(new Error(`Request timed out after ${timeout}ms`));
   }, timeout);
+
+  // Detach the caller-signal listener and clear the timeout exactly once.
+  const cleanup = () => {
+    if (callerAbortListener && init?.signal) {
+      init.signal.removeEventListener("abort", callerAbortListener);
+      callerAbortListener = null;
+    }
+    clearTimeout(timeoutId);
+  };
 
   try {
     const res = await fetchImpl(input, {
@@ -58,18 +64,43 @@ export async function apiFetch(
       signal: controller.signal,
     });
 
-    // 401 Interceptor: If 401 Unauthorized occurs, attempt silent token renewal and retry once
+    // 401 Interceptor: attempt silent token renewal and retry once.
     if (res.status === 401 && init?.headers) {
       const newToken = await getValidIdToken(true);
       if (newToken) {
         const headers = new Headers(init.headers);
         headers.set("Authorization", `Bearer ${newToken}`);
         console.warn("[API Fetch] 401 Unauthorized intercepted. Retrying request with refreshed token.");
-        return await fetchImpl(input, {
-          ...init,
-          headers,
-          signal: controller.signal,
-        });
+
+        // The retry gets a FRESH controller + timeout so it is not killed by the
+        // still-pending original timeout, and a fresh caller-signal listener
+        // that is also cleaned up.
+        cleanup();
+        const retryController = new AbortController();
+        let retryCallerListener: (() => void) | null = null;
+        if (init?.signal) {
+          if (init.signal.aborted) {
+            retryController.abort(init.signal.reason);
+          } else {
+            retryCallerListener = () => retryController.abort(init.signal?.reason);
+            init.signal.addEventListener("abort", retryCallerListener, { once: true });
+          }
+        }
+        const retryTimeoutId = setTimeout(() => {
+          retryController.abort(new Error(`Request timed out after ${timeout}ms`));
+        }, timeout);
+        try {
+          return await fetchImpl(input, {
+            ...init,
+            headers,
+            signal: retryController.signal,
+          });
+        } finally {
+          if (retryCallerListener && init?.signal) {
+            init.signal.removeEventListener("abort", retryCallerListener);
+          }
+          clearTimeout(retryTimeoutId);
+        }
       }
     }
 
@@ -85,6 +116,6 @@ export async function apiFetch(
 
     throw error;
   } finally {
-    clearTimeout(timeoutId);
+    cleanup();
   }
 }


### PR DESCRIPTION
## Problem
`src/lib/api.ts` `apiFetch` set up a single `AbortController` + `setTimeout` for the request and, on a 401, retried by calling `fetchImpl` again with the **same** `controller.signal`. Two bugs resulted:
1. The retry reused the original timeout, so a slow 401 could be aborted by the still-pending original `setTimeout` even though the retry itself hadn't timed out — forcing manual retries.
2. When the caller passed `init.signal`, `apiFetch` added an abort listener with `{ once: true }` on the caller's signal but never removed it on early success/error, leaking a listener tied to a possibly-unmounted caller.

## Fix
- The 401 retry now uses a **fresh** `AbortController` and a fresh `setTimeout`, so it has its own full timeout window.
- A `cleanup()` helper detaches the caller-signal listener (and clears the timeout) exactly once — both for the initial request and for the retry — so no listener leaks on the caller's `AbortSignal`.

## Files changed
- `src/lib/api.ts`

## Testing
- A 401 response now retries with a new controller/timeout rather than the stale original one.
- The caller-signal listener is removed in the `finally` path for both the primary request and the retry, so no listener remains attached after completion.

Closes #1075
