### PR TITLE
ForecastComparison persists only 6 of 12 generated forecasts (slice(0,6))

### DIFF
--- a/src/components/forecast/ForecastComparison.tsx
+++ b/src/components/forecast/ForecastComparison.tsx
@@ -71,7 +71,7 @@ async function persistGeneratedForecasts(
   if (!generated.length) return;
   const existing = await getForecasts(userId);
   const byMonth = new Map(existing.map((f) => [f.month, f]));
-  for (const m of generated.slice(0, 6)) {
+  for (const m of generated) {
     const payload = {
       month: m.month,
       projectedIncome: m.income,


### PR DESCRIPTION
﻿## Problem
ForecastComparison.tsx persists only the first 6 of the 12 generated monthly forecasts via persistGeneratedForecasts(generated.slice(0, 6)). On reload the component seeds monthly with 6 rows, silently shrinking the chart/summary relative to a fresh generate.

## Fix
Removed the slice(0, 6) so the helper iterates and persists all 12 generated forecasts, matching freshly generated state after reload.

## Files changed
- src/components/forecast/ForecastComparison.tsx

## Testing
- Verified that after regenerate + reload, monthly contains all 12 rows (matching a fresh generate).

Closes #1133
