### PR TITLE
fix(verification): require word-boundary and value-consistent verbatim match in grounding

### DIFF
--- a/src/lib/verification/grounding.ts
+++ b/src/lib/verification/grounding.ts
@@ -183,6 +183,48 @@ function nearestValue(index: SourceIndex, value: number): number | null {
   );
 }
 
+const DIGIT_BOUNDARY = /[\d.,]/;
+
+/**
+ * Finds the first verbatim occurrence of `literal` in `index.fullText` that is
+ * word-bounded on both sides and whose surrounding figure parses to the same
+ * value as `claimValue`. A bare substring match (e.g. "50" inside "1500") is
+ * rejected so scaled figures are not false-verified against the wrong number.
+ *
+ * Returns the character offset of the match, or -1 when none qualifies.
+ */
+function findVerbatimMatch(
+  index: SourceIndex,
+  literal: string,
+  claimValue: number,
+): number {
+  let at = index.fullText.indexOf(literal);
+  while (at !== -1) {
+    const before = index.fullText[at - 1] ?? "";
+    const after = index.fullText[at + literal.length] ?? "";
+
+    const boundedBefore = !before || !DIGIT_BOUNDARY.test(before);
+    const boundedAfter = !after || !DIGIT_BOUNDARY.test(after);
+
+    if (boundedBefore && boundedAfter) {
+      // Value-consistency: parse the figure around the match and require it to
+      // equal the claim value, so "50" does not verify a "50 million" claim.
+      const windowStart = Math.max(0, at - 20);
+      const windowEnd = Math.min(index.fullText.length, at + literal.length + 20);
+      const parsed = parseNumber(
+        index.fullText.slice(windowStart, windowEnd),
+        index.convention,
+      );
+      if (parsed && valuesEqual(parsed.value, claimValue)) {
+        return at;
+      }
+    }
+
+    at = index.fullText.indexOf(literal, at + literal.length);
+  }
+  return -1;
+}
+
 /**
  * Decides whether a single claim is supported by the document.
  *
@@ -198,7 +240,7 @@ export function groundClaim(
   const literal = claim.raw.trim();
 
   if (literal) {
-    const exactOffset = index.fullText.indexOf(literal);
+    const exactOffset = findVerbatimMatch(index, literal, claim.value);
     if (exactOffset !== -1) {
       return {
         ...claim,


### PR DESCRIPTION
## Summary
Fixes #1323

`buildNumber` stores the claim's `raw` as the **bare digit run** (`core`) while keeping `scale`/`isPercent` separately, so "$50 million" becomes `raw: "50"`, `value: 5e7`. `groundClaim`'s exact-match tier then did `index.fullText.indexOf(literal)` on that bare `raw` — so `"50"` matched inside `"1500"`, `"250"`, `"5020"`, `"50%"`, etc. Almost any scaled figure was "verified" against the wrong number, destroying the grounding feature's integrity (unverified claims showed as grounded).

## Fix
Replace the bare `indexOf` with `findVerbatimMatch`, which:
- scans every occurrence of `literal`,
- requires a digit word-boundary on both sides (no adjacent `[\d.,]`),
- parses the figure around the candidate match and requires `valuesEqual(parsed.value, claim.value)` before accepting it.

```diff
- const exactOffset = index.fullText.indexOf(literal);
+ const exactOffset = findVerbatimMatch(index, literal, claim.value);
```

A bare "50" inside "1500" is now rejected by the boundary check, and a scaled "50" (value 5e7) does not verify against a literal "50" (value 50) because the parsed values differ. The existing `byValue` and tolerance tiers remain as fallbacks for normalised/derived matches.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._