### PR TITLE
fix(budget): average spending over analysis window, not months-with-activity

### DIFF
--- a/src/lib/budgetUtils.ts
+++ b/src/lib/budgetUtils.ts
@@ -398,10 +398,12 @@ export async function generateBudgetSuggestions(
   );
 
   const categoryMonthlyTotals = new Map<string, Map<string, number>>();
+  const windowMonths = new Set<string>();
   expenseTransactions.forEach((t) => {
     const dateVal = toDate(t.date);
     if (!dateVal) return;
     const monthKey = `${dateVal.getFullYear()}-${String(dateVal.getMonth() + 1).padStart(2, '0')}`;
+    windowMonths.add(monthKey);
     const category = t.category || 'Other';
     if (!categoryMonthlyTotals.has(category)) {
       categoryMonthlyTotals.set(category, new Map<string, number>());
@@ -409,15 +411,21 @@ export async function generateBudgetSuggestions(
     const monthMap = categoryMonthlyTotals.get(category)!;
     monthMap.set(monthKey, (monthMap.get(monthKey) || 0) + Math.abs(t.amount));
   });
+  // Divide each category's total by the actual analysis window (the number of
+  // months present in the fetched range), not by the number of months in which
+  // that category had any transaction, so sporadic categories get a true
+  // monthly baseline instead of a single month's spend reported as the average.
+  const windowMonthCount = Math.max(1, windowMonths.size);
 
   const suggestions: CategoryBudgetSuggestion[] = [];
   categoryMonthlyTotals.forEach((monthMap, category) => {
     const monthlyTotals = Array.from(monthMap.values());
-    const averageSpending = monthlyTotals.reduce((sum, v) => sum + v, 0) / monthlyTotals.length;
+    const categoryTotal = monthlyTotals.reduce((sum, v) => sum + v, 0);
+    const averageSpending = categoryTotal / windowMonthCount;
     const suggestedAmount = Math.max(0, Math.round(averageSpending / 10) * 10);
     const variance =
       monthlyTotals.reduce((sum, v) => sum + Math.pow(v - averageSpending, 2), 0) /
-      monthlyTotals.length;
+      Math.max(1, monthlyTotals.length);
     const stdDev = Math.sqrt(variance);
     const coefficientOfVariation = averageSpending > 0 ? stdDev / averageSpending : 0;
 


### PR DESCRIPTION
## Summary
Fixes #1329

`generateBudgetSuggestions` computed the per-category average by dividing by `monthlyTotals.length` — the number of months in which that **category had any transaction** — not the fixed analysis window:
```ts
const monthlyTotals = Array.from(monthMap.values());
const averageSpending = monthlyTotals.reduce((s, v) => s + v, 0) / monthlyTotals.length;
```

A category spent in only 1 of the 3 fetched months got `averageSpending = thatMonthTotal / 1` — i.e. that single month's spend was reported as the monthly average. Suggested budgets and the `confidenceScore` were therefore inflated/misleading for sporadic categories.

## Fix
Divide by the actual number of months in the analysis window (the distinct month keys across the fetched range), so the average reflects a true monthly baseline:
```ts
const windowMonthCount = Math.max(1, windowMonths.size);
const averageSpending = categoryTotal / windowMonthCount;
```

For a 3-month feed, a category spent in one month now averages to `thatMonthTotal / 3` instead of `/ 1`. The variance/std-dev (used for the consistency signal) is still computed over the months with activity, guarded against divide-by-zero.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._