### PR TITLE
fix : resolved five data-correctness bugs across currency, budget, compliance, and health modules

### DIFF
--- a/src/lib/budgetUtils.ts
+++ b/src/lib/budgetUtils.ts
@@ -96,7 +96,7 @@ export async function fetchBudgetCategories(userId: string): Promise<BudgetCateg
         name: data.name || '',
         monthlyLimit: data.monthlyLimit || 0,
         rolloverEnabled: data.rolloverEnabled || false,
-        rolloverPercentage: data.rolloverPercentage || 100,
+        rolloverPercentage: data.rolloverPercentage ?? 100,
         rolledOverAmount: data.rolledOverAmount || 0,
         createdAt: data.createdAt || '',
         updatedAt: data.updatedAt || '',
@@ -378,7 +378,9 @@ async function fetchUserTransactionsInRange(
 export async function fetchLast3MonthsTransactions(userId: string): Promise<Transaction[]> {
   const now = new Date();
   const startDate = new Date(now.getFullYear(), now.getMonth() - 2, 1);
-  const endDate = new Date(now.getFullYear(), now.getMonth(), 1);
+  // Use end of current month so the 3-month window is complete months only.
+  // (startDate = 2 months ago on the 1st; endDate = end of this month)
+  const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0);
   return fetchUserTransactionsInRange(userId, startDate, endDate);
 }
 

--- a/src/lib/complianceUtils.ts
+++ b/src/lib/complianceUtils.ts
@@ -44,18 +44,29 @@ function isExpenseTransaction(t: AuditTransaction): boolean {
 
 /**
  * Scans financial transactions and documents for AML and SOX compliance issues.
+ * Transactions with unparseable amounts or dates are skipped; they do not
+ * contribute to the audit score and do not silently corrupt violation results.
  */
 export function auditFinancialData(
   transactions: AuditTransaction[],
 ): ComplianceScore {
   const violations: ComplianceViolation[] = [];
 
+  // Parse-validate every transaction upfront. Skip entries whose amount or date
+  // cannot be interpreted rather than silently including them with a fallback
+  // value that would corrupt the AML/SOX/FINRA rule checks.
+  const valid = transactions.filter((t) => {
+    if (typeof t.amount !== 'number' || !Number.isFinite(t.amount)) return false;
+    const d = t.date instanceof Date ? t.date : new Date(t.date as string);
+    return !isNaN(d.getTime());
+  });
+
   // Amounts are compared with Math.abs so the rules work for both signed
   // storage (negative expenses) and unsigned storage (positive amounts with a
   // `type` field), consistent with anomalyUtils/reportUtils.
 
   // AML Rule 1: Structuring / Smurfing detection (multiple transactions just under $10,000 threshold)
-  const structuringTxns = transactions.filter(
+  const structuringTxns = valid.filter(
     (t) => Math.abs(t.amount) >= 9000 && Math.abs(t.amount) < 10000,
   );
   if (structuringTxns.length >= 2) {
@@ -82,10 +93,10 @@ export function auditFinancialData(
 
   // AML Rule 2: High velocity round-trip transfers (high-value deposit and a
   // rapid withdrawal that actually fall inside the same short window)
-  const largeExpenses = transactions.filter(
+  const largeExpenses = valid.filter(
     (t) => Math.abs(t.amount) > 25000 && isExpenseTransaction(t),
   );
-  const largeIncomes = transactions.filter(
+  const largeIncomes = valid.filter(
     (t) => Math.abs(t.amount) > 25000 && !isExpenseTransaction(t),
   );
   const roundTripDetected =
@@ -111,7 +122,7 @@ export function auditFinancialData(
   }
 
   // SOX Rule 1: Off-balance sheet expenditure disclosure
-  const unclassifiedLarge = transactions.filter(
+  const unclassifiedLarge = valid.filter(
     (t) =>
       Math.abs(t.amount) > 50000 &&
       (!t.category || t.category.toLowerCase() === "other"),
@@ -134,7 +145,7 @@ export function auditFinancialData(
   // date-only row as after-hours (midnight hours < 9), while `Date` objects
   // stringified to an Invalid Date and never fired. Weekend detection works on
   // the date alone.
-  const suspiciousDates = transactions.filter((t) => {
+  const suspiciousDates = valid.filter((t) => {
     const d = auditDate(t.date);
     const day = d.getDay();
     if (day === 0 || day === 6) return true; // weekend

--- a/src/lib/currencyUtils.ts
+++ b/src/lib/currencyUtils.ts
@@ -196,19 +196,27 @@ export function aggregateMultiCurrencyTotals(
   return { totalBase, byCurrency };
 }
 
+const ZERO_DECIMAL_CURRENCIES = new Set(['JPY', 'KRW', 'VND', 'IDR', 'CLP', 'PYG', 'GNF', 'RWF', 'UGX', 'VUV', 'XAF', 'XOF', 'XPF']);
+
+/**
+ * Formats an amount for display in the given currency code.
+ * Zero-decimal currencies (JPY, KRW, VND, etc.) are displayed without
+ * fraction digits; all other currencies default to 2 fraction digits.
+ */
 export function formatCurrencyDisplay(amount: number, currencyCode: string): string {
   const currency = MAJOR_CURRENCIES.find((c) => c.code === currencyCode);
   const symbol = currency?.symbol || currencyCode;
+  const decimals = ZERO_DECIMAL_CURRENCIES.has(currencyCode) ? 0 : 2;
   try {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: currencyCode,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
     }).format(amount);
   } catch (err) {
     console.error("formatCurrency: failed to format currency", err);
-    return `${symbol}${amount.toFixed(2)}`;
+    return `${symbol}${amount.toFixed(decimals)}`;
   }
 }
 

--- a/src/lib/healthUtils.ts
+++ b/src/lib/healthUtils.ts
@@ -78,8 +78,9 @@ export function calculateSpendingScore(transactions: Transaction[]): number {
   const categoryCount = new Set(expenses.map((t) => t.category)).size;
 
   const avgTransactionSize = totalSpent / expenses.length;
+  const DISCRETIONARY = new Set(['entertainment', 'shopping', 'dining']);
   const discretionary = expenses
-    .filter((t) => ['Entertainment', 'Shopping', 'Dining'].includes(t.category))
+    .filter((t) => DISCRETIONARY.has((t.category || '').toLowerCase()))
     .reduce((sum, t) => sum + t.amount, 0);
   const discretionaryRatio = totalSpent > 0 ? discretionary / totalSpent : 0;
 


### PR DESCRIPTION
## Summary of What Has Been Done
Resolved five distinct data-correctness bugs across four utility modules:

### Issue #1182: fix : add support for zero-decimal currencies in formatCurrencyDisplay
## Summary of What Has Been Done

Added a `ZERO_DECIMAL_CURRENCIES` set containing currencies that should not display fraction digits (JPY, KRW, VND, IDR, CLP, PYG, GNF, RWF, UGX, VUV, XAF, XOF, XPF, etc.). The `formatCurrencyDisplay` function now reads the currency code and adjusts `minimumFractionDigits` / `maximumFractionDigits` to `0` for zero-decimal currencies and `2` for all others.

## Changes Made

- `src/lib/currencyUtils.ts`: Added `ZERO_DECIMAL_CURRENCIES` constant; updated `formatCurrencyDisplay` to branch on the currency code.

## Impact it Made

JPY, KRW, VND and other zero-decimal currencies now display without spurious trailing `.00`, matching ISO 4217 display conventions.

Closes #1182

**Note: Please assign this PR to the `tmdeveloper007` account.**


### Issue #1181: fix : preserve explicit 0 rolloverPercentage instead of falling back to 100
## Summary of What Has Been Done

Changed `data.rolloverPercentage || 100` to `data.rolloverPercentage ?? 100` in the `fetchBudgetCategories` function inside `src/lib/budgetUtils.ts`. The nullish coalescing operator (`??`) only falls back to `100` when the value is `null` or `undefined`; an explicit `0` is now correctly preserved.

## Changes Made

- `src/lib/budgetUtils.ts`: `fetchBudgetCategories` — replaced `||` with `??` for `rolloverPercentage`.

## Impact it Made

Users who explicitly set rollover percentage to 0 will have that choice persisted and restored correctly, instead of being silently overridden to 100 on every category re-fetch.

Closes #1181

**Note: Please assign this PR to the `tmdeveloper007` account.**


### Issue #1180: fix : validate transactions before compliance audit to avoid silent corruption
## Summary of What Has Been Done

Added a pre-filter step at the top of `auditFinancialData` in `src/lib/complianceUtils.ts` that removes transactions whose `amount` is not a finite number or whose `date` cannot be parsed to a valid `Date`. All subsequent AML/SOX/FINRA rule checks now operate on this validated `valid` array. The function JSDoc was updated to document the skip behaviour.

## Changes Made

- `src/lib/complianceUtils.ts`: Added `valid` pre-filter; replaced all `transactions` references in audit rules with `valid`.

## Impact it Made

Compliance audit scores are no longer corrupted by transactions with unparseable amounts or dates. Invalid records are preserved in the system but correctly excluded from the compliance scan, preventing false positives or false negatives in AML structuring detection, SOX unclassified expenditure checks, and FINRA business-hours flagging.

Closes #1180

**Note: Please assign this PR to the `tmdeveloper007` account.**


### Issue #1179: fix : correct fetchLast3MonthsTransactions date range to include complete months
## Summary of What Has Been Done

Changed `endDate` in `fetchLast3MonthsTransactions` (`src/lib/budgetUtils.ts`) from `new Date(now.getFullYear(), now.getMonth(), 1)` (first of current month) to `new Date(now.getFullYear(), now.getMonth() + 1, 0)` (last day of current month). Updated the function JSDoc comment to clarify that the window spans complete months from 2 months ago through the end of the current month.

## Changes Made

- `src/lib/budgetUtils.ts`: `fetchLast3MonthsTransactions` — `endDate` now resolves to the last calendar day of the current month.

## Impact it Made

The function now returns a genuine 3-month window of transaction data. Budget suggestion generation ("Based on your last 3 months of spending patterns") receives the expected 3 months of data, improving the accuracy of average-spending calculations and confidence scoring.

Closes #1179

**Note: Please assign this PR to the `tmdeveloper007` account.**


### Issue #1177: fix : make calculateSpendingScore category check case-insensitive
## Summary of What Has Been Done

Replaced the case-sensitive string array check `['Entertainment', 'Shopping', 'Dining'].includes(t.category)` in `calculateSpendingScore` (`src/lib/healthUtils.ts`) with a lowercase `Set(['entertainment', 'shopping', 'dining'])` and normalised `t.category` via `.toLowerCase()` before the Set lookup.

## Changes Made

- `src/lib/healthUtils.ts`: `calculateSpendingScore` — introduced `DISCRETIONARY` Set; category names are lowercased before membership test.

## Impact it Made

The discretionary spending score is now consistent regardless of category name capitalisation in the database. Users with lowercase category entries ('entertainment', 'shopping', 'dining') will now correctly be flagged for discretionary spending, resulting in more accurate health scores and actionable improvement suggestions.

Closes #1177

**Note: Please assign this PR to the `tmdeveloper007` account.**

