### PR TITLE
SubscriptionAnalyzer mutates the subscriptions React state via in-place Array.sort

### DIFF
--- a/src/components/subscriptions/SubscriptionAnalyzer.tsx
+++ b/src/components/subscriptions/SubscriptionAnalyzer.tsx
@@ -109,7 +109,7 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
   }, [subscriptions, estimatedMonthlyIncome]);
 
   const filteredSubscriptions = useMemo(() => {
-    let result = subscriptions;
+    let result = [...subscriptions];
 
     if (filter !== "all") {
       result = result.filter((s) => s.frequency === filter);


### PR DESCRIPTION
﻿## Problem
In SubscriptionAnalyzer.tsx the derived ilteredSubscriptions list aliases the subscriptions React state array and then sorts it **in place**, mutating component state outside of setState when no filter is active.

## Fix
Copy the state array first (let result = [...subscriptions]) before filtering/sorting, so the subscriptions state remains referentially stable and unmutated.

## Files changed
- src/components/subscriptions/SubscriptionAnalyzer.tsx

## Testing
- Verified the source subscriptions list is no longer reordered after sorting the filtered view.

Closes #1129
