### PR TITLE
fix(subscriptions): use annualizationFactor in SubscriptionCard

### DIFF
--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -18,6 +18,7 @@ import { formatCurrency } from "@/src/lib/utils";
 import {
   updateSubscription,
   deleteSubscription,
+  getAnnualizationFactor,
 } from "@/src/lib/subscriptionUtils";
 
 interface SubscriptionCardProps {
@@ -219,29 +220,18 @@ export function SubscriptionCard({
                 </span>
                 <span className="text-indigo-400 font-mono font-bold">
                   {formatCurrency(
-                    subscription.amount *
-                    (subscription.frequency === "monthly"
-                      ? 12
-                      : subscription.frequency === "yearly"
-                        ? 1
-                        : 52)
+                    subscription.amount * getAnnualizationFactor(subscription)
                   )}
                 </span>
               </div>
               <Progress
-                value={
-                  subscription.frequency === "monthly"
-                    ? 100 / 12
-                    : subscription.frequency === "yearly"
-                      ? 100
-                      : 100 / 52
-                }
+                value={100 / getAnnualizationFactor(subscription)}
                 className="h-1.5 bg-slate-800"
               >
                 <div
                   className="h-full bg-indigo-500 rounded-full transition-all"
                   style={{
-                    width: `${subscription.frequency === "monthly" ? 100 / 12 : subscription.frequency === "yearly" ? 100 : 100 / 52}%`,
+                    width: `${100 / getAnnualizationFactor(subscription)}%`,
                   }}
                 />
               </Progress>


### PR DESCRIPTION
## Summary
Fixes #1234

`SubscriptionCard` (`src/components/subscriptions/SubscriptionCard.tsx:220-245`) computed annual cost and the progress bar using hard-coded factors `12 / 1 / 52`, ignoring the per-subscription `annualizationFactor` that `calculateSubscriptionCosts` / `calculateCategoryGroups` correctly use.

For a bi-weekly subscription detected with `annualizationFactor: 26`, the dashboard showed `amount*26` annually in the analyzer but `amount*52` in the card — the two UI surfaces contradicted each other.

## Fix
Use `getAnnualizationFactor(subscription)` (already exported by `subscriptionUtils.ts`; prefers the stored observed-interval factor, falls back to the frequency default) for both the annual cost and the per-charge progress fraction:

```diff
- {formatCurrency(subscription.amount * (frequency === "monthly" ? 12 : frequency === "yearly" ? 1 : 52))}
+ {formatCurrency(subscription.amount * getAnnualizationFactor(subscription))}

- <Progress value={frequency === "monthly" ? 100/12 : frequency === "yearly" ? 100 : 100/52} ...>
+ <Progress value={100 / getAnnualizationFactor(subscription)} ...>
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._