### PR TITLE
Missing FX rate silently treated as 1:1, overstating multi-currency portfolio totals

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -165,21 +165,28 @@ export function calculateTotalValue(holdings: Holding[]): number {
  * `rates` and `baseCurrency` are supplied each holding is converted via
  * `convertAmount` (USD-base FX table) before it is summed, so multi-currency
  * portfolios no longer treat every local-currency amount as if it were the
- * base currency. Holdings whose currency is missing from the rate table fall
- * back to their raw local value rather than being dropped, so totals stay
- * stable when a rate is temporarily unavailable.
+ * base currency. When a rate is genuinely missing or non-positive,
+ * `convertAmount` returns `null` and we surface that (log a warning and return
+ * `null`) instead of silently folding the foreign amount in at 1:1 parity, so
+ * totals, allocations and performance are not overstated.
  */
 function holdingBaseValue(
   holding: Holding,
   rates?: Record<string, number>,
   baseCurrency?: string,
-): number {
+): number | null {
   const local = holding.quantity * holding.currentPrice;
   if (!rates || !baseCurrency || !holding.currency || holding.currency === baseCurrency) {
     return local;
   }
   const converted = convertAmount(local, holding.currency, baseCurrency, rates);
-  return converted == null ? local : converted;
+  if (converted == null) {
+    console.warn(
+      `Skipping holding ${holding.symbol}: FX rate unavailable for ${holding.currency} → ${baseCurrency}.`,
+    );
+    return null;
+  }
+  return converted;
 }
 
 export function calculateTotalValue(
@@ -187,7 +194,10 @@ export function calculateTotalValue(
   rates?: Record<string, number>,
   baseCurrency?: string,
 ): number {
-  return holdings.reduce((sum, h) => sum + holdingBaseValue(h, rates, baseCurrency), 0);
+  return holdings.reduce((sum, h) => {
+    const v = holdingBaseValue(h, rates, baseCurrency);
+    return sum + (v == null ? 0 : v);
+  }, 0);
 }
 
 export function calculateProfitLoss(holding: Holding): { value: number; percent: number } {
@@ -207,6 +217,7 @@ export function calculateAllocation(
   const classMap = new Map<AssetClass, number>();
   holdings.forEach((h) => {
     const value = holdingBaseValue(h, rates, baseCurrency);
+    if (value == null) return;
     classMap.set(h.assetClass, (classMap.get(h.assetClass) || 0) + value);
   });
 
@@ -225,10 +236,10 @@ export function calculatePerformance(
   baseCurrency?: string,
 ): PerformanceMetrics {
   const totalValue = calculateTotalValue(holdings, rates, baseCurrency);
-  const totalCost = holdings.reduce(
-    (sum, h) => sum + holdingBaseValue({ ...h, currentPrice: h.avgCost }, rates, baseCurrency),
-    0,
-  );
+  const totalCost = holdings.reduce((sum, h) => {
+    const v = holdingBaseValue({ ...h, currentPrice: h.avgCost }, rates, baseCurrency);
+    return sum + (v == null ? 0 : v);
+  }, 0);
   const totalProfitLoss = totalValue - totalCost;
   const totalProfitLossPercent = totalCost > 0 ? (totalProfitLoss / totalCost) * 100 : 0;
 
@@ -269,11 +280,12 @@ export function generatePortfolioSummary(
   const topHoldings = holdings
     .map((h) => {
       const value = holdingBaseValue(h, rates, baseCurrency);
+      const safeValue = value == null ? 0 : value;
       return {
         symbol: h.symbol,
         name: h.name,
-        value,
-        weight: metrics.totalValue > 0 ? value / metrics.totalValue : 0,
+        value: safeValue,
+        weight: metrics.totalValue > 0 ? safeValue / metrics.totalValue : 0,
       };
     })
     .sort((a, b) => b.value - a.value)


### PR DESCRIPTION
## Problem

## Description
In `holdingBaseValue` (`src/lib/portfolioUtils.ts:172-176`), when `convertAmount` returns `null` (currency absent from the rate table, or non-positive rate), the code falls back to `local` — i.e. it adds the foreign-currency amount *as if it were already in the base currency*. This fallback is inherited by `calculateTotalValue`, `calculateAllocation` and `calculatePerformance`.

## Expected Behavior
A missing/unconvertible rate must not be silently folded in at parity. It should be surfaced (skipped with a warning, or accumulated into an "unconverted" bucket) so totals stay correct.

## Actual Behavior
A EUR 1,000 holding with a temporarily missing EUR rate is counted as `$1,000` in a USD-base portfolio, instead of being flagged/skipped. Totals, allocation percentages and performance are silently overstated whenever a rate is unavailable.

## Proposed Fix
Make `holdingBaseValue` return `null` on unconvertible input and have the callers skip/flag it (and optionally warn the user). Example:
```ts
const converted = convertAmount(local, holding.currency, baseCurrency, rates);
if (converted == null) return null; // caller skips / flags instead of substituting local
return converted;
```

## Fix

fix: treat missing FX rate as unavailable instead of 1:1 in portfolio totals (closes #1220)

## Files changed

- src/lib/portfolioUtils.ts | 36 ++++++++++++++++++++++++------------

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1220
