### PR TITLE
fix(trends): skip transactions with invalid dates instead of rebucketing to now

### DIFF
--- a/src/lib/trendsUtils.ts
+++ b/src/lib/trendsUtils.ts
@@ -173,7 +173,8 @@ export function groupByCategoryAndPeriod(
 
   transactions.forEach((t) => {
     if (normalizeTransactionType(t.type) !== 'expense') return;
-    const tDate = toDate(t.date) || new Date();
+    const tDate = toDate(t.date);
+    if (!tDate) return;
     const key = isMonth ? formatMonthKey(tDate) : formatWeekKey(tDate);
     if (!byCategory.has(t.category)) {
       const base: CategoryPeriodDatum = { category: t.category };
@@ -206,7 +207,8 @@ export function generateMonthlyComparison(
   const map = new Map<string, CategoryPeriodDatum>();
   transactions.forEach((t) => {
     if (normalizeTransactionType(t.type) !== 'expense') return;
-    const tDate = toDate(t.date) || new Date();
+    const tDate = toDate(t.date);
+    if (!tDate) return;
     const key = formatMonthKey(tDate);
     if (!key.match(/^\d{4}-\d{2}$/)) return;
     if (!map.has(t.category)) {
@@ -237,7 +239,8 @@ export function generateWeeklyComparison(
   const map = new Map<string, CategoryPeriodDatum>();
   transactions.forEach((t) => {
     if (normalizeTransactionType(t.type) !== 'expense') return;
-    const tDate = toDate(t.date) || new Date();
+    const tDate = toDate(t.date);
+    if (!tDate) return;
     const key = formatWeekKey(tDate);
     if (!map.has(t.category)) {
       const base: CategoryPeriodDatum = { category: t.category };
@@ -303,7 +306,8 @@ export function generateTrendLines(
   transactions.forEach((t) => {
     if (normalizeTransactionType(t.type) !== 'expense') return;
     if (filterCategory && t.category !== filterCategory) return;
-    const tDate = toDate(t.date) || new Date();
+    const tDate = toDate(t.date);
+    if (!tDate) return;
     const key = formatMonthKey(tDate);
     if (matrix.has(key)) {
       const monthMap = matrix.get(key)!;


### PR DESCRIPTION
## Summary
Fixes #1372

`generateTrendLines` and siblings in `src/lib/trendsUtils.ts` reassigned missing/unparseable transaction dates to the current period (`toDate(t.date) || new Date()`) at four sites (lines 176, 209, 240, 306), while the `CategoryTrends.tsx` pie chart **skips** invalid dates.

A null date was bucketed into the current month/week, corrupting the current period's category totals, distribution, and trend lines, and making the bar/line charts disagree with the pie chart on the same dataset.

## Fix
Skip unparseable dates at all four sites instead of polluting the current period:

```diff
- const tDate = toDate(t.date) || new Date();
- const key = formatMonthKey(tDate);
+ const tDate = toDate(t.date);
+ if (!tDate) return;
+ const key = formatMonthKey(tDate);
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._