### PR TITLE
Currency display forces 2 fraction digits, breaking zero-decimal currencies (JPY/KRW/CLP/VND)

### DIFF
--- a/src/lib/currencyUtils.ts
+++ b/src/lib/currencyUtils.ts
@@ -203,12 +203,10 @@ export function formatCurrencyDisplay(amount: number, currencyCode: string): str
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: currencyCode,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
     }).format(amount);
   } catch (err) {
     console.error("formatCurrency: failed to format currency", err);
-    return `${symbol}${amount.toFixed(2)}`;
+    return `${symbol}${amount.toLocaleString('en-US')}`;
   }
 }
 


### PR DESCRIPTION
﻿## Problem
ormatCurrencyDisplay in src/lib/currencyUtils.ts hard-coded minimumFractionDigits: 2, maximumFractionDigits: 2, overriding Intl's per-currency defaults. Zero-decimal currencies rendered spurious cents (e.g. ¥100.00 for JPY, ₩50,000.00 for KRW, CLP 1.000,00, ₫1.000,00), and the 	oFixed(2) fallback had the same bug.

## Fix
Dropped the hard-coded fraction digits so Intl.NumberFormat applies each currency's natural minor units (ISO 4217: 0 for JPY/KRW/CLP/VND, 2 for most, 3 for BHD/KWD). The error-path fallback now uses mount.toLocaleString('en-US') instead of 	oFixed(2).
`	s
return new Intl.NumberFormat('en-US', { style: 'currency', currency: currencyCode }).format(amount);
`

## Files changed
- src/lib/currencyUtils.ts — ormatCurrencyDisplay uses natural currency decimals (and matching fallback).

## Testing
No unit-test harness exists in the repo. Verified by reading: JPY/KRW now format with no decimals, USD/EUR/GBP keep 2, and 3-decimal currencies (BHD/KWD) keep 3, per Intl defaults.

Closes #1182
