### PR TITLE
Verification ratio excludes derived claims, marking fully-grounded reports as 0% verified

### DIFF
--- a/src/lib/verification/grounding.ts
+++ b/src/lib/verification/grounding.ts
@@ -358,7 +358,7 @@ function summarize(claims: GroundedClaim[]): GroundingSummary {
     verified,
     derived,
     unverified,
-    ratio: totalClaims === 0 ? 0 : verified / totalClaims,
+    ratio: totalClaims === 0 ? 0 : (verified + derived) / totalClaims,
     adjudicated: false,
     version: 1,
   };

--- a/src/lib/verification/index.ts
+++ b/src/lib/verification/index.ts
@@ -118,7 +118,7 @@ export async function verifyDocumentAnalysis(
         verified,
         derived,
         unverified,
-        ratio: totalClaims === 0 ? 0 : verified / totalClaims,
+        ratio: totalClaims === 0 ? 0 : (verified + derived) / totalClaims,
         adjudicated: true,
         version: 1,
       };


### PR DESCRIPTION
## Problem

## Description
In `grounding.ts` (`src/lib/verification/grounding.ts:361`) and the same formula in `index.ts`, the verification `ratio` is computed as `verified / totalClaims`. `derived` claims (figures within `DERIVED_TOLERANCE` of a source value — rounded restatements, computed ratios) **are** grounded, but they are excluded from the ratio.

## Expected Behavior
`ratio` should reflect everything tied to the source: `verified + derived`.

## Actual Behavior
A report whose every figure is supported *only* as a derived match yields `ratio = 0`, falsely signaling "nothing is verified." The headline metric consumers (UI, the adjudication gate) then treat a well-grounded analysis as entirely unverified.

## Proposed Fix
```ts
ratio: totalClaims === 0 ? 0 : (verified + derived) / totalClaims,
```
(apply in both `grounding.ts` and `verification/index.ts`)

## Fix

fix: include derived claims in verification ratio (closes #1245)

## Files changed

- src/lib/verification/grounding.ts | 2 +-
- src/lib/verification/index.ts     | 2 +-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1245
