### PR TITLE
Compliance audit silently drops any transaction whose amount/date fails to parse (NaN excluded from all AML/SOX/FINRA rules)

### DIFF
--- a/src/lib/complianceUtils.ts
+++ b/src/lib/complianceUtils.ts
@@ -27,19 +27,27 @@ export interface AuditTransaction {
 const STRUCTURING_WINDOW_DAYS = 7;
 const ROUND_TRIP_WINDOW_DAYS = 7;
 
-function auditDate(value: string | Date): Date {
+function parseAuditDate(value: string | Date): Date | null {
   const d = value instanceof Date ? value : new Date(value);
-  return isNaN(d.getTime()) ? new Date() : d;
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function normalizeAmount(value: unknown): number {
+  if (typeof value === "number") return value;
+  return Number(String(value ?? "").replace(/[^0-9.\-]/g, ""));
 }
 
 function daysBetween(a: Date, b: Date): number {
   return Math.abs(a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24);
 }
 
-function isExpenseTransaction(t: AuditTransaction): boolean {
-  if (t.type === "expense") return true;
-  if (t.type === "income") return false;
-  return t.amount < 0;
+function isExpenseTransaction(
+  amount: number,
+  type?: "income" | "expense",
+): boolean {
+  if (type === "expense") return true;
+  if (type === "income") return false;
+  return amount < 0;
 }
 
 /**
@@ -50,21 +58,59 @@ export function auditFinancialData(
 ): ComplianceScore {
   const violations: ComplianceViolation[] = [];
 
-  // Amounts are compared with Math.abs so the rules work for both signed
+  // Parse and validate every transaction up front. Malformed amounts/dates must
+  // be surfaced as data-quality violations, never silently skipped or coerced
+  // to "today".
+  const parsed = transactions.map((t) => {
+    const amt = normalizeAmount(t.amount);
+    const date = parseAuditDate(t.date);
+    return { t, amt, date };
+  });
+
+  // Data-quality pass: report transactions that cannot be safely evaluated.
+  for (const { t, amt, date } of parsed) {
+    if (Number.isNaN(amt)) {
+      violations.push({
+        id: "dq-non-numeric-amount",
+        category: "SOX",
+        severity: "medium",
+        title: "Non-numeric transaction amount",
+        description: `Transaction "${t.description}" has a non-numeric amount (${String(t.amount)}) and was excluded from compliance rules.`,
+        transactionReference: t.description,
+        recommendedAction: "Correct the transaction amount in the source document.",
+      });
+    } else if (date === null) {
+      violations.push({
+        id: "dq-invalid-date",
+        category: "SOX",
+        severity: "medium",
+        title: "Missing or invalid transaction date",
+        description: `Transaction "${t.description}" has an unparseable date (${String(t.date)}) and was excluded from date-dependent rules.`,
+        transactionReference: t.description,
+        recommendedAction: "Correct the transaction date in the source document.",
+      });
+    }
+  }
+
+  // Only transactions with a numeric amount participate in the value-based
+  // rules. Amounts are compared with Math.abs so the rules work for both signed
   // storage (negative expenses) and unsigned storage (positive amounts with a
   // `type` field), consistent with anomalyUtils/reportUtils.
+  const valid = parsed.filter((p) => !Number.isNaN(p.amt));
+  // Date-dependent rules additionally require a parseable date.
+  const dated = valid.filter(
+    (p): p is typeof p & { date: Date } => p.date !== null,
+  );
 
   // AML Rule 1: Structuring / Smurfing detection (multiple transactions just under $10,000 threshold)
-  const structuringTxns = transactions.filter(
-    (t) => Math.abs(t.amount) >= 9000 && Math.abs(t.amount) < 10000,
+  const structuringTxns = dated.filter(
+    (p) => Math.abs(p.amt) >= 9000 && Math.abs(p.amt) < 10000,
   );
   if (structuringTxns.length >= 2) {
     // Only flag when the transactions actually occur in close succession.
-    const inCloseSuccession = structuringTxns.some((t, i) =>
+    const inCloseSuccession = structuringTxns.some((p, i) =>
       structuringTxns.slice(i + 1).some(
-        (other) =>
-          daysBetween(auditDate(t.date), auditDate(other.date)) <=
-          STRUCTURING_WINDOW_DAYS,
+        (other) => daysBetween(p.date, other.date) <= STRUCTURING_WINDOW_DAYS,
       ),
     );
     if (inCloseSuccession) {
@@ -82,20 +128,18 @@ export function auditFinancialData(
 
   // AML Rule 2: High velocity round-trip transfers (high-value deposit and a
   // rapid withdrawal that actually fall inside the same short window)
-  const largeExpenses = transactions.filter(
-    (t) => Math.abs(t.amount) > 25000 && isExpenseTransaction(t),
+  const largeExpenses = dated.filter(
+    (p) => Math.abs(p.amt) > 25000 && isExpenseTransaction(p.amt, p.t.type),
   );
-  const largeIncomes = transactions.filter(
-    (t) => Math.abs(t.amount) > 25000 && !isExpenseTransaction(t),
+  const largeIncomes = dated.filter(
+    (p) => Math.abs(p.amt) > 25000 && !isExpenseTransaction(p.amt, p.t.type),
   );
   const roundTripDetected =
     largeIncomes.length > 0 &&
     largeExpenses.length > 0 &&
     largeIncomes.some((inc) =>
       largeExpenses.some(
-        (exp) =>
-          daysBetween(auditDate(inc.date), auditDate(exp.date)) <=
-          ROUND_TRIP_WINDOW_DAYS,
+        (exp) => daysBetween(inc.date, exp.date) <= ROUND_TRIP_WINDOW_DAYS,
       ),
     );
   if (roundTripDetected) {
@@ -111,10 +155,10 @@ export function auditFinancialData(
   }
 
   // SOX Rule 1: Off-balance sheet expenditure disclosure
-  const unclassifiedLarge = transactions.filter(
-    (t) =>
-      Math.abs(t.amount) > 50000 &&
-      (!t.category || t.category.toLowerCase() === "other"),
+  const unclassifiedLarge = valid.filter(
+    (p) =>
+      Math.abs(p.amt) > 50000 &&
+      (!p.t.category || p.t.category.toLowerCase() === "other"),
   );
   if (unclassifiedLarge.length > 0) {
     violations.push({
@@ -130,17 +174,15 @@ export function auditFinancialData(
   // FINRA Rule: Weekend and after-hours transaction flag. The app's
   // transaction data is date-only (no time-of-day), so the after-hours clause
   // must not be assumed: it only applies when the raw value actually carries an
-  // HH:mm time. Previously `new Date(t.date + 'T00:00:00')` flagged every
-  // date-only row as after-hours (midnight hours < 9), while `Date` objects
-  // stringified to an Invalid Date and never fired. Weekend detection works on
-  // the date alone.
-  const suspiciousDates = transactions.filter((t) => {
-    const d = auditDate(t.date);
+  // HH:mm time. Transactions with an unparseable date are excluded here (and
+  // reported as a data-quality violation above) rather than coerced to today.
+  const suspiciousDates = dated.filter((p) => {
+    const d = p.date;
     const day = d.getDay();
     if (day === 0 || day === 6) return true; // weekend
     const hasExplicitTime =
-      typeof t.date === "string"
-        ? /\d{1,2}:\d{2}/.test(t.date)
+      typeof p.t.date === "string"
+        ? /\d{1,2}:\d{2}/.test(p.t.date)
         : d.getHours() !== 0 || d.getMinutes() !== 0;
     if (!hasExplicitTime) return false; // no time-of-day in the data
     const hours = d.getHours();


### PR DESCRIPTION
﻿## Problem
uditFinancialData in src/lib/complianceUtils.ts compares amounts via Math.abs(t.amount). A non-numeric mount (e.g. ",500.00", "1,200.00", or undefined) yields NaN, so the transaction is silently dropped from every AML/SOX/FINRA rule. Separately, uditDate fell back to 
ew Date() ("today") for unparseable dates, enabling false structuring/velocity flags and mis-bucketing.

## Fix
- Added 
ormalizeAmount() which strips currency formatting and coerces to a number; non-numeric values become NaN and are reported as a SOX data-quality violation instead of being skipped.
- Changed uditDate to parseAuditDate returning Date | null. Transactions with an unparseable date are reported as a data-quality violation and excluded only from date-dependent rules (never coerced to today).
- Refactored the rule loop to operate on a pre-validated alid/dated set so malformed data is surfaced, not silently passed.

## Files changed
- src/lib/complianceUtils.ts — defensive amount/date parsing and data-quality violations.

## Testing
No unit-test harness exists in the repo, so automated tests were not added. Verified by reading: numeric amounts still drive all rules; NaN/non-numeric amounts and invalid dates now produce dq-non-numeric-amount / dq-invalid-date violations rather than being dropped or coerced to today.

Closes #1180
