### PR TITLE
validateAnalysisPayload does not clamp sentiment_score to [-1, 1]

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -231,6 +231,12 @@ function safeJsonParse(text: string): unknown {
   }
 }
 
+function clampSentiment(v: unknown): number {
+  const n = Number(v || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(-1, Math.min(1, n));
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function validateAnalysisPayload(payload: any): AnalysisResponse {
   const required = [
@@ -271,7 +277,7 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
     action_items: Array.isArray(payload.action_items)
       ? payload.action_items.map((v: unknown) => sanitizeString(String(v)))
       : [],
-    sentiment_score: Number(payload.sentiment_score || 0),
+    sentiment_score: clampSentiment(payload.sentiment_score),
     entities: Array.isArray(payload.entities)
       ? payload.entities.map((v: unknown) => sanitizeString(String(v)))
       : [],

--- a/api/process.ts
+++ b/api/process.ts
@@ -322,11 +322,18 @@ function safeJsonParse(text: string): unknown {
   return result.data;
 }
 
+function clampSentiment(v: unknown): number {
+  const n = Number(v || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(-1, Math.min(1, n));
+}
+
 function validatePayload(p: any) {
   const keys = ["summary", "key_metrics", "risk_assessment", "action_items", "sentiment_score", "entities", "full_report"];
   for (const k of keys) if (!(k in p)) throw new Error(`Missing key: ${k}`);
   const words = String(p.full_report || "").trim().split(/\s+/).filter(Boolean).length;
   if (words < 120) throw new Error(`full_report too short: ${words} words`);
+  p.sentiment_score = clampSentiment(p.sentiment_score);
   return p;
 }
 

--- a/server.ts
+++ b/server.ts
@@ -200,6 +200,12 @@ function safeJsonParse(text: string): unknown {
   return result.data;
 }
 
+function clampSentiment(v: unknown): number {
+  const n = Number(v || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(-1, Math.min(1, n));
+}
+
 function validateAnalysisPayload(payload: any): AnalysisResponse {
   const required = [
     "summary",
@@ -250,7 +256,7 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
     action_items: Array.isArray(payload.action_items)
       ? payload.action_items.map((v: unknown) => sanitizeString(String(v)))
       : [],
-    sentiment_score: Number(payload.sentiment_score || 0),
+    sentiment_score: clampSentiment(payload.sentiment_score),
     entities: Array.isArray(payload.entities)
       ? payload.entities.map((v: unknown) => sanitizeString(String(v)))
       : [],


### PR DESCRIPTION
﻿## Problem
alidateAnalysisPayload in server.ts and the equivalent validation in pi/analyze.ts accept an arbitrary sentiment_score without bounds-checking. A model/route returning -2, 3, or 999 passes validation and is persisted verbatim, corrupting sentiment aggregations (dashboard averages, sort orders, color coding). The schema documents sentiment_score as a number between -1.0 and 1.0.

## Fix
Added a shared clampSentiment(v) helper (clamps to [-1, 1], returns  for non-finite input) and applied it to the sentiment_score field in all three validators (server.ts, pi/analyze.ts, pi/process.ts). pi/process.ts now also clamps the value inside alidatePayload.

## Files changed
- server.ts
- api/analyze.ts
- api/process.ts

## Testing
- Verified a sentiment_score of 3 is stored as 1 and -2's input of -5 as -1.
- Verified NaN/undefined fall back to .

Closes #1123
