### PR TITLE
Subscription burden is always 0% (income never passed)

### DIFF
--- a/src/components/subscriptions/SubscriptionAnalyzer.tsx
+++ b/src/components/subscriptions/SubscriptionAnalyzer.tsx
@@ -28,7 +28,6 @@ import {
   fetchUserSubscriptions,
   detectAndSaveSubscriptions,
   generateSubscriptionSummary,
-  estimateMonthlyIncome,
   Subscription,
 } from "@/src/lib/subscriptionUtils";
 import { formatCurrency } from "@/src/lib/utils";
@@ -42,7 +41,7 @@ const FREQUENCY_FILTERS = [
 
 export function SubscriptionAnalyzer({ user }: { user: any }) {
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
-  const [estimatedMonthlyIncome, setEstimatedMonthlyIncome] = useState(0);
+  const [recentTransactions, setRecentTransactions] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [analyzing, setAnalyzing] = useState(false);
   const [filter, setFilter] = useState<string>("all");
@@ -51,7 +50,7 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
   useEffect(() => {
     if (user?.uid) {
       loadSubscriptions();
-      loadIncome();
+      loadRecentTransactions();
     }
   }, [user?.uid]);
 
@@ -68,12 +67,12 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
     }
   };
 
-  const loadIncome = async () => {
+  const loadRecentTransactions = async () => {
     try {
-      const transactions = await fetchUserTransactions(user.uid, 183);
-      setEstimatedMonthlyIncome(estimateMonthlyIncome(transactions));
+      const transactions = await fetchUserTransactions(user.uid, 365);
+      setRecentTransactions(transactions);
     } catch (error) {
-      console.error("Error loading income:", error);
+      console.error("Error loading transactions:", error);
     }
   };
 
@@ -81,6 +80,7 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
     setAnalyzing(true);
     try {
       const transactions = await fetchUserTransactions(user.uid, 365);
+      setRecentTransactions(transactions);
       if (transactions.length < 10) {
         toast.error(
           "Not enough transaction history to analyze. Upload or add more transactions.",
@@ -105,8 +105,13 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
   };
 
   const summary = useMemo(() => {
+    const incomeTxns = recentTransactions.filter((t) => t.type === "income");
+    const months =
+      new Set(incomeTxns.map((t) => format(t.date, "yyyy-MM"))).size || 1;
+    const estimatedMonthlyIncome =
+      incomeTxns.reduce((s, t) => s + t.amount, 0) / months;
     return generateSubscriptionSummary(subscriptions, estimatedMonthlyIncome);
-  }, [subscriptions, estimatedMonthlyIncome]);
+  }, [subscriptions, recentTransactions]);
 
   const filteredSubscriptions = useMemo(() => {
     let result = subscriptions;


### PR DESCRIPTION
﻿## Problem
The "Subscription Burden" metric was always 0% and the "High burden" warning could never fire because the estimated monthly income was never derived from the transactions available to the analyzer. The summary generator (generateSubscriptionSummary) requires income to compute burden, but the card relied on a stale/empty income value, so calculateSubscriptionBurden hit its estimatedMonthlyIncome <= 0 guard and returned 0.

## Fix
Implemented the issue's Proposed Fix in src/components/subscriptions/SubscriptionAnalyzer.tsx:
- Replaced the estimatedMonthlyIncome state (previously populated from a separate 183-day fetch) with a ecentTransactions state.
- loadRecentTransactions() (called on mount) and handleAnalyze() both load the last 365 days of transactions via etchUserTransactions(user.uid, 365) and store them in ecentTransactions.
- The summary useMemo now computes estimatedMonthlyIncome inline from ecentTransactions (income type only, averaged over the distinct months present) and passes it into generateSubscriptionSummary(subscriptions, estimatedMonthlyIncome), so the "X% of monthly income" card and the > 20% "High burden" alert work correctly.
- Removed the now-unused estimateMonthlyIncome import.

## Files changed
- src/components/subscriptions/SubscriptionAnalyzer.tsx — derive income from 365-day transactions and feed it to the summary generator.

## Testing
No build environment (no node_modules) is available. Verified by reading the code: generateSubscriptionSummary/calculateSubscriptionBurden consume the passed income, ormat is already imported from date-fns, and 	.type/	.amount/	.date match the transaction shape used by etchUserTransactions. Manual verification: load the Subscriptions tab, confirm the burden percentage and High-burden alert reflect actual income from the past year.
