### PR TITLE
project_goal tool reports monthlyContribution of 100% level while building timeline from the selected level

### DIFF
--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -202,7 +202,7 @@ export const TOOL_CATALOGUE: AgentTool[] = [
           ? aggressive
           : safeMonthly;
       return {
-        monthlyContribution: safeMonthly,
+        monthlyContribution: selectedMonthly,
         conservative,
         aggressive,
         timeline: Number.isFinite(safeMonthly)


### PR DESCRIPTION
## Problem

## Description
The `project_goal` tool (`src/lib/chatAgent.ts:183-202`) computes `selectedMonthly` from the chosen `level` (conservative 85% / aggressive 120%) and builds the `timeline` from `selectedMonthly`, but returns `monthlyContribution: monthly` (the fixed 100% value) regardless of `level`.

## Expected Behavior
The reported `monthlyContribution` should equal the value actually used for the projection, so the headline number and the chart agree.

## Actual Behavior
A "conservative" request reports "$X/month" (100%) while the chart is generated assuming 85% — the agent answers with a figure that doesn't match the plan it shows, and users act on the wrong monthly amount.

## Proposed Fix
```ts
return {
  monthlyContribution: selectedMonthly,
  conservative,
  aggressive,
  timeline: generateTimelineProjection(target, current, selectedMonthly),
};
```

## Fix

fix: build project_goal timeline from the reported monthlyContribution level (closes #1224)

## Files changed

- src/lib/chatAgent.ts | 2 +-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1224
