### PR TITLE
fix: added console.warn to empty catch blocks in clearAllLocalData

### DIFF
--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -230,8 +230,8 @@ export function clearAllLocalData(): void {
 
   try {
     window.localStorage.removeItem(LOCAL_DOCS_KEY);
-  } catch {
-    // ignore
+  } catch (err) {
+    console.warn("[FinSight] Failed to clear localStorage:", err);
   }
 
   try {
@@ -242,15 +242,15 @@ export function clearAllLocalData(): void {
       if (key && key.startsWith("fin_local_doc_")) doomed.push(key);
     }
     doomed.forEach((key) => session.removeItem(key));
-  } catch {
-    // ignore
+  } catch (err) {
+    console.warn("[FinSight] Failed to clear sessionStorage:", err);
   }
 
   try {
     window.dispatchEvent(
       new CustomEvent("fin_local_docs_changed", { detail: { cleared: true } }),
     );
-  } catch {
-    // ignore
+  } catch (err) {
+    console.warn("[FinSight] Failed to dispatch fin_local_docs_changed event:", err);
   }
 }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced three empty `catch` blocks in `src/lib/storageUtils.ts` with proper error logging using `console.warn`. The `clearAllLocalData()` function silently swallowed all errors when clearing localStorage, sessionStorage, or dispatching events, making it impossible to debug storage-related failures.

## Changes Made

Replaced each `catch { // ignore }` with `catch (err) { console.warn("[FinSight] ...", err); }` in the three try/catch blocks within `clearAllLocalData()`:
- localStorage removal failure now logs `"[FinSight] Failed to clear localStorage:"`
- sessionStorage cleanup failure now logs `"[FinSight] Failed to clear sessionStorage:"`
- CustomEvent dispatch failure now logs `"[FinSight] Failed to dispatch fin_local_docs_changed event:"`

## Impact it Made

- Errors during local data clearing are now observable in browser devtools
- Helps users and developers diagnose storage issues (private browsing mode, quota exceeded, security restrictions)
- No functional change — errors are still suppressed, just now logged

Closes #1096

## Note: please assign this PR to the `tmdeveloper007` account.
