### PR TITLE
Unvalidated AI numeric outputs: sentiment_score not clamped and non-finite key_metrics abort the whole upload

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -230,6 +230,11 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
     );
   }
 
+  const rawSentiment = Number(payload.sentiment_score);
+  const sentiment_score = Number.isFinite(rawSentiment)
+    ? Math.max(-1, Math.min(1, rawSentiment))
+    : 0;
+
   return {
     summary: sanitizeString(String(payload.summary || "")),
     key_metrics:
@@ -250,7 +255,7 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
     action_items: Array.isArray(payload.action_items)
       ? payload.action_items.map((v: unknown) => sanitizeString(String(v)))
       : [],
-    sentiment_score: Number(payload.sentiment_score || 0),
+    sentiment_score,
     entities: Array.isArray(payload.entities)
       ? payload.entities.map((v: unknown) => sanitizeString(String(v)))
       : [],
@@ -394,6 +399,7 @@ function sanitizeString(text: string): string {
 /** Recursively sanitize string leaves of an arbitrary value (objects/arrays)
  * so untrusted model output rendered in the UI cannot carry HTML/script. */
 function sanitizeDeep(value: any): any {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
   if (typeof value === "string") return sanitizeString(value);
   if (Array.isArray(value)) return value.map(sanitizeDeep);
   if (value && typeof value === "object") {


### PR DESCRIPTION
## Problem

## Description
In the analysis pipeline (`server.ts`):
- `sentiment_score: Number(payload.sentiment_score || 0)` is never clamped to `[-1, 1]` (line 253).
- `key_metrics` is stored verbatim (lines 235-238) with no finite/range validation.

## Expected Behavior
`sentiment_score` must be clamped to `[-1, 1]`, and `key_metrics` values must be coerced so non-finite (`NaN`/`Infinity`) or negative numbers are normalized before persistence.

## Actual Behavior
- A model returning `sentiment_score: 999` or `-5` breaks any UI/threshold logic that assumes the `[-1,1]` range.
- More critically, Firestore **rejects** `NaN`/`Infinity` values. A single bad `key_metrics` number makes the `add()` reject; that rejection is a non-permission error, so `server.ts` deletes the already-uploaded PDF and throws `PipelineError`, failing the entire analysis because of one bad metric.

## Proposed Fix
```ts
const sentiment = Number(payload.sentiment_score);
const sentiment_score = Number.isFinite(sentiment) ? Math.max(-1, Math.min(1, sentiment)) : 0;

function sanitizeMetrics(v: unknown, depth = 0): unknown {
  if (depth > 4 || v === null || v === undefined) return v;
  if (typeof v === "number") return Number.isFinite(v) ? v : 0;
  if (typeof v === "string") { const n = Number(String(v).replace(/[^0-9.\-]/g, "")); return Number.isFinite(n) ? n : v; }
  if (Array.isArray(v)) return v.map((x) => sanitizeMetrics(x, depth + 1));
  if (typeof v === "object") return Object.fromEntries(Object.entries(v as Record<string, unknown>).map(([k, x]) => [k, sanitizeMetrics(x, depth + 1)]));
  return v;
}
const key_metrics = sanitizeMetrics(typeof payload.key_metrics === "object" && payload.key_metrics ? payload.key_metrics : {});
```

## Fix

fix: clamp sentiment_score and sanitize non-finite key_metrics on AI upload (closes #1230)

## Files changed

- server.ts | 8 +++++++-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1230
