### PR TITLE
fix(analyze): sort month keys lexicographically for correct trend pairs

### DIFF
--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -356,7 +356,7 @@ export function generateBudgetAdvice(context: FinancialContext): ChatResponse {
 
 export function analyzeSpendingPatterns(context: FinancialContext): ChatResponse {
   const { monthlySpending, spendingByMonth } = context;
-  const months = Object.keys(monthlySpending).sort((a: any, b: any) => Number(a) - Number(b));
+  const months = Object.keys(monthlySpending).sort();
   let response = '';
 
   if (months.length < 2) {


### PR DESCRIPTION
## Summary
Fixes #1326

`analyzeSpendingPatterns` sorted month keys with `Number(a) - Number(b)`. The keys are strings like `"2024-01"`, so `Number("2024-01")` is `NaN`, the comparator returned `NaN`, and the sort order was undefined/implementation-dependent. With a `NaN` sort, "consecutive" months are paired arbitrarily, so the spending-pattern narrative ("spending increased from X to Y") can be computed against the wrong month pairs and report false trends.

## Fix
`yyyy-MM` keys sort lexicographically = chronologically, so a plain `.sort()` produces the correct calendar order and pairs the right consecutive months.

```diff
- const months = Object.keys(monthlySpending).sort((a: any, b: any) => Number(a) - Number(b));
+ const months = Object.keys(monthlySpending).sort();
```

## Verification
- `new Date("2024-01")` style keys now sort `["2024-01", "2024-02", "2024-03"]` as expected.
- No other behaviour change; the sort is only used to order months for trend pairing.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._