### PR TITLE
[Bug] saveTrendAnalysis uses a week key for quarter/custom periods

### DIFF
--- a/src/lib/trendsUtils.ts
+++ b/src/lib/trendsUtils.ts
@@ -377,7 +377,12 @@ export async function saveTrendAnalysis(
     };
   });
 
-  const periodKey = config.type === 'month' ? formatMonthKey(config.startDate) : formatWeekKey(config.startDate);
+  const periodKey =
+    config.type === 'month'
+      ? formatMonthKey(config.startDate)
+      : config.type === 'week'
+        ? formatWeekKey(config.startDate)
+        : `${formatMonthKey(config.startDate)}_${formatMonthKey(config.endDate)}`;
 
   try {
     await setDoc(doc(db, 'trend_analysis', `${userId}_${periodKey}`), {


### PR DESCRIPTION
﻿## Problem

For quarter/custom period types saveTrendAnalysis derived the doc key with formatWeekKey, colliding with weekly analyses that share the same start week and losing saved analyses.

## Fix

Use formatMonthKey for month, formatWeekKey for week, and a range-based key ${formatMonthKey(start)}_ for quarter/custom, giving each period type a unique, stable key.

## Files changed

src/lib/trendsUtils.ts

## Testing

Unit: saving a quarter analysis and a weekly analysis sharing the start week write to distinct docs; the quarter key is derived from its actual range.

Closes #1116

