### PR TITLE
Key-metric claims can never be adjudicated: numeric RAG query uses bare normalized integer absent from source

### DIFF
--- a/src/lib/verification/adjudicator.ts
+++ b/src/lib/verification/adjudicator.ts
@@ -60,7 +60,15 @@ export async function adjudicateClaims(
     const batch = unverifiedClaims.slice(i, i + batchSize);
     
     const claimsWithContext = batch.map((claim) => {
-      const { relevantChunks } = ragEngine.retrieveContext(claim.raw, 3);
+      // Key-metric claims store `raw` as a bare normalized integer
+      // (e.g. "4523000"); the source prints it grouped ("4,523,000"), which
+      // tokenizes to distinct tokens with no overlap. Build a query in the
+      // lexical form present in the source so the figure can be retrieved.
+      const lexicalFigure = Number.isFinite(claim.value)
+        ? claim.value.toLocaleString("en-US")
+        : claim.raw;
+      const query = `${claim.label} ${lexicalFigure}`;
+      const { relevantChunks } = ragEngine.retrieveContext(query, 3);
       return {
         claim,
         chunks: relevantChunks,


### PR DESCRIPTION
## Problem

## Description
Model-based adjudication (`src/lib/verification/adjudicator.ts:62-63`) retrieves RAG context for each claim using `claim.raw`. For structured key-metric claims, `collectMetricClaims` stores `raw: String(value)` — a bare normalized integer such as `"4523000"` (`src/lib/verification/grounding.ts:269`).

`retrieveContext` -> `similaritySearch` tokenizes the query with `\b[a-z0-9_]+\b`, so the token is `4523000`. The source text contains `"4,523,000"`, which tokenizes to `4`, `523`, `000` — **zero overlap**, cosine = 0, no chunks retrieved, the prompt gets "No context found", and the model returns `unsupported`. The claim stays `unverified` even when it is correctly in the document.

## Expected Behavior
The RAG query should match the lexical form present in the source (grouped digits + label), so numeric metrics can actually be adjudicated.

## Actual Behavior
Every structured numeric metric claim is effectively unverifiable — grounded figures get flagged as unverified, corrupting the verification ratio and citations.

## Proposed Fix
Build a query that tokenizes like the source, and/or verify numeric claims by value against `buildSourceIndex`:
```ts
const lexicalFigure = claim.value.toLocaleString("en-US"); // "4,523,000"
const query = `${claim.label} ${lexicalFigure}`;
const { relevantChunks } = ragEngine.retrieveContext(query, 3);
```
(Deeper fix: verify numeric claims by value against `buildSourceIndex`, as `groundClaim` already does, rather than lexical RAG.)

## Fix

fix: adjudicate key-metric claims against the real source value, not a normalized integer (closes #1226)

## Files changed

- src/lib/verification/adjudicator.ts | 10 +++++++++-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1226
