### PR TITLE
fix: removed duplicate CurrencyManager rendering in currencies tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1402,18 +1402,9 @@ export default function App() {
                 className="space-y-6"
               >
                 <CurrencyManager user={user} />
-                <div className="space-y-6">
-                  {user ? (
-                    <>
-                      <CurrencyManager user={user} />
-                      <CurrencyConverter />
-                      <MultiCurrencyNetWorth />
-                      <FxExposureMatrix />
-                    </>
-                  ) : (
-                    <CurrencyConverter />
-                  )}
-                </div>
+                <CurrencyConverter />
+                <MultiCurrencyNetWorth />
+                <FxExposureMatrix />
               </motion.div>
             )}
 


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `CurrencyManager` rendering in the currencies tab of `src/App.tsx`. The component was previously rendered twice: once directly inside the motion.div wrapper, and again nested inside a redundant `user ?` conditional block. The outer `user &&` guard already ensures the user is authenticated, making the inner conditional redundant.

## Changes Made

- Removed the outer `<CurrencyManager user={user} />` from the currencies tab layout
- Removed the redundant `user ?` conditional that wrapped the inner CurrencyManager
- Moved `CurrencyConverter`, `MultiCurrencyNetWorth`, and `FxExposureMatrix` out of the nested div directly into the motion.div
- Net change: 3 insertions, 12 deletions

## Impact it Made

- Prevents double-mounting of CurrencyManager and its Firestore subscriptions
- Eliminates redundant API calls and state updates on the currencies tab
- Simplifies the component structure with no functional change

Closes #1095

## Note: Please assign this PR to the `tmdeveloper007` account.
