### PR TITLE
fix(rag): drop zero-score chunks from similaritySearch

### DIFF
--- a/src/lib/rag/vectorStore.ts
+++ b/src/lib/rag/vectorStore.ts
@@ -79,6 +79,7 @@ export class InMemoryVectorStore {
     });
 
     return scored
+      .filter((c) => c.score > 0)
       .sort((a, b) => b.score - a.score)
       .slice(0, topK);
   }


### PR DESCRIPTION
## Summary
Fixes #1107

`similaritySearch` (`src/lib/rag/vectorStore.ts`) returned the top-K chunks by score even when every score was `0`. A zero cosine similarity (sparse embeddings share no vocabulary with the query) means no relevance, yet such chunks were still surfaced whenever the corpus was small or the query shared no terms with any chunk.

## Fix
Drop zero-score chunks before slicing the top-K so retrieval only returns genuinely relevant hits:

```diff
  return scored
+   .filter((c) => c.score > 0)
    .sort((a, b) => b.score - a.score)
    .slice(0, topK);
```

When no chunk shares any terms with the query, `similaritySearch` now returns `[]` instead of misleading zero-relevance hits.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._