### PR TITLE
fix(verification): only promote claims to verified/derived when a citation exists

### DIFF
--- a/src/lib/verification/index.ts
+++ b/src/lib/verification/index.ts
@@ -76,32 +76,33 @@ export async function verifyDocumentAnalysis(
         const adjudication = adjudicationResults[claim.id];
         if (adjudication && (adjudication.verdict === "supported" || adjudication.verdict === "partial")) {
           const status: ClaimStatus = adjudication.verdict === "supported" ? "verified" : "derived";
-          
+          // Find the chunk that supported this claim first. Only promote to
+          // verified/derived when a backing chunk (and therefore a citation)
+          // actually exists; otherwise the claim stays unverified.
+          const chunk = chunks.find((c) => c.id === adjudication.chunkId);
+          if (!chunk) continue;
+
           claim.status = status;
           claim.reason = adjudication.reason;
 
-          // Find the chunk that supported this claim
-          const chunk = chunks.find((c) => c.id === adjudication.chunkId);
-          if (chunk) {
-            const page = chunk.pageNumber || 1;
-            const snippet = chunk.text.slice(0, 240).replace(/\s+/g, " ").trim();
-            const charOffset = chunk.charStart || 0;
+          const page = chunk.pageNumber || 1;
+          const snippet = chunk.text.slice(0, 240).replace(/\s+/g, " ").trim();
+          const charOffset = chunk.charStart || 0;
 
-            const citation: Citation = {
-              page,
-              chunkId: chunk.id,
-              snippet,
-              charOffset,
-              matchType: "adjudicated",
-            };
+          const citation: Citation = {
+            page,
+            chunkId: chunk.id,
+            snippet,
+            charOffset,
+            matchType: "adjudicated",
+          };
 
-            claim.citation = citation;
+          claim.citation = citation;
 
-            // Store in citations map if under the limit
-            if (citationsCount < 100) {
-              result.citations[claim.id] = citation;
-              citationsCount++;
-            }
+          // Store in citations map if under the limit
+          if (citationsCount < 100) {
+            result.citations[claim.id] = citation;
+            citationsCount++;
           }
         }
       }


### PR DESCRIPTION
## Summary
Fixes #1324

In `verifyAnalysis`, when the model returned `supported`/`partial`, the code set `claim.status` to `verified`/`derived` **before** looking up the backing chunk. If `adjudication.chunkId` was empty/`unknown` (the default in `adjudicator.ts`), `chunk` was `undefined`, yet `claim.status` was already promoted — so the claim ended up "verified" with `claim.citation === undefined`. This inflated the grounding `ratio` and broke any downstream code that reads `claim.citation` (snippet/page), making the whole verification summary untrustworthy.

## Fix
Look up the backing chunk **first** and only promote to verified/derived when a chunk (and therefore a citation) actually exists. When `chunk` is missing, `continue` keeps the claim unverified:

```diff
- const status: ClaimStatus = adjudication.verdict === "supported" ? "verified" : "derived";
- claim.status = status;
- claim.reason = adjudication.reason;
- // Find the chunk that supported this claim
  const chunk = chunks.find((c) => c.id === adjudication.chunkId);
- if (chunk) {
-   ... build citation and assign claim.citation ...
- }
+ if (!chunk) continue;
+ claim.status = status;
+ claim.reason = adjudication.reason;
+ ... build citation and assign claim.citation ...
```

Now a claim can never be `verified`/`derived` without a corresponding `citation`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._