### PR TITLE
[Bug] inferRecurrenceFrequency collapses bi-weekly/bimonthly to monthly

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -37,7 +37,29 @@ export interface RecurringTransaction {
   category: string;
   type: "income" | "expense";
   averageAmount: number;
-  frequency: "weekly" | "monthly" | "quarterly" | "yearly";
+  frequency: "weekly" | "biweekly" | "monthly" | "bimonthly" | "quarterly" | "yearly";
+}
+
+/** Canonical occurrences-per-year for a recurring frequency. Used by any
+ * projection/annualization code so a bi-weekly income (26/yr) or bi-monthly
+ * charge (6/yr) is scaled correctly instead of being treated as monthly (12/yr). */
+export function occurrencesPerYear(
+  frequency: RecurringTransaction["frequency"],
+): number {
+  switch (frequency) {
+    case "weekly":
+      return 52;
+    case "biweekly":
+      return 26;
+    case "monthly":
+      return 12;
+    case "bimonthly":
+      return 6;
+    case "quarterly":
+      return 4;
+    case "yearly":
+      return 1;
+  }
 }
 
 // Single source of truth for the observation/projection window so the fetch
@@ -74,7 +96,9 @@ function inferRecurrenceFrequency(
       : intervals[mid];
 
   if (median >= 5 && median <= 10) return "weekly";
+  if (median >= 11 && median <= 24) return "biweekly";
   if (median >= 25 && median <= 35) return "monthly";
+  if (median >= 36 && median <= 84) return "bimonthly";
   if (median >= 85 && median <= 95) return "quarterly";
   if (median >= 350 && median <= 380) return "yearly";
   return "monthly";


### PR DESCRIPTION
﻿## Problem

inferRecurrenceFrequency only recognized weekly/monthly/quarterly/yearly bands, so bi-weekly (~14d) and bi-monthly (~60d) cadences fell through to monthly, halving or doubling projected recurring cash flow.

## Fix

Added bands for biweekly (median 11-24) and bimonthly (median 36-84), extended RecurringTransaction['frequency'] to include them, and exported occurrencesPerYear() mapping each frequency to occurrences/year (biweekly 26, bimonthly 6) for correct projection/annualization.

## Files changed

src/lib/cashflowUtils.ts

## Testing

Unit: median intervals of 14 and 60 days classify as biweekly/bimonthly; occurrencesPerYear returns 26 and 6 respectively.

Closes #1115

