### PR TITLE
fix(insights): filter dismissed anomalies and remove dead code

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -13,7 +13,6 @@
  *  - Generating plain-language summaries of spending behaviour
  *  - Calculating category trends (week-over-week, month-over-month)
  */
-import { detectAnomalies as detectAnomaliesCanonical } from './anomalyUtils';
 import { collection, getDocs, query, where, orderBy, limit } from "firebase/firestore";
 import {
   startOfWeek,
@@ -248,8 +247,9 @@ export function detectAnomalies(
   const anomalies = detectAnomaliesCore(coreTransactions);
   const insights: Insight[] = anomalies
     .filter((a) => a.type === "large_transaction") // insights only surfaces large-transaction anomalies
+    .filter((a) => !ignoredTransactionIds?.has(a.transactionId || ""))
     .map((a) => ({
-      id: a.id || uid(),
+      id: a.transactionId || a.id || uid(),
       userId: a.userId,
       type: "anomaly" as const,
       category: a.category,
@@ -262,21 +262,6 @@ export function detectAnomalies(
     }));
 
   return insights.sort((a, b) => b.amount - a.amount);
-  const rawAnomalies = detectAnomaliesCanonical(transactions);
-
-  return rawAnomalies.map((item, idx) => {
-    const anomalyId = `anomaly-${idx}-${Date.now()}`;
-    return {
-      id: anomalyId,
-      type: 'anomaly' as const,
-      title: 'description' in item && typeof item.description === 'string'
-        ? item.description
-        : 'Transaction Anomaly Detected',
-      description: item.description || 'Anomalous financial pattern detected.',
-      severity: (item.severity as 'low' | 'medium' | 'high') || 'medium',
-      date: item.date ? new Date(item.date) : new Date(),
-    };
-  }).filter((item) => !ignoredTransactionIds?.has(item.id));
 }
 // ---------------------------------------------------------------------------
 // 3. Savings opportunities


### PR DESCRIPTION
## Summary
Fixes #1221

`buildInsights` -> `detectAnomalies` (`src/lib/insightsUtils.ts:248-264`) built the anomaly insights but never referenced the `ignoredTransactionIds` parameter. The only code honoring `ignoredTransactionIds` lived in the unreachable block after the early `return` at line 264 (lines 265-279). `InsightsDashboard` passes `dismissedTransactionIds` (source transaction ids from dismissed Firestore anomaly docs) expecting dismissed anomalies to be filtered out.

Two compounding bugs:
1. **Dead code** — `return insights.sort(...)` ran before the filtering block, so the filter never executed.
2. **Unmatchable ids** — even if reached, the dead filter compared `ignoredTransactionIds` (transaction ids) against insight `id`s built as `a.id || uid()`. `detectAnomaliesCore` (anomalyUtils) omits `id` from its return type, so every insight got a fresh random `uid()` — the filter could never match.

## Fix
- Filter by `a.transactionId` before mapping (matching the `dismissedTransactionIds` set built from `anomaly.transactionId`).
- Set the insight `id` to the source `transactionId` so dismissal keys line up.
- Remove the unreachable post-return block and its now-unused `detectAnomaliesCanonical` import.

```diff
  const insights: Insight[] = anomalies
    .filter((a) => a.type === "large_transaction")
+   .filter((a) => !ignoredTransactionIds?.has(a.transactionId || ""))
    .map((a) => ({
-     id: a.id || uid(),
+     id: a.transactionId || a.id || uid(),
      ...
    }));
  return insights.sort((a, b) => b.amount - a.amount);
- const rawAnomalies = detectAnomaliesCanonical(transactions);
- return rawAnomalies.map(...).filter((item) => !ignoredTransactionIds?.has(item.id));
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._