### PR TITLE
fix(goals): return 0 instead of NaN for invalid deadline in calculateMonthlyContribution

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -26,9 +26,11 @@ export function calculateMonthlyContribution(
   if (remaining <= 0) return 0;
 
   // Guard against empty/invalid deadlines so we never return NaN downstream.
-  if (!deadline) return NaN;
+  // Return 0 (not NaN) so callers like formatCurrency render "\$0" instead of
+  // "NaN" when the deadline is missing or unparseable (issue #1352).
+  if (!deadline) return 0;
   const deadlineDate = new Date(deadline);
-  if (Number.isNaN(deadlineDate.getTime())) return NaN;
+  if (Number.isNaN(deadlineDate.getTime())) return 0;
 
   const now = new Date();
   // A past-due deadline is "overdue": no monthly contribution applies.


### PR DESCRIPTION
## Summary
Fixes #1352

`calculateMonthlyContribution` (`src/lib/goalUtils.ts:20-33`) returned `NaN` when the deadline was missing or unparseable. That poisoned the `project_goal` tool output (`{ monthlyContribution: NaN, conservative: NaN, aggressive: NaN, timeline: [] }`) and surfaced as literal `NaN` to the user via `formatCurrency`.

The `project_goal` tool calls `calculateMonthlyContribution(target, current, String(args.deadline ?? ""))`, so an omitted deadline became `new Date("")` → `Invalid Date` → `differenceInDays` → `NaN` → `Math.max(1, NaN)` → `NaN` → `Math.ceil(remaining / NaN)` = `NaN`.

## Fix
Return `0` (a safe value) for missing/invalid deadlines, matching the sibling `calculateDaysRemaining` guard, so the user sees `/bin/bash` instead of `NaN`:

```diff
- if (!deadline) return NaN;
+ if (!deadline) return 0;
  const deadlineDate = new Date(deadline);
- if (Number.isNaN(deadlineDate.getTime())) return NaN;
+ if (Number.isNaN(deadlineDate.getTime())) return 0;
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._