### PR TITLE
Subscription: detect bi-weekly/quarterly/semi-annual cadences

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -35,12 +35,20 @@ export interface Transaction {
   type: "income" | "expense";
 }
 
+export type SubscriptionFrequency =
+  | "weekly"
+  | "bi-weekly"
+  | "monthly"
+  | "quarterly"
+  | "semi-annual"
+  | "yearly";
+
 export interface Subscription {
   id: string;
   userId: string;
   name: string;
   amount: number;
-  frequency: "monthly" | "yearly" | "weekly";
+  frequency: SubscriptionFrequency;
   category: string;
   nextRenewalDate: Date;
   isActive: boolean;
@@ -240,7 +248,7 @@ export function groupTransactionsIntoSubscriptions(
 export function analyzeSubscriptionPattern(
   transactions: Transaction[],
 ): {
-  frequency: "monthly" | "yearly" | "weekly";
+  frequency: SubscriptionFrequency;
   confidence: number;
   /** Observed average interval between charges, in days. Cost annualization is
    * derived from this so it reflects the actual cadence (e.g. bi-weekly at
@@ -265,26 +273,40 @@ export function analyzeSubscriptionPattern(
   const stdDev = Math.sqrt(variance);
   const consistency = stdDev < avgInterval * 0.3 ? 1 : 0.5;
 
-  if (avgInterval >= 25 && avgInterval <= 35) {
+  if (avgInterval >= 5 && avgInterval <= 10) {
+    return { frequency: "weekly", confidence: consistency, avgIntervalDays: avgInterval };
+  } else if (avgInterval > 10 && avgInterval <= 18) {
+    return { frequency: "bi-weekly", confidence: consistency, avgIntervalDays: avgInterval };
+  } else if (avgInterval >= 25 && avgInterval <= 35) {
     return { frequency: "monthly", confidence: consistency, avgIntervalDays: avgInterval };
+  } else if (avgInterval >= 80 && avgInterval <= 100) {
+    return { frequency: "quarterly", confidence: consistency, avgIntervalDays: avgInterval };
+  } else if (avgInterval >= 170 && avgInterval <= 190) {
+    return { frequency: "semi-annual", confidence: consistency, avgIntervalDays: avgInterval };
   } else if (avgInterval >= 350 && avgInterval <= 380) {
     return { frequency: "yearly", confidence: consistency, avgIntervalDays: avgInterval };
-  } else if (avgInterval >= 5 && avgInterval <= 10) {
-    return { frequency: "weekly", confidence: consistency, avgIntervalDays: avgInterval };
   }
 
   return { frequency: "monthly", confidence: 0.3, avgIntervalDays: avgInterval };
 }
 
-/** Default annualization factor (charges per year) per declared frequency. */
+/** Default annualization factor (charges per year) per declared frequency.
+ * Only used as a fallback when a subscription has no stored annualizationFactor;
+ * detected subscriptions always store the observed-interval factor instead. */
 function defaultAnnualizationFactor(
-  frequency: Subscription["frequency"],
+  frequency: SubscriptionFrequency,
 ): number {
   switch (frequency) {
     case "weekly":
       return 52;
+    case "bi-weekly":
+      return 26;
     case "monthly":
       return 12;
+    case "quarterly":
+      return 4;
+    case "semi-annual":
+      return 2;
     case "yearly":
       return 1;
   }
@@ -306,14 +328,30 @@ export function getAnnualizationFactor(sub: Subscription): number {
 
 function advanceByFrequency(
   date: Date,
-  frequency: "monthly" | "yearly" | "weekly",
+  frequency: SubscriptionFrequency,
   originalDay?: number,
 ): Date {
   switch (frequency) {
     case "weekly":
       return addWeeks(date, 1);
+    case "bi-weekly":
+      return addWeeks(date, 2);
     case "yearly":
       return addYears(date, 1);
+    case "quarterly": {
+      const day = originalDay ?? date.getDate();
+      const next = addMonths(date, 3);
+      const lastDayOfNextMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
+      next.setDate(Math.min(day, lastDayOfNextMonth));
+      return next;
+    }
+    case "semi-annual": {
+      const day = originalDay ?? date.getDate();
+      const next = addMonths(date, 6);
+      const lastDayOfNextMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
+      next.setDate(Math.min(day, lastDayOfNextMonth));
+      return next;
+    }
     case "monthly":
     default: {
       const day = originalDay ?? date.getDate();
@@ -327,7 +365,7 @@ function advanceByFrequency(
 
 export function predictNextRenewalDate(
   transactions: Transaction[],
-  frequency: "monthly" | "yearly" | "weekly",
+  frequency: SubscriptionFrequency,
 ): Date {
   const sorted = [...transactions].sort(
     (a, b) => b.date.getTime() - a.date.getTime(),


### PR DESCRIPTION
﻿## Problem
nalyzeSubscriptionPattern() only classified intervals into weekly (5-10d), monthly (25-35d), and yearly (350-380d). Any other interval — most importantly **bi-weekly (~14d)** and **quarterly (~90d)** — fell through to the default eturn { frequency: "monthly", confidence: 0.3, ... }. Because detectAndSaveSubscriptions skips anything with confidence < 0.4, bi-weekly/quarterly subscriptions were never even created, and if they were they'd be mislabeled monthly and annualized with a hardcoded ×12.

## Fix
- Extended the requency type (SubscriptionFrequency) to include i-weekly, quarterly, and semi-annual.
- Added explicit detection branches in nalyzeSubscriptionPattern: bi-weekly 11-18d, quarterly 80-100d, semi-annual 170-190d, each returning the real requency with the proper consistency-based confidence (≥0.5, so it clears the 0.4 detection threshold). vgIntervalDays is still returned for callers.
- detectAndSaveSubscriptions already stores nnualizationFactor = 365.25 / avgIntervalDays (lines ~553/565), so the correct factor is now persisted for these cadences instead of the ×12 default.
- Updated defaultAnnualizationFactor (bi-weekly 26, quarterly 4, semi-annual 2) and dvanceByFrequency/predictNextRenewalDate to handle the new frequencies for renewal prediction.

Costs flow through calculateSubscriptionCosts/calculateCategoryGroups via getAnnualizationFactor, which prefers the stored factor — so a bi-weekly  charge is now annualized as ~26/yr = , not , and a quarterly  as 4/yr = , not ,200.

## Files changed
- src/lib/subscriptionUtils.ts — SubscriptionFrequency union, cadence branches, annualization + renewal handling

## Testing
No build env available (no node_modules). Verified by reading the detection/threshold/annualization flow and confirming defaultAnnualizationFactor's switch now returns for every union member (no missing-return) and all requency params accept the wider union. Manual check: feed transactions 14 days apart → frequency i-weekly, factor ≈26; 90 days apart → quarterly, factor ≈4.

Closes #1170
