### PR TITLE
[Bug] Verification adjudication promotes claims without a valid in-scope citation

### DIFF
--- a/src/lib/verification/adjudicator.ts
+++ b/src/lib/verification/adjudicator.ts
@@ -36,6 +36,7 @@ export interface AdjudicationVerdict {
   verdict: "supported" | "partial" | "unsupported";
   chunkId: string;
   reason: string;
+  retrievedChunkIds: string[];
 }
 
 /**
@@ -66,6 +67,11 @@ export async function adjudicateClaims(
         chunks: relevantChunks,
       };
     });
+
+    const retrievedByClaim: Record<string, string[]> = {};
+    for (const { claim, chunks: retrieved } of claimsWithContext) {
+      retrievedByClaim[claim.id] = retrieved.map((c) => c.id);
+    }
 
     const claimsFormatted = claimsWithContext.map(({ claim, chunks: retrieved }) => {
       const chunksText = retrieved.map((c) => `Chunk [ID: ${c.id}] (Page ${c.pageNumber || "unknown"}):\n${c.text}`).join("\n---\n");
@@ -124,6 +130,7 @@ ${claimsFormatted}`;
               verdict: item.verdict || "unsupported",
               chunkId: item.chunkId || "",
               reason: item.reason || "",
+              retrievedChunkIds: retrievedByClaim[item.claimId] || [],
             };
           }
         }

--- a/src/lib/verification/index.ts
+++ b/src/lib/verification/index.ts
@@ -74,34 +74,37 @@ export async function verifyDocumentAnalysis(
         if (claim.status !== "unverified") continue;
 
         const adjudication = adjudicationResults[claim.id];
-        if (adjudication && (adjudication.verdict === "supported" || adjudication.verdict === "partial")) {
-          const status: ClaimStatus = adjudication.verdict === "supported" ? "verified" : "derived";
-          
+        const retrieved = new Set(adjudication?.retrievedChunkIds ?? []);
+        const chunk =
+          adjudication && (adjudication.verdict === "supported" || adjudication.verdict === "partial")
+            ? retrieved.has(adjudication.chunkId ?? "")
+              ? chunks.find((c) => c.id === adjudication.chunkId)
+              : undefined
+            : undefined;
+
+        if (chunk && chunk.text.includes(String(claim.value))) {
+          const status: ClaimStatus = adjudication!.verdict === "supported" ? "verified" : "derived";
           claim.status = status;
-          claim.reason = adjudication.reason;
+          claim.reason = adjudication!.reason;
 
-          // Find the chunk that supported this claim
-          const chunk = chunks.find((c) => c.id === adjudication.chunkId);
-          if (chunk) {
-            const page = chunk.pageNumber || 1;
-            const snippet = chunk.text.slice(0, 240).replace(/\s+/g, " ").trim();
-            const charOffset = chunk.charStart || 0;
+          const page = chunk.pageNumber || 1;
+          const snippet = chunk.text.slice(0, 240).replace(/\s+/g, " ").trim();
+          const charOffset = chunk.charStart || 0;
 
-            const citation: Citation = {
-              page,
-              chunkId: chunk.id,
-              snippet,
-              charOffset,
-              matchType: "adjudicated",
-            };
+          const citation: Citation = {
+            page,
+            chunkId: chunk.id,
+            snippet,
+            charOffset,
+            matchType: "adjudicated",
+          };
 
-            claim.citation = citation;
+          claim.citation = citation;
 
-            // Store in citations map if under the limit
-            if (citationsCount < 100) {
-              result.citations[claim.id] = citation;
-              citationsCount++;
-            }
+          // Store in citations map if under the limit
+          if (citationsCount < 100) {
+            result.citations[claim.id] = citation;
+            citationsCount++;
           }
         }
       }


### PR DESCRIPTION
﻿## Problem

verifyDocumentAnalysis marks a claim verified/derived before validating that the cited chunkId resolves to a chunk actually retrieved for that claim, and never checks that the chunk text contains the claimed value. It also resolves chunkId across the entire chunks array, so the model can cite a chunk retrieved for a different claim or an invented id. This silently inflates grounding.ratio and presents unverified numbers as grounded.

## Fix

Resolve and validate the citation BEFORE setting claim.status. Scope chunk resolution to the chunk ids retrieved for that specific claim (AdjudicationVerdict now returns retrievedChunkIds), and only promote the claim when the cited chunk exists in-scope AND its text includes String(claim.value); otherwise it stays unverified.

## Files changed

src/lib/verification/index.ts, src/lib/verification/adjudicator.ts

## Testing

Unit: a supported verdict whose chunkId is missing from the claim's retrievedChunkIds stays unverified; a verdict whose chunk text does not contain the value stays unverified; a valid in-scope citation with matching text is promoted and a citation object is attached.

Closes #1106

