### PR TITLE
MultiScenarioMatrix defaultProbabilityModifier is never applied to the projection

### DIFF
--- a/src/components/forecast/MultiScenarioMatrix.tsx
+++ b/src/components/forecast/MultiScenarioMatrix.tsx
@@ -31,7 +31,8 @@ export const MultiScenarioMatrix: React.FC = () => {
     scenarios.forEach((scen) => {
       const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * ((idx + 1) / 12);
       const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * ((idx + 1) / 12);
-      const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor));
+      const realization = Math.max(0, 1 - (scen.defaultProbabilityModifier / 100) * ((idx + 1) / 12));
+      const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor) * realization);
       dataPoint[scen.name] = netCash;
     });
     return dataPoint;


### PR DESCRIPTION
﻿## Problem
MultiScenarioMatrix.tsx carries a defaultProbabilityModifier on every scenario, but the projection math only uses evenueGrowthModifier and expenseInflationModifier. The default-probability dimension has no effect, so two scenarios differing only by default probability render identical curves.

## Fix
Incorporated defaultProbabilityModifier into the cash projection as a probability-of-realization factor (ealization = max(0, 1 - (modifier/100) * ((idx+1)/12))), so default probability now shifts the line.

## Files changed
- src/components/forecast/MultiScenarioMatrix.tsx

## Testing
- Verified scenarios identical except for default probability now produce visibly different projected cash curves.

Closes #1132
