### PR TITLE
Portfolio: duplicate holding creation race on concurrent first-buys

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -299,7 +299,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
       if (!holdingsSnap.empty) {
         holdingRef = holdingsSnap.docs[0].ref;
       } else if (input.type === 'buy') {
-        holdingRef = doc(holdings);
+        holdingRef = doc(db, 'portfolioHoldings', `${userId}_${symbol.toUpperCase()}`);
       } else {
         throw new Error(`Cannot sell ${input.quantity} shares: no holding exists for ${symbol}`);
       }


### PR DESCRIPTION
﻿## Problem
In ddTransaction() the holding document id for a brand-new symbol was generated with doc(holdings) (a random id) **outside** the Firestore transaction. Two concurrent first-buys for the same symbol each resolved "no existing holding" and minted their own random id, so the transaction never detected the conflict and two separate holdings for the same symbol were created.

## Fix
Changed the new-holding reference to a deterministic id derived from userId and symbol:
doc(db, 'portfolioHoldings', ${userId}_).

Now concurrent first-buys for the same (userId, symbol) target the same document. The first transaction 	x.sets the holding; the second transaction's 	x.get(holdingRef) reads the just-created doc (re-read at commit) and falls into the existing-holding branch (update instead of create), eliminating the duplicate. The existing (userId, symbol) composite index backs the lookup.

## Files changed
- src/lib/portfolioUtils.ts — deterministic holding id for new buys (line ~302)

## Testing
No build env available (no node_modules). Verified logic by reading the transaction flow: with a stable key, 	x.get inside unTransaction now detects a concurrently-created holding and updates it. Manual verification would submit two concurrent first-buys for one symbol and assert exactly one portfolioHoldings document exists.

Closes #1168
