### PR TITLE
fix(chat): parse yyyy-MM month labels locally to avoid UTC off-by-one

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -46,7 +46,7 @@ import {
   Cell,
   Legend,
 } from 'recharts';
-import { format, startOfMonth, subMonths } from 'date-fns';
+import { format, startOfMonth, subMonths, parseISO } from 'date-fns';
 
 import { Card, CardContent } from '@/src/components/ui/card';
 import { Button } from '@/src/components/ui/button';
@@ -383,7 +383,7 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
               dataKey="month"
               stroke="#94a3b8"
               fontSize={11}
-              tickFormatter={(value) => format(new Date(value), 'MMM yyyy')}
+              tickFormatter={(value) => format(parseISO(`${value}-01`), 'MMM yyyy')}
             />
             <YAxis stroke="#94a3b8" fontSize={11} tickFormatter={(value) => formatCurrency(value)} />
             <Tooltip


### PR DESCRIPTION
## Summary
Fixes #1368

The chat spending chart's X-axis (`src/components/chat/ChatAssistant.tsx:386`) parsed a `yyyy-MM` string as **UTC** midnight:

```tsx
tickFormatter={(value) => format(new Date(value), 'MMM yyyy')}
```

`month` is produced via `format(t.date, 'yyyy-MM')` in `chatUtils.ts`. `new Date("2024-01")` is parsed as UTC midnight Jan 1, but `format` (date-fns) renders in the **local** timezone. In any negative-offset zone (the Americas, much of Europe in winter), `new Date("2024-01")` rendered as `Dec 2023` — every month label shifted back one month.

## Fix
Parse with `parseISO` on a full `yyyy-MM-01` string so the date is read in local time:

```diff
- import { format, startOfMonth, subMonths } from 'date-fns';
+ import { format, startOfMonth, subMonths, parseISO } from 'date-fns';

- tickFormatter={(value) => format(new Date(value), 'MMM yyyy')}
+ tickFormatter={(value) => format(parseISO(`${value}-01`), 'MMM yyyy')}
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._