### PR TITLE
Goal planner month-count mismatch: contribution uses 30-day months, projection uses calendar months

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -1,4 +1,4 @@
-import { format, differenceInDays, addMonths } from 'date-fns';
+import { format, differenceInDays, differenceInCalendarMonths, addMonths } from 'date-fns';
 import { getDefaultCurrency } from '@/src/lib/utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, react-hooks/immutability, react-hooks/purity, react-hooks/refs, react-hooks/set-state-in-effect */
@@ -27,7 +27,7 @@ export function calculateMonthlyContribution(
 
   const deadlineDate = new Date(deadline);
   const now = new Date();
-  const monthsRemaining = Math.max(1, differenceInDays(deadlineDate, now) / 30);
+  const monthsRemaining = Math.max(1, differenceInCalendarMonths(deadlineDate, now));
 
   return Math.ceil(remaining / monthsRemaining);
 }
@@ -55,7 +55,7 @@ export function generateContributionSuggestions(
 
   const deadlineDate = new Date(deadline);
   const now = new Date();
-  const monthsRemaining = Math.max(1, differenceInDays(deadlineDate, now) / 30);
+  const monthsRemaining = Math.max(1, differenceInCalendarMonths(deadlineDate, now));
   const baseMonthly = Math.ceil(remaining / monthsRemaining);
 
   const suggestions = [


### PR DESCRIPTION
﻿## Problem
calculateMonthlyContribution and generateContributionSuggestions in src/lib/goalUtils.ts computed the months remaining as differenceInDays(deadline, now) / 30 (fixed 30-day months), while generateTimelineProjection replays contributions through real calendar months via ddMonths. The two definitions diverge, so the recommended monthly contribution does not actually reach the target by the deadline (it is too small over 31-day months / February, making the plan silently infeasible).

## Fix
Replaced differenceInDays(deadlineDate, now) / 30 with Math.max(1, differenceInCalendarMonths(deadlineDate, now)) in both calculateMonthlyContribution (line 30) and generateContributionSuggestions (line 58), and imported differenceInCalendarMonths from date-fns. Both the required-contribution math and the calendar-month projection now use the same month model, so a contribution derived from calculateMonthlyContribution lands on the deadline when fed back into generateTimelineProjection.

## Files changed
- src/lib/goalUtils.ts — calendar-month count for contribution sizing (import + 2 call sites).

## Testing
No build environment available (no node_modules). Verified by reading: differenceInCalendarMonths and ddMonths share the same calendar-month semantics, so the contribution sized with the new count, summed across that many ddMonths steps, reaches 	argetAmount at/before the deadline. A test asserting generateTimelineProjection(target, current, calculateMonthlyContribution(...)) reaches 	arget no later than deadline is recommended (per issue).

Closes #1172
