### PR TITLE
fix: added console.warn to empty catch in storeLocalDocument

### DIFF
--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -136,7 +136,8 @@ export async function saveLocalAnalysis(
         evictOldest(docMap, MAX_LOCAL_DOCS);
         writeLocalDocMap(docMap, payload.documentId);
         return { ok: true, quotaExceeded: true };
-      } catch {
+      } catch (err) {
+        console.warn("[FinSight] storeLocalDocument failed:", err);
         return { ok: false, quotaExceeded: true };
       }
     }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced an empty `catch` block in `src/lib/storageUtils.ts` with a `console.warn` call. The `storeLocalDocument` function silently swallowed storage errors (such as quota exceeded or unavailable storage in private browsing mode), making it impossible to diagnose storage-related failures.

## Changes Made

In `src/lib/storageUtils.ts` around line 139, replaced:

```typescript
// Before:
} catch {
  return { ok: false, quotaExceeded: true };
}

// After:
} catch (err) {
  console.warn("[FinSight] storeLocalDocument failed:", err);
  return { ok: false, quotaExceeded: true };
}
```

## Impact it Made

- Errors during document caching are now observable in browser devtools
- Helps distinguish quota-exceeded errors from other storage failures
- No functional change — the function still returns the correct failure state

Closes #1098

## Note: please assign this PR to the `tmdeveloper007` account.
