### PR TITLE
fix(chatAgent): truncate observations at whitespace boundary

### DIFF
--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -289,11 +289,16 @@ function parseAgentJson(text: string): Record<string, unknown> | null {
   return null;
 }
 
-function summariseObservation(obs: unknown): string {
+function summariseObservation(obs: unknown, limit = 4000): string {
   try {
     const json = JSON.stringify(obs);
-    // Keep observations compact so they fit in the model context.
-    return json.length > 2000 ? json.slice(0, 2000) + "…" : json;
+    if (json.length <= limit) return json;
+    // Cut at the last whitespace boundary at or before the limit so we never
+    // split inside a number or JSON token (which would corrupt the figure the
+    // model reads and cites). Fall back to a hard cut only if there is no
+    // whitespace in range.
+    const cut = json.lastIndexOf(" ", limit);
+    return json.slice(0, cut > 0 ? cut : limit) + " …(truncated)";
   } catch {
     return String(obs);
   }


### PR DESCRIPTION
## Summary
Fixes #1244

`summariseObservation` (`src/lib/chatAgent.ts:283-291`) truncated every tool observation at a hard **2000-character offset**: `json.slice(0, 2000) + "…"`. There was no awareness of token/number boundaries.

The cut routinely sliced through a number, a JSON key, or an array element, so the model read a truncated figure (e.g. `…"totalSpending":1234`) or malformed JSON and cited/computed from the corrupted value — directly undermining the agent's "every figure must come from a tool" guarantee.

## Fix
Cut at the last whitespace boundary at or before the limit (default `4000`) so a number/JSON token is never split; fall back to a hard cut only when there is no whitespace in range:

```diff
- function summariseObservation(obs: unknown): string {
-   try {
-     const json = JSON.stringify(obs);
-     return json.length > 2000 ? json.slice(0, 2000) + "…" : json;
-   } catch { return String(obs); }
- }
+ function summariseObservation(obs: unknown, limit = 4000): string {
+   try {
+     const json = JSON.stringify(obs);
+     if (json.length <= limit) return json;
+     const cut = json.lastIndexOf(" ", limit);
+     return json.slice(0, cut > 0 ? cut : limit) + " …(truncated)";
+   } catch { return String(obs); }
+ }
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._