### PR TITLE
fix(goals): skip paused goals in the auto-complete effect

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -132,7 +132,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
   useEffect(() => {
     if (!user) return;
     goals.forEach((goal) => {
-      if (goal.status === 'completed') return;
+      if (goal.status === 'completed' || goal.status === 'paused') return;
       if (notifiedGoalIds.current.has(goal.id)) return;
       if (updatingGoalIds.current.has(goal.id)) return;
       const isComplete = goal.currentAmount >= goal.targetAmount;


### PR DESCRIPTION
## Summary
Fixes #1236

The goal-auto-complete effect (`src/components/goals/GoalPlanner.tsx:134-150`) only skipped `goal.status === 'completed'`. It did **not** skip `paused` goals.

A goal the user deliberately paused that happened to be fully funded (`currentAmount >= targetAmount`) was silently flipped to `completed` on the next `goals` change. Users could not keep a funded goal paused.

## Fix
Skip paused goals as well so they remain paused:

```diff
- if (goal.status === 'completed') return;
+ if (goal.status === 'completed' || goal.status === 'paused') return;
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._