### PR TITLE
fix(chat): route savings before the generic advice token

### DIFF
--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -279,6 +279,11 @@ export function generateChatResponse(
     const result = generateSpendingSummary(context);
     response = result.message;
     chartData = result.chartData;
+  } else if (lowerMessage.includes('saving') || lowerMessage.includes('savings')) {
+    // Check savings before the generic 'advice'/'budget' token, otherwise
+    // "give me savings advice" is hijacked by the budget branch (issue #1371).
+    const result = generateSavingsRecommendations(context);
+    response = result.message;
   } else if (lowerMessage.includes('budget') || lowerMessage.includes('advice')) {
     const result = generateBudgetAdvice(context);
     response = result.message;
@@ -287,9 +292,6 @@ export function generateChatResponse(
     response = result.message;
     chartData = result.chartData;
     suggestions = result.suggestions;
-  } else if (lowerMessage.includes('saving') || lowerMessage.includes('savings')) {
-    const result = generateSavingsRecommendations(context);
-    response = result.message;
   } else if (lowerMessage.includes('pattern') || lowerMessage.includes('trend')) {
     const result = analyzeSpendingPatterns(context);
     response = result.message;


### PR DESCRIPTION
## Summary
Fixes #1371

The keyword router (`src/lib/chatUtils.ts:278-303`) checked `budget`/`advice` **before** `saving`/`savings`, so any message containing `advice` (e.g. "give me savings advice", "advice on how to save more") was routed to `generateBudgetAdvice` and the savings branch became unreachable for those queries.

## Fix
Move the `saving`/`savings` check ahead of `budget`/`advice` so the more specific intent wins:

```diff
  } else if (lowerMessage.includes('saving') || lowerMessage.includes('savings')) {
    const result = generateSavingsRecommendations(context);
    response = result.message;
  } else if (lowerMessage.includes('budget') || lowerMessage.includes('advice')) {
    const result = generateBudgetAdvice(context);
    response = result.message;
  }
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._