### PR TITLE
fix(analyze): clamp sentiment_score to [-1, 1] in validateAnalysisPayload

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -271,7 +271,10 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
     action_items: Array.isArray(payload.action_items)
       ? payload.action_items.map((v: unknown) => sanitizeString(String(v)))
       : [],
-    sentiment_score: Number(payload.sentiment_score || 0),
+    sentiment_score: Math.max(
+      -1,
+      Math.min(1, Number.isFinite(Number(payload.sentiment_score)) ? Number(payload.sentiment_score) : 0),
+    ),
     entities: Array.isArray(payload.entities)
       ? payload.entities.map((v: unknown) => sanitizeString(String(v)))
       : [],


### PR DESCRIPTION
## Summary
Fixes #1123

`validateAnalysisPayload` (`api/analyze.ts`) accepted any LLM-returned number as `sentiment_score` (`Number(payload.sentiment_score || 0)`) with no clamping. A model returning `5`, `-3`, or `42` stored an out-of-range sentiment that broke downstream consumers expecting a `[-1, 1]` range.

## Fix
Clamp the value to `[-1, 1]`, defaulting to `0` for non-finite values:

```diff
- sentiment_score: Number(payload.sentiment_score || 0),
+ sentiment_score: Math.max(-1, Math.min(1, Number.isFinite(Number(payload.sentiment_score)) ? Number(payload.sentiment_score) : 0)),
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._