### PR TITLE
filteredSubscriptions mutates the subscriptions React state array in place via Array.sort

### DIFF
--- a/src/components/subscriptions/SubscriptionAnalyzer.tsx
+++ b/src/components/subscriptions/SubscriptionAnalyzer.tsx
@@ -130,7 +130,7 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
       });
     }
 
-    return result.sort(
+    return [...result].sort(
       (a, b) => a.nextRenewalDate.getTime() - b.nextRenewalDate.getTime(),
     );
   }, [subscriptions, filter, showUpcomingOnly]);


### PR DESCRIPTION
## Problem

## Description
`filteredSubscriptions` (`src/components/subscriptions/SubscriptionAnalyzer.tsx:128-130`) returns `result.sort(...)` directly. When no category/filter is applied, `result` is the **same array reference** as the `subscriptions` React state (it is assigned `result = subscriptions` upstream), so `Array.sort` mutates the component state in place.

## Expected Behavior
Derived values must not mutate state. Sorting should operate on a copy.

## Actual Behavior
When the filter is all, `result.sort(...)` reorders the `subscriptions` state array in place. Any other reader of `subscriptions` (e.g. `generateSubscriptionSummary` in the same render) sees a silently reordered array — a classic immutability violation that breaks memoization and future assumptions.

## Proposed Fix
```ts
return [...result].sort(
  (a, b) => a.nextRenewalDate.getTime() - b.nextRenewalDate.getTime(),
);
```

## Fix

fix: avoid mutating subscriptions state in place in filteredSubscriptions (closes #1235)

## Files changed

- src/components/subscriptions/SubscriptionAnalyzer.tsx | 2 +-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1235
