### PR TITLE
AnomalyDashboard detectCategorySpikes flags false spikes by comparing partial current month to full-month history

### DIFF
--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -154,15 +154,30 @@ export function detectCategorySpikes(
   transactions: Transaction[];
   averageAllCategories: number;
 }> {
-  const currentMonth = format(new Date(), "yyyy-MM");
-  const byCategory = new Map<string, Transaction[]>();
+  // Compare two COMPLETE calendar months: the last fully-elapsed month
+  // against the one before it. Bucketing the still-running current month and
+  // comparing it against full-month history would flag false spikes at month
+  // boundaries, when the current month has only partial data. (Issue #1222)
+  const lastMonth = format(subMonths(new Date(), 1), "yyyy-MM");
+  const priorMonth = format(subMonths(new Date(), 2), "yyyy-MM");
+  const lastMonthByCategory = new Map<string, Transaction[]>();
+  const priorMonthByCategory = new Map<string, Transaction[]>();
 
   transactions.forEach((transaction) => {
     if (normalizeTransactionType(transaction.type) !== "expense") return;
-    const date = toDate(transaction.date) || new Date();
-    if (format(date, "yyyy-MM") !== currentMonth) return;
+    const monthKey = format(toDate(transaction.date) || new Date(), "yyyy-MM");
     const category = transaction.category || "Other";
-    byCategory.set(category, [...(byCategory.get(category) || []), transaction]);
+    if (monthKey === lastMonth) {
+      lastMonthByCategory.set(category, [
+        ...(lastMonthByCategory.get(category) || []),
+        transaction,
+      ]);
+    } else if (monthKey === priorMonth) {
+      priorMonthByCategory.set(category, [
+        ...(priorMonthByCategory.get(category) || []),
+        transaction,
+      ]);
+    }
   });
 
   // Overall per-category average used as a sanity floor for categories with
@@ -180,7 +195,7 @@ export function detectCategorySpikes(
       ? categoryAverages.reduce((sum, avg) => sum + avg, 0) / categoryAverages.length
       : 0;
 
-  return Array.from(byCategory.entries())
+  return Array.from(lastMonthByCategory.entries())
     .map(([category, items]) => {
       const categoryBaseline = baseline.get(category) || null;
       const amount = items.reduce((sum, item) => sum + Math.abs(item.amount), 0);
@@ -190,15 +205,15 @@ export function detectCategorySpikes(
       if (!item.baseline) {
         return averageAllCategories > 0 && item.amount > averageAllCategories * 2;
       }
-      if (item.baseline.monthlyTotals.length < 2) return false;
-      const previousTotals = item.baseline.monthlyTotals.slice(0, -1);
-      const average =
-        previousTotals.reduce((sum, total) => sum + total, 0) /
-        previousTotals.length;
+      const priorItems = priorMonthByCategory.get(item.category) || [];
+      const priorAmount = priorItems.reduce(
+        (sum, t) => sum + Math.abs(t.amount),
+        0,
+      );
       return (
-        average > 0 &&
-        item.amount > average * 1.5 &&
-        item.amount - average > Math.max(20, average * 0.5)
+        priorAmount > 0 &&
+        item.amount > priorAmount * 1.5 &&
+        item.amount - priorAmount > Math.max(20, priorAmount * 0.5)
       );
     });
 }


### PR DESCRIPTION
## Problem

## Description
`detectCategorySpikes` (`src/lib/anomalyUtils.ts:157-204`), the function `AnomalyDashboard` actually calls, buckets **only the current, still-running month** (`format(date,"yyyy-MM") !== currentMonth` returns early) and compares it against the average of prior *full* months.

## Expected Behavior
The detection should compare the last fully-elapsed month to the one before it (exactly like the already-fixed `detectAnomalies` in the same file), so spikes are detected only when a completed month genuinely exceeds history.

## Actual Behavior
On, say, the 10th of the month, a user who has already spent 1.5x their usual monthly average trips a "spike" even though the month is only a third over. This is the exact false-positive the sibling `detectAnomalies` was patched for, but it was re-introduced in the dashboard's separate code path.

## Proposed Fix
Use last-month vs prior-month (both complete):
```ts
const lastMonth = format(subMonths(new Date(), 1), "yyyy-MM");
const priorMonth = format(subMonths(new Date(), 2), "yyyy-MM");
transactions.forEach((t) => {
  if (normalizeTransactionType(t.type) !== "expense") return;
  const mk = format(toDate(t.date) || new Date(), "yyyy-MM");
  if (mk !== lastMonth && mk !== priorMonth) return;
  ...
});
// split lastMonth total vs priorMonth average for the spike test
```

## Fix

fix: compare current month to prior full months in detectCategorySpikes (closes #1222)

## Files changed

- src/lib/anomalyUtils.ts | 43 +++++++++++++++++++++++++++++--------------

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1222
