### PR TITLE
GoalPlanner detail dialog shows a stale snapshot of the goal after contributions

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -68,7 +68,8 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
-  const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
+  const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null);
+  const selectedGoal = goals.find((g) => g.id === selectedGoalId) || null;
   const [selectedSuggestionLevel, setSelectedSuggestionLevel] = useState<'Recommended' | 'Conservative' | 'Aggressive'>('Recommended');
   const notifiedGoalIds = useRef(new Set<string>());
   const updatingGoalIds = useRef(new Set<string>());
@@ -260,7 +261,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
     try {
       await deleteDoc(doc(db, 'goals', goalId));
       toast.success('Goal deleted');
-      if (selectedGoal?.id === goalId) setSelectedGoal(null);
+      if (selectedGoalId === goalId) setSelectedGoalId(null);
     } catch (error) {
       console.error('Error deleting goal:', error);
       handleFirestoreError(error, OperationType.DELETE, `goals/${goalId}`);
@@ -471,7 +472,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                         goal={goal}
                         baseCurrency={baseCurrency}
                         onUpdateAmount={updateGoalAmount}
-                        onViewDetails={setSelectedGoal}
+                        onViewDetails={(g) => setSelectedGoalId(g.id)}
                         onStatusChange={(id, status) => updateGoalStatus(id, status)}
                         onDelete={deleteGoal}
                       />
@@ -505,7 +506,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                         goal={goal}
                         baseCurrency={baseCurrency}
                         onUpdateAmount={updateGoalAmount}
-                        onViewDetails={setSelectedGoal}
+                        onViewDetails={(g) => setSelectedGoalId(g.id)}
                         onStatusChange={(id, status) => updateGoalStatus(id, status)}
                         onDelete={deleteGoal}
                       />
@@ -537,7 +538,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
                       goal={goal}
                       baseCurrency={baseCurrency}
                       onUpdateAmount={updateGoalAmount}
-                      onViewDetails={setSelectedGoal}
+                      onViewDetails={(g) => setSelectedGoalId(g.id)}
                       onStatusChange={(id, status) => updateGoalStatus(id, status)}
                       onDelete={deleteGoal}
                     />
@@ -569,7 +570,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
         </div>
       )}
 
-      <Dialog open={!!goalDetail} onOpenChange={(open) => !open && setSelectedGoal(null)}>
+      <Dialog open={!!goalDetail}               onOpenChange={(open) => !open && setSelectedGoalId(null)}>
         <DialogContent className="bg-slate-900 border-slate-800 text-white max-w-2xl rounded-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <div className="flex items-center justify-between">


### PR DESCRIPTION
﻿## Problem
GoalPlanner.tsx stores the selected goal object in selectedGoal and never re-derives it from the live goals array. After a contribution updates goals, the open detail dialog keeps showing the stale snapshot.

## Fix
Store only selectedGoalId and derive the live selectedGoal via goals.find((g) => g.id === selectedGoalId). onViewDetails now sets the id instead of the object, and the dialog always reflects the latest goal state.

## Files changed
- src/components/goals/GoalPlanner.tsx

## Testing
- Verified that contributing to a goal updates the open detail dialog's remaining amount, progress, and projected completion date.

Closes #1130
