### PR TITLE
Tax estimator brackets gross income directly with no standard/itemized deduction (systematic overstatement)

### DIFF
--- a/src/components/tax/TaxEstimation.tsx
+++ b/src/components/tax/TaxEstimation.tsx
@@ -31,6 +31,7 @@ import {
   generateTaxSummary,
   formatCurrency,
   formatPercent,
+  type FilingStatus,
   type TaxBreakdown,
   type TaxEstimateRecord,
 } from '@/src/lib/taxUtils';
@@ -64,6 +65,8 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
   const [breakdown, setBreakdown] = useState<TaxBreakdown | null>(null);
   const [previousYear, setPreviousYear] = useState<TaxEstimateRecord | null>(null);
   const [loadingHistory, setLoadingHistory] = useState(false);
+  const [filingStatus, setFilingStatus] = useState<FilingStatus>('single');
+  const [deductionsInput, setDeductionsInput] = useState('');
 
   const country = useMemo(
     () => COUNTRY_TAX_DATA.find((c) => c.code === countryCode),
@@ -126,12 +129,16 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
 
   useEffect(() => {
     if (annualIncome > 0) {
-      const result = calculateTax(annualIncome, countryCode, regionCode);
+      const deductionsValue = parseFloat(deductionsInput);
+      const result = calculateTax(annualIncome, countryCode, regionCode, {
+        filingStatus: countryCode === 'US' ? filingStatus : undefined,
+        deductions: !isNaN(deductionsValue) && deductionsValue > 0 ? deductionsValue : undefined,
+      });
       setBreakdown(result);
     } else {
       setBreakdown(null);
     }
-  }, [annualIncome, countryCode, regionCode]);
+  }, [annualIncome, countryCode, regionCode, filingStatus, deductionsInput]);
 
   const handleSave = async () => {
     if (!user || !breakdown) {
@@ -284,9 +291,49 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
               />
             </div>
 
+            {countryCode === 'US' && (
+              <>
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500">
+                    Filing Status
+                  </label>
+                  <Select
+                    value={filingStatus}
+                    onValueChange={(v) => setFilingStatus(v as FilingStatus)}
+                    className="bg-slate-800 border-slate-700 text-white h-12"
+                    options={[
+                      { value: 'single', label: 'Single' },
+                      { value: 'married_joint', label: 'Married Filing Jointly' },
+                      { value: 'married_separate', label: 'Married Filing Separately' },
+                      { value: 'head_of_household', label: 'Head of Household' },
+                    ]}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500">
+                    Itemized Deductions (optional)
+                  </label>
+                  <Input
+                    type="number"
+                    placeholder="0"
+                    value={deductionsInput}
+                    onChange={(e) => setDeductionsInput(e.target.value)}
+                    className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500 h-12 tabular-nums"
+                    min="0"
+                    step="100"
+                  />
+                  <p className="text-xs text-slate-500">
+                    The 2024 standard deduction for this status is applied unless you enter a
+                    smaller itemized amount.
+                  </p>
+                </div>
+              </>
+            )}
+
             <div className="space-y-2">
               <label className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500">
-                Income
+                Gross Income
               </label>
               <div className="flex gap-2">
                 <Input

--- a/src/lib/taxUtils.ts
+++ b/src/lib/taxUtils.ts
@@ -347,21 +347,65 @@ function applyBrackets(income: number, brackets: TaxBracket[] | undefined): numb
   return tax;
 }
 
+export type FilingStatus = 'single' | 'married_joint' | 'married_separate' | 'head_of_household';
+
+// 2024 US federal standard deduction amounts. The US bracket tables below are
+// post-standard-deduction, so gross income must be reduced by a deduction
+// before bracketing or every estimate is systematically overstated.
+const STANDARD_DEDUCTIONS_2024: Record<FilingStatus, number> = {
+  single: 14600,
+  married_joint: 29200,
+  married_separate: 14600,
+  head_of_household: 21900,
+};
+
+export function standardDeduction(filingStatus?: FilingStatus): number {
+  if (!filingStatus) return 0;
+  return STANDARD_DEDUCTIONS_2024[filingStatus] ?? 0;
+}
+
+function roundToCents(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export interface CalculateTaxOptions {
+  // Filing status used to derive the standard deduction (US only).
+  filingStatus?: FilingStatus;
+  // Itemized deductions; when provided, the smaller of the standard deduction
+  // and the itemized amount is subtracted from gross income before bracketing.
+  deductions?: number;
+}
+
+// `income` is the user's GROSS annual income. For US jurisdictions a standard
+// (or itemized) deduction is subtracted before the bracket tables are applied.
 export function calculateTax(
   income: number,
   countryCode: string,
-  regionCode: string
+  regionCode: string,
+  options?: CalculateTaxOptions
 ): TaxBreakdown | null {
   const country = COUNTRY_TAX_DATA.find((c) => c.code === countryCode);
   if (!country) return null;
   const region = country.regions.find((r) => r.code === regionCode);
   if (!region) return null;
 
+  // The US bracket tables are post-standard-deduction, so gross income must be
+  // reduced by a deduction before bracketing; otherwise every estimate is
+  // systematically overstated. Other jurisdictions bake their allowance into
+  // the 0% bands and are left untouched.
+  let deduction = 0;
+  if (countryCode === 'US') {
+    const standard = standardDeduction(options?.filingStatus);
+    const itemized = options?.deductions ?? Infinity;
+    deduction = Math.min(standard, itemized);
+  }
   const annualIncome = income > 0 ? income : 0;
-  const federalTax = applyBrackets(annualIncome, region.federalBrackets);
-  const stateTax = applyBrackets(annualIncome, region.stateBrackets);
-  const localTax = region.localRate ? annualIncome * region.localRate : 0;
-  const totalTax = federalTax + stateTax + localTax;
+  const taxableIncome = Math.max(0, annualIncome - deduction);
+
+  const federalTax = roundToCents(applyBrackets(taxableIncome, region.federalBrackets));
+  const stateTax = roundToCents(applyBrackets(taxableIncome, region.stateBrackets));
+  const localTax = roundToCents(region.localRate ? taxableIncome * region.localRate : 0);
+  const totalTax = roundToCents(federalTax + stateTax + localTax);
   const effectiveRate = annualIncome > 0 ? totalTax / annualIncome : 0;
 
   return {


### PR DESCRIPTION
﻿## Problem
calculateTax() in src/lib/taxUtils.ts applied the US bracket tables directly to the gross income the user typed. Those brackets are post-standard-deduction, so every estimate was systematically overstated (e.g. phantom 10% tax on the first ,600 for a single filer). Results were also not rounded to cents.

## Fix
- Added FilingStatus type, STANDARD_DEDUCTIONS_2024 (single ,600 / MFJ ,200 / MFS ,600 / HoH ,900), and a standardDeduction() helper.
- calculateTax now accepts optional ilingStatus and deductions (itemized). For US jurisdictions it subtracts min(standardDeduction(filingStatus), itemized) from gross income before pplyBrackets; non-US jurisdictions keep their 0% allowance bands untouched.
- All tax components (ederalTax, stateTax, localTax, 	otalTax) are rounded to cents.
- UI (TaxEstimation.tsx): for US, added a Filing Status select and an optional Itemized Deductions input, passed into calculateTax. Income label clarified as Gross Income.

## Files changed
- src/lib/taxUtils.ts — deduction logic, rounding, types/helpers, documentation of gross vs taxable income.
- src/components/tax/TaxEstimation.tsx — US filing-status + itemized-deduction inputs wired to calculateTax.

## Testing
No build environment available (no node_modules). Verified by reading: with ilingStatus='single' and gross income of ,000, taxable income becomes ,400 before bracketing (previously ,000), removing the overstatement. Rounding uses Math.round(x*100)/100 for cent accuracy.

Closes #1171
