### PR TITLE
fix: added cancellation guard to chat conversations useEffect

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -164,12 +164,15 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
 
   useEffect(() => {
     if (!currentUserId) return;
-    const unsubscribe = loadConversations(currentUserId).then((convs) => {
-      if (!currentUserId) return;
+    let cancelled = false;
+
+    loadConversations(currentUserId).then((convs) => {
+      if (cancelled) return;
       setConversations(convs);
     });
+
     return () => {
-      unsubscribe.then(() => {});
+      cancelled = true;
     };
   }, [currentUserId]);
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added a cancellation guard to the `useEffect` that loads chat conversations in `src/components/chat/ChatAssistant.tsx`. The previous implementation called `unsubscribe.then(() => {})` in the cleanup function, which does not cancel the async operation — it merely waits for it to complete and discards the result. If `currentUserId` changed while the load was in flight, the stale `setConversations` call could overwrite the fresh conversation list for the new user.

## Changes Made

Replaced the race-prone cleanup with a boolean `cancelled` flag:

```typescript
// Before:
const unsubscribe = loadConversations(currentUserId).then((convs) => {
  if (!currentUserId) return;
  setConversations(convs);
});
return () => { unsubscribe.then(() => {}); };

// After:
let cancelled = false;
loadConversations(currentUserId).then((convs) => {
  if (cancelled) return;
  setConversations(convs);
});
return () => { cancelled = true; };
```

## Impact it Made

- Prevents stale conversation lists from overwriting fresh data after user switch
- Eliminates potential data leaks between user sessions
- Aligns cleanup with React best practices for async effects

Closes #1097

## Note: please assign this PR to the `tmdeveloper007` account.
