### PR TITLE
Buy transactions create portfolio holdings hard-coded to currency 'USD', corrupting multi-currency valuations

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -108,6 +108,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
   const [txPrice, setTxPrice] = useState('');
   const [txFees, setTxFees] = useState('');
   const [txNotes, setTxNotes] = useState('');
+  const [txCurrency, setTxCurrency] = useState('USD');
 
   useEffect(() => {
     if (!user) {
@@ -251,6 +252,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
         fees,
         notes: txNotes || '',
         date: new Date().toISOString(),
+        currency: txCurrency,
       });
       if (result) {
         const [h, t] = await Promise.all([
@@ -324,7 +326,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <Dialog open={addTransactionOpen} onOpenChange={setAddTransactionOpen}>
+          <Dialog open={addTransactionOpen} onOpenChange={(open) => { if (open) setTxCurrency(baseCurrency); setAddTransactionOpen(open); }}>
             <DialogTrigger>
               <Button
                 variant="outline"
@@ -381,6 +383,20 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
                 <div>
                   <label className="text-xs text-slate-400 uppercase tracking-wider font-semibold">Notes</label>
                   <Input value={txNotes} onChange={(e) => setTxNotes(e.target.value)} className="mt-1 bg-slate-800 border-slate-700 text-white" />
+                </div>
+                <div>
+                  <label className="text-xs text-slate-400 uppercase tracking-wider font-semibold">Currency</label>
+                  <Select
+                    value={txCurrency}
+                    onChange={(e) => setTxCurrency(e.target.value)}
+                    options={[
+                      { value: 'USD', label: 'USD' },
+                      { value: 'EUR', label: 'EUR' },
+                      { value: 'GBP', label: 'GBP' },
+                      { value: 'INR', label: 'INR' },
+                    ]}
+                    className="mt-1 bg-slate-800 border-slate-700 text-white"
+                  />
                 </div>
                 <Button onClick={handleAddTransaction} className="w-full bg-violet-600 hover:bg-violet-700">Save Transaction</Button>
               </div>

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -118,6 +118,10 @@ export interface TransactionInput {
   /** Optional asset class for the new holding created by a first buy. When
    * omitted, addTransaction infers it from the symbol. (Issue #1030) */
   assetClass?: AssetClass;
+  /** Optional currency for the holding created by a first buy. When omitted,
+   * addTransaction falls back to the user's base currency, then 'USD'.
+   * (Issue #1217) */
+  currency?: string;
 }
 
 // Well-known symbols that are not equities. Anything unrecognized defaults to
@@ -295,6 +299,21 @@ export async function addTransaction(userId: string, input: TransactionInput): P
     const symbol = input.symbol.trim();
     const now = new Date().toISOString();
 
+    // Resolve the user's base currency so a new holding created by a first buy
+    // is persisted in the correct currency rather than hard-coded 'USD'.
+    // (Issue #1217)
+    let userBaseCurrency = 'USD';
+    try {
+      const settingsDoc = await getDoc(doc(db, 'currencies', userId));
+      if (settingsDoc.exists()) {
+        const data = settingsDoc.data() as { baseCurrency?: string };
+        userBaseCurrency = data.baseCurrency || 'USD';
+      }
+    } catch {
+      userBaseCurrency = 'USD';
+    }
+    const holdingCurrency = input.currency || userBaseCurrency;
+
     // Queries are not allowed inside client transactions — resolve the holding
     // document ref first, then lock/update it atomically with the ledger write.
     let holdingRef = input.holdingId ? doc(db, 'portfolioHoldings', input.holdingId) : null;
@@ -334,7 +353,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
             quantity,
             avgCost,
             currentPrice: input.price,
-            currency: 'USD',
+            currency: holdingCurrency,
             createdAt: serverTimestamp(),
             updatedAt: serverTimestamp(),
           });


### PR DESCRIPTION
## Problem

## Description
In `addTransaction` (`src/lib/portfolioUtils.ts:330`), when a buy creates a **new** holding, the holding document is written with `currency: 'USD'` unconditionally. `TransactionInput` has no `currency` field, so any non-USD asset purchased via the transaction form receives a holding whose `currency` is `'USD'` while `avgCost`/`currentPrice` are stored in the foreign currency. Every downstream base-currency conversion keys off `holding.currency`, so it treats foreign prices as USD.

## Expected Behavior
The holding's `currency` should reflect the actual transaction currency and be persisted, so `holdingBaseValue` / `calculateTotalValue` produce correct totals, cost and allocation in the user's base currency.

## Actual Behavior
`currency: 'USD'` is hard-coded. In a multi-currency portfolio the value, cost, P/L and allocation for the holding are massively over-/under-stated because `convertAmount` is skipped (the holding is treated as already being in USD). `addHolding` correctly accepts `currency`, so only the transaction write path is affected.

## Proposed Fix
1. Add `currency?: string` to `TransactionInput` (near `src/lib/portfolioUtils.ts:103`).
2. Thread `currency` from the transaction form (`PortfolioTracker.tsx` `handleAddTransaction`).
3. In `addTransaction`, create the holding with:
```ts
currency: input.currency || 'USD',
```
4. When no currency is supplied, default to the user's `baseCurrency`.

This is distinct from the earlier `portfolio-pl-base-currency` fix, which corrected the read-side conversion but not this write-side hard-coding.

## Fix

fix: persist new portfolio holding in user base currency instead of hardcoded USD (closes #1217)

## Files changed

- src/components/portfolio/PortfolioTracker.tsx | 18 +++++++++++++++++-
- src/lib/portfolioUtils.ts                     | 21 ++++++++++++++++++++-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1217
