### PR TITLE
chore: guarded Firebase config console.log behind non-production check

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -22,12 +22,14 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-FLDV1FCY1G",
 };
 
-console.log("[Firebase] Config loaded:", {
-  apiKey: firebaseConfig.apiKey ? firebaseConfig.apiKey.substring(0, 8) + "..." : "MISSING",
-  authDomain: firebaseConfig.authDomain || "MISSING",
-  projectId: firebaseConfig.projectId || "MISSING",
-  appId: firebaseConfig.appId ? "set" : "MISSING",
-});
+if (process.env.NODE_ENV !== "production") {
+  console.log("[Firebase] Config loaded:", {
+    apiKey: firebaseConfig.apiKey ? firebaseConfig.apiKey.substring(0, 8) + "..." : "MISSING",
+    authDomain: firebaseConfig.authDomain || "MISSING",
+    projectId: firebaseConfig.projectId || "MISSING",
+    appId: firebaseConfig.appId ? "set" : "MISSING",
+  });
+}
 
 const firestoreDatabaseId = String(
   import.meta.env.VITE_FIREBASE_FIRESTORE_DATABASE_ID || "(default)",


### PR DESCRIPTION
## Summary of What Has Been Done

Wrapped the Firebase config startup `console.log` in `src/lib/firebase.ts` with a `process.env.NODE_ENV !== "production"` guard. This removes Firebase configuration details (even though truncated) from production browser consoles.

## Changes Made

In `src/lib/firebase.ts`, wrapped the console.log block:

```typescript
// Before:
console.log("[Firebase] Config loaded:", { ... });

// After:
if (process.env.NODE_ENV !== "production") {
  console.log("[Firebase] Config loaded:", { ... });
}
```

This follows the same pattern already used elsewhere in the codebase (e.g., `src/lib/firebase.ts` line 165).

## Impact it Made

- Removes Firebase config logging from production browser devtools
- Keeps useful startup logging available during development
- Minimal change with no functional impact

Closes #1099

## Note: please assign this PR to the `tmdeveloper007` account.
