### PR TITLE
SubscriptionCard ignores per-subscription annualizationFactor, contradicting the analyzer total

### DIFF
--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -13,7 +13,7 @@ import { Progress } from "@/src/components/ui/progress";
 import { Calendar, AlertTriangle, Trash2, RefreshCw } from "lucide-react";
 import { format, differenceInDays, differenceInMilliseconds, startOfDay } from "date-fns";
 import { toast } from "sonner";
-import { Subscription } from "@/src/lib/subscriptionUtils";
+import { Subscription, getAnnualizationFactor } from "@/src/lib/subscriptionUtils";
 import { formatCurrency } from "@/src/lib/utils";
 import {
   updateSubscription,
@@ -138,6 +138,8 @@ export function SubscriptionCard({
         ? "Yearly"
         : "Weekly";
 
+  const annualizationFactor = getAnnualizationFactor(subscription);
+
   return (
     <motion.div
       layout
@@ -218,30 +220,17 @@ export function SubscriptionCard({
                   Annual Cost
                 </span>
                 <span className="text-indigo-400 font-mono font-bold">
-                  {formatCurrency(
-                    subscription.amount *
-                    (subscription.frequency === "monthly"
-                      ? 12
-                      : subscription.frequency === "yearly"
-                        ? 1
-                        : 52)
-                  )}
+                  {formatCurrency(subscription.amount * annualizationFactor)}
                 </span>
               </div>
               <Progress
-                value={
-                  subscription.frequency === "monthly"
-                    ? 100 / 12
-                    : subscription.frequency === "yearly"
-                      ? 100
-                      : 100 / 52
-                }
+                value={100 / annualizationFactor}
                 className="h-1.5 bg-slate-800"
               >
                 <div
                   className="h-full bg-indigo-500 rounded-full transition-all"
                   style={{
-                    width: `${subscription.frequency === "monthly" ? 100 / 12 : subscription.frequency === "yearly" ? 100 : 100 / 52}%`,
+                    width: `${100 / annualizationFactor}%`,
                   }}
                 />
               </Progress>


### PR DESCRIPTION
## Problem

## Description
`SubscriptionCard` (`src/components/subscriptions/SubscriptionCard.tsx:220-245`) computes annual cost and the progress bar using hard-coded factors `12 / 1 / 52`, ignoring the per-subscription `annualizationFactor` that `calculateSubscriptionCosts` / `calculateCategoryGroups` correctly use.

## Expected Behavior
The card should use `subscription.annualizationFactor` (or `getAnnualizationFactor(sub)`) so the displayed annual cost and progress match the analyzer totals.

## Actual Behavior
For a bi-weekly subscription detected with `annualizationFactor: 26`, the dashboard shows `amount*26` annually in the analyzer but `amount*52` in the card — the two UI surfaces contradict each other.

## Proposed Fix
```ts
const factor = subscription.annualizationFactor
  ?? (subscription.frequency === monthly ? 12 : subscription.frequency === yearly ? 1 : 52);
{formatCurrency(subscription.amount * factor)}
value={100 / factor}
```
(pull `getAnnualizationFactor` from `subscriptionUtils` for consistency.)

## Fix

fix: apply per-subscription annualizationFactor in SubscriptionCard (closes #1234)

## Files changed

- src/components/subscriptions/SubscriptionCard.tsx | 23 ++++++-----------------

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1234
