### PR TITLE
[Bug] Auto-categorization substring match mis-routes spend

### DIFF
--- a/src/lib/categorizationUtils.ts
+++ b/src/lib/categorizationUtils.ts
@@ -38,7 +38,9 @@ export function applyCategorizationRules(
     if (!rule.isActive) continue;
 
     const normalizedKeyword = rule.keyword.trim().toLowerCase();
-    if (normalizedKeyword.length > 0 && normalizedDesc.includes(normalizedKeyword)) {
+    if (normalizedKeyword.length === 0) continue;
+    const escaped = normalizedKeyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (new RegExp(`\\b${escaped}\\b`).test(normalizedDesc)) {
       return rule.assignedCategory;
     }
   }


### PR DESCRIPTION
﻿## Problem

applyCategorizationRules matched a keyword as a substring, so 'art' matched 'smart', 'car' matched 'carbon', etc., routing unrelated spend into the wrong category.

## Fix

Match using a word-boundary regex with the keyword escaped for regex special characters; empty/whitespace keywords and inactive rules are still skipped.

## Files changed

src/lib/categorizationUtils.ts

## Testing

Unit: rule keyword 'art' does not match 'smart'/'cart'; keyword 'car' does not match 'carbon'; an exact whole-word token still matches.

Closes #1110

