### PR TITLE
fix(insights): thread baseCurrency into generatePlainSummary prose

### DIFF
--- a/src/components/insights/InsightsDashboard.tsx
+++ b/src/components/insights/InsightsDashboard.tsx
@@ -195,7 +195,7 @@ function WeeklySection({
   baseCurrency: string;
 }) {
   const { weeklySummary, weekly } = bundle;
-  const summary = generatePlainSummary(weeklySummary);
+  const summary = generatePlainSummary(weeklySummary, baseCurrency);
   const topDeltas = weekly.slice(0, 6);
 
   return (
@@ -263,7 +263,7 @@ function MonthlySection({
   baseCurrency: string;
 }) {
   const { monthlySummary } = bundle;
-  const summary = generatePlainSummary(monthlySummary);
+  const summary = generatePlainSummary(monthlySummary, baseCurrency);
 
   return (
     <section>

--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -559,7 +559,7 @@ function buildPeriodSummary(
 /**
  * Produce a friendly, plain-language sentence describing a period summary.
  */
-export function generatePlainSummary(summary: PeriodSummary): string {
+export function generatePlainSummary(summary: PeriodSummary, currency?: string): string {
   if (summary.transactionCount === 0) {
     return `No spending recorded for ${summary.label.toLowerCase()} yet. Once you add transactions, we'll break down where your money goes.`;
   }
@@ -567,7 +567,7 @@ export function generatePlainSummary(summary: PeriodSummary): string {
   const top = summary.topCategories[0];
   const parts: string[] = [];
   parts.push(
-    `You spent ${formatCurrency(summary.total)} across ${summary.transactionCount} transaction${
+    `You spent ${formatCurrency(summary.total, currency)} across ${summary.transactionCount} transaction${
       summary.transactionCount === 1 ? "" : "s"
     } ${summary.label.toLowerCase()}.`,
   );
@@ -576,7 +576,7 @@ export function generatePlainSummary(summary: PeriodSummary): string {
     const share =
       summary.total > 0 ? Math.round((top.total / summary.total) * 100) : 0;
     parts.push(
-      `${top.category} was your biggest category at ${formatCurrency(top.total)} (${share}% of spend).`,
+      `${top.category} was your biggest category at ${formatCurrency(top.total, currency)} (${share}% of spend).`,
     );
   }
 

--- a/tests/plain-summary-currency.test.mjs
+++ b/tests/plain-summary-currency.test.mjs
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const insightsUtils = readFileSync(
+  path.join(repoRoot, "src/lib/insightsUtils.ts"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+const dashboard = readFileSync(
+  path.join(repoRoot, "src/components/insights/InsightsDashboard.tsx"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("generatePlainSummary accepts an optional currency argument", () => {
+  assert.ok(
+    /export function generatePlainSummary\(summary: PeriodSummary, currency\?: string\): string/.test(
+      insightsUtils,
+    ),
+    "generatePlainSummary must accept an optional `currency?: string` parameter",
+  );
+});
+
+test("generatePlainSummary threads currency into formatCurrency calls", () => {
+  assert.ok(
+    /formatCurrency\(summary\.total, currency\)/.test(insightsUtils),
+    "the total figure must be formatted with the passed currency",
+  );
+  assert.ok(
+    /formatCurrency\(top\.total, currency\)/.test(insightsUtils),
+    "the top-category figure must be formatted with the passed currency",
+  );
+});
+
+test("InsightsDashboard passes baseCurrency into generatePlainSummary", () => {
+  assert.ok(
+    /generatePlainSummary\(weeklySummary, baseCurrency\)/.test(dashboard),
+    "weekly section must pass baseCurrency to generatePlainSummary",
+  );
+  assert.ok(
+    /generatePlainSummary\(monthlySummary, baseCurrency\)/.test(dashboard),
+    "monthly section must pass baseCurrency to generatePlainSummary",
+  );
+});
+


### PR DESCRIPTION
## What changed

`generatePlainSummary` (`src/lib/insightsUtils.ts`) called `formatCurrency(summary.total, ...)` and `formatCurrency(top.total, ...)` with **no currency argument**, so the plain-language sentence always used `getDefaultCurrency()` while the surrounding card rendered the big number in the user's `baseCurrency` — producing contradicting figures (e.g. "You spent $1,200" next to "€1,200") in the same card.

### Fix
1. `generatePlainSummary` now accepts an optional `currency?: string` parameter and passes it to both `formatCurrency` calls.
2. Updated the two callers in `InsightsDashboard.tsx` (Weekly and Monthly sections) to pass `baseCurrency`.

## Tests
Added `tests/plain-summary-currency.test.mjs` (matches the repo's source-text test style) verifying:
- `generatePlainSummary` accepts the optional `currency` param.
- The currency is threaded into both `formatCurrency` calls.
- Both dashboard callers pass `baseCurrency`.

All 3 tests pass: `node --test tests/plain-summary-currency.test.mjs`

Closes #1239

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._