### PR TITLE
fix(privacy): include currencies and privacy_settings in data export

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -135,6 +135,8 @@ const USER_COLLECTIONS = [
   "tax_estimates",
   "bills",
   "activity_log",
+  "currencies",
+  "privacy_settings",
 ];
 
 export async function exportUserData(


### PR DESCRIPTION
## Summary
Fixes #1322

`exportUserData` walks `USER_COLLECTIONS` to build the GDPR "export my data" JSON, but the list omitted the `currencies` collection (and `privacy_settings`). A user's base currency, supported-currency list, and full `conversionHistory` were never included in their own data export — an incomplete export of personal settings, which undermines the data-portability guarantee.

## Fix
Add `currencies` and `privacy_settings` to `USER_COLLECTIONS`:
```diff
   "bills",
   "activity_log",
+  "currencies",
+  "privacy_settings",
 ];
```

These collections are userId-keyed and read via the same `for (const colName of USER_COLLECTIONS)` loop, so they flow through the existing export path with no other changes.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._