### PR TITLE
fix(forecast): sort loaded forecasts ascending by month

### DIFF
--- a/src/components/forecast/ForecastComparison.tsx
+++ b/src/components/forecast/ForecastComparison.tsx
@@ -118,7 +118,7 @@ export function ForecastComparison({ user }: ForecastComparisonProps) {
             expenses: f.projectedExpenses,
             net: f.netBalance,
             confidence: f.confidence,
-          }));
+          })).sort((a, b) => a.month.localeCompare(b.month));
           setMonthly(mapped);
           setQuarterly(generateQuarterlyForecast(mapped));
         } else if (active) {


### PR DESCRIPTION
## Summary
Fixes #1227

`getForecasts` (`src/lib/forecastUtils.ts:235`) orders by `month desc`, so the loaded `monthly` (and derived `quarterly`) arrays were newest-first. `ForecastComparison.tsx` fed that array straight into the charts and called `calculateTrend` on it.

- The time axis ran right-to-left (e.g. `2027-08 -> 2026-09`) and the "Net Balance Trend" was backwards.
- `calculateTrend` (`forecastUtils.ts:165`) takes `data.slice(-3)` as "recent", but on a desc array `slice(-3)` is the **oldest** three entries, so the up/down arrow was **inverted**.

The freshly-generated branch returns ascending months, so the bug only appeared after the first reload/persist — making it intermittent and easy to miss.

## Fix
Sort ascending when mapping results in the load effect:

```diff
  const mapped: MonthlyForecast[] = existing.map((f) => ({
    month: f.month,
    ...
- }));
+ })).sort((a, b) => a.month.localeCompare(b.month));
  setMonthly(mapped);
  setQuarterly(generateQuarterlyForecast(mapped));
```

Chart data and trend calculations now run ascending by month, matching the generated branch.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._