### PR TITLE
PortfolioTracker 'Profit / Loss' Summary card sums local-currency P/L into a base-currency total

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -186,9 +186,17 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
       }, 0),
     [holdings, rates, baseCurrency],
   );
-  const profitLoss = useMemo(() => {
-    return holdings.reduce((sum, h) => sum + calculateProfitLoss(h).value, 0);
-  }, [holdings]);
+  const profitLoss = useMemo(
+    () =>
+      holdings.reduce((sum, h) => {
+        const local = (h.currentPrice - h.avgCost) * h.quantity;
+        if (!rates || !h.currency || h.currency === baseCurrency)
+          return sum + local;
+        const converted = convertAmount(local, h.currency, baseCurrency, rates);
+        return sum + (converted == null ? local : converted);
+      }, 0),
+    [holdings, rates, baseCurrency],
+  );
   const allocation = useMemo(
     () => calculateAllocation(holdings, rates ?? undefined, baseCurrency),
     [holdings, rates, baseCurrency],


### PR DESCRIPTION
﻿## Problem
In PortfolioTracker.tsx the Summary "Profit / Loss" card sums each holding's profit/loss computed in the holding's **local** currency, while 	otalValue/	otalCost are converted to aseCurrency. For multi-currency portfolios the P/L figure mixes currencies.

## Fix
Rewrote the profitLoss useMemo to convert each holding's local P/L into aseCurrency (via convertAmount) before summing, using ates/aseCurrency as dependencies, matching the existing 	otalCost/	otalValue handling.

## Files changed
- src/components/portfolio/PortfolioTracker.tsx

## Testing
- Verified an EUR position's P/L is converted to the USD base before being added to the total.

Closes #1125
