### PR TITLE
Analysis validation accepts full_report as short as 120 words, contradicting the 600-word schema

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -247,7 +247,7 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
   }
   const fullReport = String(payload.full_report || "").trim();
   const wordCount = fullReport.split(/\s+/).filter(Boolean).length;
-  if (wordCount < 120)
+  if (wordCount < 600)
     throw new Error(`full_report too short (${wordCount} words)`);
 
   return {

--- a/api/process.ts
+++ b/api/process.ts
@@ -326,7 +326,7 @@ function validatePayload(p: any) {
   const keys = ["summary", "key_metrics", "risk_assessment", "action_items", "sentiment_score", "entities", "full_report"];
   for (const k of keys) if (!(k in p)) throw new Error(`Missing key: ${k}`);
   const words = String(p.full_report || "").trim().split(/\s+/).filter(Boolean).length;
-  if (words < 120) throw new Error(`full_report too short: ${words} words`);
+  if (words < 600) throw new Error(`full_report too short: ${words} words`);
   return p;
 }
 

--- a/server.ts
+++ b/server.ts
@@ -219,14 +219,9 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
 
   const fullReport = String(payload.full_report || "").trim();
   const wordCount = fullReport.split(/\s+/).filter(Boolean).length;
-  if (wordCount < 120) {
+  if (wordCount < 600) {
     throw new Error(
       `Model response full_report is too short (${wordCount} words)`,
-    );
-  }
-  if (wordCount < 450) {
-    console.warn(
-      `AI_SCHEMA_VALIDATION_WARNING: full_report is ${wordCount} words; accepting shorter valid analysis.`,
     );
   }
 


### PR DESCRIPTION
﻿## Problem
The analysis payload validator enforces a 120-word minimum for ull_report, but the published schema and the LLM prompt contract require a 600-word minimum. Reports of 120-599 words are stored and rendered as complete analyses while violating the schema.

## Fix
Raised the ull_report validation floor from 120 to 600 words in all three validators (server.ts, pi/analyze.ts, pi/process.ts). Removed the obsolete "<450 words" acceptance warning, which is now unreachable since 600 is the hard minimum.

## Files changed
- server.ts
- api/analyze.ts
- api/process.ts

## Testing
- Verified a 599-word report is now rejected; a 600-word report is accepted.

Closes #1124
