### PR TITLE
fix(rollover): base utilization % and unused badge on effective limit

### DIFF
--- a/src/components/rollover/RolloverManager.tsx
+++ b/src/components/rollover/RolloverManager.tsx
@@ -293,7 +293,11 @@ export function RolloverManager({ user }: RolloverManagerProps) {
               const rolloverAmount = category.rolloverEnabled
                 ? calculateRolloverAmount(unusedBudget, category.rolloverPercentage)
                 : 0;
-              const rolloverPercentage = category.monthlyLimit > 0 ? (unusedBudget / category.monthlyLimit) * 100 : 0;
+              // Effective limit = base limit + already-rolled-over amount, so the
+              // utilization % and "unused" badge stay consistent with the
+              // "Effective Limit" display (which uses monthlyLimit + rolledOverAmount).
+              const effectiveLimit = category.monthlyLimit + (category.rolledOverAmount || 0);
+              const rolloverPercentage = effectiveLimit > 0 ? (unusedBudget / effectiveLimit) * 100 : 0;
 
               return (
                 <motion.div
@@ -316,7 +320,7 @@ export function RolloverManager({ user }: RolloverManagerProps) {
                             )}
                             {unusedBudget > 0 && (
                               <Badge className="bg-indigo-500/10 text-indigo-400 border-indigo-500/30 text-[10px] font-bold uppercase tracking-wider">
-                                {formatCurrency(unusedBudget)} unused
+                                {formatCurrency(Math.max(0, unusedBudget - (category.rolledOverAmount || 0)))} unused
                               </Badge>
                             )}
                           </div>


### PR DESCRIPTION
## Summary
Fixes #1242

In `RolloverManager.tsx`, the "Unused %" bar was computed against the **base** monthly limit, not the effective limit:
- `rolloverPercentage` (line 296): `category.monthlyLimit > 0 ? (unusedBudget / category.monthlyLimit) * 100 : 0`
- The "unused" badge (lines 317-321) showed `unusedBudget` even after a rollover had already carried the surplus forward.

`calculateRolloverAmount` and the "Effective Limit" display (lines 345-349) correctly use `monthlyLimit + rolledOverAmount`, so the percentage was internally inconsistent with them.

## Fix
- Base the utilization % on the effective limit (`monthlyLimit + rolledOverAmount`).
- Show the "unused" badge net of the already-rolled amount.

```diff
- const rolloverPercentage = category.monthlyLimit > 0 ? (unusedBudget / category.monthlyLimit) * 100 : 0;
+ const effectiveLimit = category.monthlyLimit + (category.rolledOverAmount || 0);
+ const rolloverPercentage = effectiveLimit > 0 ? (unusedBudget / effectiveLimit) * 100 : 0;

  {formatCurrency(unusedBudget)} unused
+ {formatCurrency(Math.max(0, unusedBudget - (category.rolledOverAmount || 0)))} unused
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._