### PR TITLE
[Bug] Global default currency leaks across accounts / never reset on logout

### DIFF
--- a/src/hooks/useBaseCurrency.ts
+++ b/src/hooks/useBaseCurrency.ts
@@ -16,7 +16,11 @@ export function useBaseCurrency(user: { uid: string } | null): string {
   const [baseCurrency, setBaseCurrency] = useState('USD')
 
   useEffect(() => {
-    if (!user) return
+    if (!user) {
+      setDefaultCurrency('USD')
+      setBaseCurrency('USD')
+      return
+    }
 
     let cancelled = false
 
@@ -37,7 +41,7 @@ export function useBaseCurrency(user: { uid: string } | null): string {
     return () => {
       cancelled = true
     }
-  }, [user])
+  }, [user?.uid])
 
   return baseCurrency
 }


### PR DESCRIPTION
﻿## Problem

useBaseCurrency never reset the module-global default currency on logout, and keyed its effect on the whole user object so the global currency write ran on every auth emission.

## Fix

On logout reset both setDefaultCurrency and setBaseCurrency to 'USD'. Depend the effect on user?.uid (stable) instead of the user object.

## Files changed

src/hooks/useBaseCurrency.ts

## Testing

Manual: log in as user A (currency EUR), log out -> formatCurrency renders USD; rapid auth emissions no longer re-run the global write.

Closes #1112

