### PR TITLE
POST /api/document-download-url Has No Rate Limit

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1333,7 +1333,25 @@ CRITICAL RULES:
 
   // Generate short-lived signed URL for secure document download
   // Prevents permanent URL access to sensitive financial documents
-  app.post("/api/document-download-url", async (req: any, res) => {
+  // Rate limiting for /api/document-download-url to prevent signed-URL
+  // quota abuse (repeated Firestore reads + crypto signing) and mass parallel
+  // issuance for the same object. Limits: 60 requests per user per 15 minutes.
+  const downloadUrlRateLimiter = rateLimit({
+    keyGenerator: (req: any) => req.ownerId || req.ip,
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 60, // 60 requests per user per 15 minutes
+    message: {
+      error: {
+        stage: "RATE_LIMIT",
+        reason:
+          "Too many document download URL requests (max 60 per 15 minutes per user)",
+        recommendation: "Please slow down and try again later.",
+      },
+    },
+    standardHeaders: false,
+  });
+
+  app.post("/api/document-download-url", downloadUrlRateLimiter, async (req: any, res) => {
     try {
       const { storagePath, documentId } = req.body;
 


### PR DESCRIPTION
﻿## Problem
POST /api/document-download-url had no rate limiting. The global auth middleware only authenticates; the endpoint itself is unbounded. An authenticated caller could hammer it at full speed, causing repeated Firestore queries (cost/quota abuse), mass signed-URL issuance for the same object (defeating the 15-minute TTL intent), and server resource exhaustion (per-request Firestore reads + crypto signing). Compare /api/analyze, which is throttled (nalyzeRateLimiter, 5/day) and concurrency-limited.

## Fix
Added a per-user downloadUrlRateLimiter in server.ts (reusing the existing express-rate-limit pattern from nalyzeRateLimiter), keyed on eq.ownerId || req.ip:
- window: 15 minutes
- max: 60 requests per user per 15 minutes
- returns a structured RATE_LIMIT 429 error on exceed.
Applied it to the POST /api/document-download-url route, matching how nalyzeRateLimiter is wired onto /api/analyze.

## Files changed
- server.ts — new downloadUrlRateLimiter and applied to /api/document-download-url.

## Testing
No build environment (no node_modules) is available. Verified by reading the code: ateLimit is already imported (line 14), eq.ownerId is populated by the auth middleware (same as /api/analyze), and the limiter is wired as standard Express middleware immediately before the handler. Manual verification: send >60 requests for one user within 15 minutes and confirm a 429 with the RATE_LIMIT body; legitimate bursts under the threshold succeed.
