### PR TITLE
fix(sensitivity): distinct low/high swing for interest-rate scenarios (#1136)

### DIFF
--- a/src/lib/sensitivityUtils.ts
+++ b/src/lib/sensitivityUtils.ts
@@ -49,7 +49,7 @@ export function calculateSensitivityDrivers(
       baselineValue: interestRate,
       unit: "%",
       lowSwingImpact: Math.round(
-        (revenue - cogs - opex - revenue * ((interestRate * 0.8) / 100)) - baseNetProfit
+        (revenue - cogs - opex - revenue * ((interestRate * 1.0) / 100)) - baseNetProfit
       ),
       highSwingImpact: Math.round(
         (revenue - cogs - opex - revenue * ((interestRate * 0.8) / 100)) - baseNetProfit
@@ -64,7 +64,7 @@ export function calculateSensitivityDrivers(
         (revenue - cogs - opex - revenue * ((interestRate * 1.2) / 100)) - baseNetProfit
       ),
       highSwingImpact: Math.round(
-        (revenue - cogs - opex - revenue * ((interestRate * 1.2) / 100)) - baseNetProfit
+        (revenue - cogs - opex - revenue * ((interestRate * 1.0) / 100)) - baseNetProfit
       ),
     },
     {

--- a/tests/sensitivity-asymmetric.test.mjs
+++ b/tests/sensitivity-asymmetric.test.mjs
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { calculateSensitivityDrivers } =
+  await import("../src/lib/sensitivityUtils.ts");
+
+// interestRateDown / interestRateUp previously computed identical
+// lowSwingImpact and highSwingImpact (both used the same multiplier), so the
+// sensitivity table showed no directional spread for interest-rate moves.
+
+function find(rows, key) {
+  const row = rows.find((r) => r.key === key);
+  assert.ok(row, `expected a row with key "${key}"`);
+  return row;
+}
+
+test("interestRateDown has distinct low and high swing impacts (#1136)", () => {
+  const rows = calculateSensitivityDrivers(1_000_000, 600_000, 200_000, 5);
+  const down = find(rows, "interestRateDown");
+  assert.notEqual(
+    down.lowSwingImpact,
+    down.highSwingImpact,
+    "interestRateDown low and high must differ (previously duplicates)",
+  );
+});
+
+test("interestRateUp has distinct low and high swing impacts (#1136)", () => {
+  const rows = calculateSensitivityDrivers(1_000_000, 600_000, 200_000, 5);
+  const up = find(rows, "interestRateUp");
+  assert.notEqual(
+    up.lowSwingImpact,
+    up.highSwingImpact,
+    "interestRateUp low and high must differ (previously duplicates)",
+  );
+});
+
+test("interestRateDown high swing reflects the -20% rate cut", () => {
+  const rows = calculateSensitivityDrivers(1_000_000, 600_000, 200_000, 5);
+  const down = find(rows, "interestRateDown");
+  // Lower interest rate => higher net profit => positive swing.
+  // low (baseline rate 1.0x) = 0 impact; high (0.8x rate) = positive.
+  assert.equal(down.lowSwingImpact, 0);
+  assert.ok(down.highSwingImpact > 0, "expected positive swing for lower rate");
+});
+
+test("interestRateUp low swing reflects the +20% rate rise", () => {
+  const rows = calculateSensitivityDrivers(1_000_000, 600_000, 200_000, 5);
+  const up = find(rows, "interestRateUp");
+  // Higher interest rate => lower net profit => negative swing.
+  // low (1.2x rate) = negative; high (baseline 1.0x) = 0.
+  assert.ok(up.lowSwingImpact < 0, "expected negative swing for higher rate");
+  assert.equal(up.highSwingImpact, 0);
+});
+
+test("baseline driver rows keep distinct low/high (revenue/cogs/opex)", () => {
+  const rows = calculateSensitivityDrivers(1_000_000, 600_000, 200_000, 5);
+  for (const key of ["revenue", "cogs", "opex"]) {
+    const row = find(rows, key);
+    assert.notEqual(row.lowSwingImpact, row.highSwingImpact, `${key} low/high must differ`);
+  }
+});
+
+test("interestRateDown and interestRateUp swing in opposite directions", () => {
+  const rows = calculateSensitivityDrivers(1_000_000, 600_000, 200_000, 5);
+  const down = find(rows, "interestRateDown");
+  const up = find(rows, "interestRateUp");
+  // The -20% row's high swing should be positive (rate falls), while the +20%
+  // row's low swing should be negative (rate rises).
+  assert.ok(down.highSwingImpact > 0);
+  assert.ok(up.lowSwingImpact < 0);
+});


### PR DESCRIPTION
## Description

In `src/lib/sensitivityUtils.ts`, the `interestRateDown` and `interestRateUp` sensitivity rows computed **identical** `lowSwingImpact` and `highSwingImpact` values because both branches used the same interest-rate multiplier. `interestRateDown` used `interestRate * 0.8` for *both* its low and high swing, and `interestRateUp` used `interestRate * 1.2` for *both*. As a result the low and high columns were exact duplicates, so the sensitivity analyzer showed **no directional spread** for interest-rate moves — defeating the entire purpose of a two-sided sensitivity table.

## Fix

Gave each interest-rate row a distinct low/high direction, exactly as proposed in the issue, so each row spans from the baseline rate (1.0× multiplier, zero impact) out to the swing (0.8× for a rate cut, 1.2× for a rate rise):

- **`interestRateDown`**: `lowSwingImpact` = baseline rate (1.0× → 0 impact), `highSwingImpact` = −20% rate cut (0.8× → positive profit swing). Lower interest ⇒ higher net profit ⇒ positive swing.
- **`interestRateUp`**: `lowSwingImpact` = +20% rate rise (1.2× → negative profit swing), `highSwingImpact` = baseline rate (1.0× → 0 impact). Higher interest ⇒ lower net profit ⇒ negative swing.

The change is two lines — the `lowSwingImpact` multiplier of `interestRateDown` (0.8 → 1.0) and the `highSwingImpact` multiplier of `interestRateUp` (1.2 → 1.0). The opposite-direction swing lines remain at 0.8× / 1.2× respectively, so each row now has a real low-to-high range anchored at the baseline. The `revenue`, `cogs`, and `opex` rows were already correct (distinct multipliers) and are untouched.

## Verification

Added `tests/sensitivity-asymmetric.test.mjs` (6 tests, all passing), following the repo's `node:test` + `.mjs` pattern (imports `sensitivityUtils.ts` directly, run via `node --experimental-strip-types --test`):

1. `interestRateDown` low ≠ high (the core regression — previously equal),
2. `interestRateUp` low ≠ high (the core regression),
3. `interestRateDown` high swing reflects the −20% rate cut (positive, baseline low = 0),
4. `interestRateUp` low swing reflects the +20% rate rise (negative, baseline high = 0),
5. baseline rows (`revenue`/`cogs`/`opex`) still have distinct low/high,
6. the two rate rows swing in opposite directions (down positive, up negative).

```
# tests 6
# pass 6
# fail 0
```

No regression: `npx tsc --noEmit` introduces **no new type errors** in `sensitivityUtils.ts` (pre-existing unrelated errors in other files remain unchanged).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

Closes #1136
