### PR TITLE
Category trend series includes a partial current month, drawing a false downward trend

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -503,14 +503,15 @@ export function calculateCategoryTrends(
   if (transactions.length === 0) return { trends: [], categories: [] };
 
   const now = new Date();
+  const endWindow = endOfMonth(subMonths(now, 1)); // last fully-elapsed month
   const startWindow = startOfMonth(subMonths(now, months - 1));
   const intervalMonths = eachMonthOfInterval({
     start: startWindow,
-    end: now,
+    end: endWindow,
   });
 
   // Determine top categories over the window to limit chart lines.
-  const windowTx = filterByPeriod(transactions, startWindow, endOfMonth(now));
+  const windowTx = filterByPeriod(transactions, startWindow, endWindow);
   const topCategories = sumByCategory(windowTx)
     .slice(0, 5)
     .map((c) => c.category);


### PR DESCRIPTION
## Problem

## Description
`calculateCategoryTrends` (`src/lib/insightsUtils.ts:505-510`) builds the monthly interval with `end: now`, so the final trend point is the **current, still-running month**. `filterByPeriod` then only sums transactions up to today for that point.

## Expected Behavior
The trend series should contain only completed months (or the current month should be annualized/excluded) so the last point is comparable to prior full months.

## Actual Behavior
The last point is almost always far lower than the preceding full months, drawing a misleading "spending dropped" line at the right edge of the 6-month chart. Meanwhile `topCategories` is computed against `endOfMonth(now)` (treating the current month as complete), so the chart and the category ranking are internally inconsistent.

## Proposed Fix
```ts
const now = new Date();
const endWindow = endOfMonth(subMonths(now, 1)); // last fully-elapsed month
const startWindow = startOfMonth(subMonths(now, months - 1));
const intervalMonths = eachMonthOfInterval({ start: startWindow, end: endWindow });
```

## Fix

fix: exclude partial current month from category trend series (closes #1238)

## Files changed

- src/lib/insightsUtils.ts | 5 +++--

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1238
