### PR TITLE
sensitivityUtils interestRateDown/Up compute identical low and high swing impacts

### DIFF
--- a/src/lib/sensitivityUtils.ts
+++ b/src/lib/sensitivityUtils.ts
@@ -49,7 +49,7 @@ export function calculateSensitivityDrivers(
       baselineValue: interestRate,
       unit: "%",
       lowSwingImpact: Math.round(
-        (revenue - cogs - opex - revenue * ((interestRate * 0.8) / 100)) - baseNetProfit
+        (revenue - cogs - opex - revenue * ((interestRate * 1.0) / 100)) - baseNetProfit
       ),
       highSwingImpact: Math.round(
         (revenue - cogs - opex - revenue * ((interestRate * 0.8) / 100)) - baseNetProfit
@@ -64,7 +64,7 @@ export function calculateSensitivityDrivers(
         (revenue - cogs - opex - revenue * ((interestRate * 1.2) / 100)) - baseNetProfit
       ),
       highSwingImpact: Math.round(
-        (revenue - cogs - opex - revenue * ((interestRate * 1.2) / 100)) - baseNetProfit
+        (revenue - cogs - opex - revenue * ((interestRate * 1.0) / 100)) - baseNetProfit
       ),
     },
     {


### PR DESCRIPTION
﻿## Problem
In src/lib/sensitivityUtils.ts the interestRateDown and interestRateUp sensitivity variables compute identical lowSwingImpact and highSwingImpact values because both branches use the same multiplier. The low vs high swing impact is always equal.

## Fix
Gave each row distinct low/high directions: interestRateDown uses 1.0 for low and .8 for high; interestRateUp uses 1.2 for low and 1.0 for high, so the table reveals asymmetric risk.

## Files changed
- src/lib/sensitivityUtils.ts

## Testing
- Verified interestRateDown.lowSwingImpact != interestRateDown.highSwingImpact and similarly for interestRateUp.

Closes #1136
