### PR TITLE
Budget suggestions use fetchLast3MonthsTransactions but only 2 months are returned (off-by-one)

### DIFF
--- a/src/lib/budgetUtils.ts
+++ b/src/lib/budgetUtils.ts
@@ -377,7 +377,7 @@ async function fetchUserTransactionsInRange(
 
 export async function fetchLast3MonthsTransactions(userId: string): Promise<Transaction[]> {
   const now = new Date();
-  const startDate = new Date(now.getFullYear(), now.getMonth() - 2, 1);
+  const startDate = new Date(now.getFullYear(), now.getMonth() - 3, 1);
   const endDate = new Date(now.getFullYear(), now.getMonth(), 1);
   return fetchUserTransactionsInRange(userId, startDate, endDate);
 }


### PR DESCRIPTION
﻿## Problem
etchLast3MonthsTransactions in src/lib/budgetUtils.ts (lines 378-383) used a start offset of -2 with an exclusive endDate (the first day of the current month). Because etchUserTransactionsInRange treats endDate as exclusive (line 359: dateVal.getTime() >= endDate.getTime()), the window [M-2-01, M-01) only covered months **M-2 and M-1 = 2 complete months**, not 3. Every consumer (generateBudgetSuggestions averages, confidence, and totals) was built on one fewer month than the name/UI imply.

## Fix
Changed the start offset from -2 to -3 so the window becomes [M-3-01, M-01), returning the 3 most recent complete months (M-3, M-2, M-1) with the current partial month excluded.

## Files changed
- src/lib/budgetUtils.ts — etchLast3MonthsTransactions: 
ow.getMonth() - 3 instead of - 2.

## Testing
No build environment available. Verified by reasoning: with endDate exclusive at the first of month M, start M-3 includes exactly months M-3, M-2 and M-1; a transaction in the current partial month (date >= endDate) is correctly excluded.

Closes #1179
