### PR TITLE
detect_anomalies tool drops category_spike anomalies and never applies its threshold parameter

### DIFF
--- a/src/lib/anomalyUtils.ts
+++ b/src/lib/anomalyUtils.ts
@@ -245,6 +245,7 @@ export async function checkHistoricalSimilarAnomalies(
 
 export function detectAnomalies(
   transactions: Transaction[],
+  threshold: number = 3,
 ): Omit<Anomaly, "id" | "createdAt">[] {
   const anomalies: Omit<Anomaly, "id" | "createdAt">[] = [];
   const categoryAverages = new Map<string, { total: number; count: number }>();
@@ -268,12 +269,12 @@ export function detectAnomalies(
       if (baselineTotal <= 0) return;
       const mean = baselineTotal / baselineCount;
       const amount = Math.abs(t.amount);
-      if (amount > mean * 3 && amount > 1000) {
+      if (amount > mean * threshold && amount > 1000) {
         anomalies.push({
           userId: t.userId,
           transactionId: t.id,
           type: "large_transaction",
-          severity: amount > mean * 5 ? "critical" : "high",
+          severity: amount > mean * (threshold + 2) ? "critical" : "high",
           category: cat,
           amount,
           averageAmount: Math.round(mean * 100) / 100,

--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -123,11 +123,11 @@ export const TOOL_CATALOGUE: AgentTool[] = [
         type: tx.type,
       } as any));
       const threshold = toNumber(args.threshold, 2);
-      const anomalies: Anomaly[] = detectAnomaliesCore(coreTxns);
+      const anomalies: Anomaly[] = detectAnomaliesCore(coreTxns, threshold);
       // Convert to Insight-like format for the chat response
       return anomalies
-        .filter((a) => a.type === "large_transaction")
         .map((a) => ({
+          type: a.type,
           category: a.category,
           amount: a.amount,
           averageAmount: a.averageAmount,


### PR DESCRIPTION
## Problem

## Description
The `detect_anomalies` tool (`src/lib/chatAgent.ts:110-140`) has two defects:
1. It hard-filters `.filter((a) => a.type === "large_transaction")`, dropping `category_spike` anomalies — even though its own description says it answers "spending spikes per category" / "why was last month so expensive?".
2. It parses `args.threshold` (`toNumber(args.threshold, 2)`) but never passes it to `detectAnomaliesCore`, which internally hard-codes `amount > mean * 3`. The parameter is a silent no-op.

## Expected Behavior
All anomaly types (at least `category_spike`) should be returned, and the `threshold` parameter should actually control the sensitivity of the detection.

## Actual Behavior
The agent can never surface category spikes, and cannot tune sensitivity despite advertising a `threshold` parameter — a misleading tool contract.

## Proposed Fix
```ts
const anomalies = detectAnomaliesCore(coreTxns, threshold); // thread threshold through
return anomalies
  .map((a) => ({ type: a.type, category: a.category, amount: a.amount, averageAmount: a.averageAmount, deviation: a.deviation, description: a.description, severity: a.severity, date: a.date }))
  .sort((a, b) => b.amount - a.amount);
```
and extend `detectAnomaliesCore`/`detectAnomalies` to accept an optional `threshold` used as the multiplier.

## Fix

fix: keep category_spike anomalies and apply threshold in detect_anomalies (closes #1225)

## Files changed

- src/lib/anomalyUtils.ts | 5 +++--
- src/lib/chatAgent.ts    | 4 ++--

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1225
