### PR TITLE
fix: remove duplicate date-fns import in ReportExport (#1076)

### DIFF
--- a/src/components/reports/ReportExport.tsx
+++ b/src/components/reports/ReportExport.tsx
@@ -41,7 +41,6 @@ import {
   endOfMonth,
   endOfDay,
 } from "date-fns";
-import { format, subDays, startOfMonth, endOfMonth, endOfDay } from "date-fns";
 import {
   fetchTransactionsForDateRange,
   generateExpenseSummary,


### PR DESCRIPTION
## Problem
`src/components/reports/ReportExport.tsx` imported the exact same named bindings from `date-fns` twice, back-to-back. The duplicate import failed lint rules (`@typescript-eslint/no-duplicate-imports` / `import/no-duplicates`) and was pure redundancy left over from an incomplete refactor.

## Fix
Removed the second, identical `import { format, subDays, startOfMonth, endOfMonth, endOfDay } from "date-fns";` line, keeping the single existing import.

## Files changed
- `src/components/reports/ReportExport.tsx`

## Testing
- No runtime behavior change; the same date-fns functions remain imported exactly once, so the duplicate-import lint rule passes.

Closes #1076
