### PR TITLE
Dismissed anomalies reappear in Insights because buildInsights ignores ignoredTransactionIds

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -13,7 +13,6 @@
  *  - Generating plain-language summaries of spending behaviour
  *  - Calculating category trends (week-over-week, month-over-month)
  */
-import { detectAnomalies as detectAnomaliesCanonical } from './anomalyUtils';
 import { collection, getDocs, query, where, orderBy, limit } from "firebase/firestore";
 import {
   startOfWeek,
@@ -248,6 +247,7 @@ export function detectAnomalies(
   const anomalies = detectAnomaliesCore(coreTransactions);
   const insights: Insight[] = anomalies
     .filter((a) => a.type === "large_transaction") // insights only surfaces large-transaction anomalies
+    .filter((a) => !ignoredTransactionIds?.has(a.transactionId))
     .map((a) => ({
       id: a.id || uid(),
       userId: a.userId,
@@ -262,21 +262,6 @@ export function detectAnomalies(
     }));
 
   return insights.sort((a, b) => b.amount - a.amount);
-  const rawAnomalies = detectAnomaliesCanonical(transactions);
-
-  return rawAnomalies.map((item, idx) => {
-    const anomalyId = `anomaly-${idx}-${Date.now()}`;
-    return {
-      id: anomalyId,
-      type: 'anomaly' as const,
-      title: 'description' in item && typeof item.description === 'string'
-        ? item.description
-        : 'Transaction Anomaly Detected',
-      description: item.description || 'Anomalous financial pattern detected.',
-      severity: (item.severity as 'low' | 'medium' | 'high') || 'medium',
-      date: item.date ? new Date(item.date) : new Date(),
-    };
-  }).filter((item) => !ignoredTransactionIds?.has(item.id));
 }
 // ---------------------------------------------------------------------------
 // 3. Savings opportunities


### PR DESCRIPTION
## Problem

## Description
`buildInsights` -> `detectAnomalies` (`src/lib/insightsUtils.ts:248-264`) builds the anomaly insights but never references the `ignoredTransactionIds` parameter. The *only* code that honors `ignoredTransactionIds` lives in the unreachable block after the early `return` at line 264 (lines 265-279). `InsightsDashboard` passes `dismissedTransactionIds` (from `fetchAnomalies`) expecting dismissed anomalies to be filtered out.

## Expected Behavior
Dismissed/ignored transactions should be excluded from the Spending Anomalies section, and there should be no dead code after a return.

## Actual Behavior
Dismissed anomalies keep re-appearing every time insights are rebuilt, defeating the dismiss action. There is also duplicate `detectAnomaliesCanonical`/`detectAnomaliesCore` usage and dead, unreachable code.

## Proposed Fix
Filter before the early return and delete the dead block:
```ts
const anomalies = detectAnomaliesCore(coreTransactions);
const insights: Insight[] = anomalies
  .filter((a) => a.type === "large_transaction")
  .filter((a) => !ignoredTransactionIds?.has(a.transactionId))
  .map((a) => ({ ... }));
return insights.sort((a, b) => b.amount - a.amount);
// remove lines 265-279 and the duplicate import
```

## Fix

fix: respect ignoredTransactionIds in buildInsights so dismissed anomalies stay dismissed (closes #1221)

## Files changed

- src/lib/insightsUtils.ts | 17 +----------------

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1221
