### PR TITLE
[Bug] RAG similaritySearch returns top-K chunks even when every score is 0

### DIFF
--- a/src/lib/rag/ragEngine.ts
+++ b/src/lib/rag/ragEngine.ts
@@ -89,6 +89,10 @@ export class RAGEngine {
       })
       .join("\n\n");
 
+    if (relevantChunks.length === 0) {
+      return { contextText: "", relevantChunks: [] };
+    }
+
     return { contextText, relevantChunks };
   }
 

--- a/src/lib/rag/vectorStore.ts
+++ b/src/lib/rag/vectorStore.ts
@@ -68,7 +68,7 @@ export class InMemoryVectorStore {
   /**
    * Performs Similarity Search and retrieves top-k relevant chunks for a query.
    */
-  public similaritySearch(query: string, topK: number = 3): ScoredChunk[] {
+  public similaritySearch(query: string, topK: number = 3, minScore = 1e-6): ScoredChunk[] {
     if (this.chunks.length === 0 || this.vocabulary.length === 0) return [];
 
     const queryEmbedding = generateSparseEmbedding(query, this.vocabulary);
@@ -79,6 +79,7 @@ export class InMemoryVectorStore {
     });
 
     return scored
+      .filter((s) => s.score > minScore)
       .sort((a, b) => b.score - a.score)
       .slice(0, topK);
   }


### PR DESCRIPTION
﻿## Problem

InMemoryVectorStore.similaritySearch always returns topK chunks, even when all cosine scores are 0, so an unrelated query receives the document's first chunks as 'context' and can produce confabulated supported verdicts in verification.

## Fix

Added a minScore parameter (default 1e-6) and filter chunks with score <= minScore before sorting/slicing, so unrelated queries return an empty set. ragEngine.retrieveContext now returns empty context when no chunks are retrieved instead of fabricating evidence.

## Files changed

src/lib/rag/vectorStore.ts, src/lib/rag/ragEngine.ts

## Testing

Unit: a query with no vocabulary overlap returns []; a query with a clear match still returns the top relevant chunks; retrieveContext returns empty contextText when relevantChunks is empty.

Closes #1107

