### PR TITLE
fix(forecast): apply defaultProbabilityModifier to MultiScenarioMatrix

### DIFF
--- a/src/components/forecast/MultiScenarioMatrix.tsx
+++ b/src/components/forecast/MultiScenarioMatrix.tsx
@@ -28,10 +28,16 @@ export const MultiScenarioMatrix: React.FC = () => {
 
   const chartData = months.map((month, idx) => {
     const dataPoint: Record<string, any> = { month };
+    const timeFraction = (idx + 1) / 12;
     scenarios.forEach((scen) => {
-      const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * ((idx + 1) / 12);
-      const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * ((idx + 1) / 12);
-      const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor));
+      const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * timeFraction;
+      const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * timeFraction;
+      // defaultProbabilityModifier scales cumulative risk-of-default across the
+      // year: a positive modifier (higher default risk) reduces projected net
+      // cash, a negative one (lower risk) raises it. Without this the
+      // default-probability dimension had no effect on the projection.
+      const defaultFactor = 1 - (scen.defaultProbabilityModifier / 100) * timeFraction;
+      const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor) * defaultFactor);
       dataPoint[scen.name] = netCash;
     });
     return dataPoint;


### PR DESCRIPTION
## Summary
Fixes #1132

`MultiScenarioMatrix.tsx` carried a `defaultProbabilityModifier` field on every scenario (including custom scenarios created via `ScenarioEditorModal`), but the projection math only used `revenueGrowthModifier` and `expenseInflationModifier`. The default-probability dimension had no effect.

A scenario that differed from Baseline only by its default-probability modifier produced a visibly identical line, so users could not compare risk-of-default across scenarios.

## Fix
Scale the projected net cash by a cumulative default factor across the year:

```diff
+ const timeFraction = (idx + 1) / 12;
  scenarios.forEach((scen) => {
-   const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * ((idx + 1) / 12);
-   const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * ((idx + 1) / 12);
+   const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * timeFraction;
+   const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * timeFraction;
+   const defaultFactor = 1 - (scen.defaultProbabilityModifier / 100) * timeFraction;
-   const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor));
+   const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor) * defaultFactor);
  });
```

A positive modifier (e.g. Bear Market = +10) cumulatively reduces the curve; a negative one (e.g. Bull Expansion = -2) raises it.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._