### PR TITLE
fix(goals): return 0 instead of NaN for invalid deadline in generateContributionSuggestions

### DIFF
--- a/src/lib/goalUtils.ts
+++ b/src/lib/goalUtils.ts
@@ -60,11 +60,12 @@ export function generateContributionSuggestions(
   const remaining = targetAmount - currentAmount;
   if (remaining <= 0) return [{ label: 'Goal reached', amount: 0 }];
 
-  // Guard against empty/invalid deadlines; return a NaN sentinel (consistent
-  // with calculateMonthlyContribution) instead of poisoning formatCurrency.
-  if (!deadline) return [{ label: 'No deadline set', amount: NaN }];
+  // Guard against empty/invalid deadlines; return 0 (not a NaN sentinel) so
+  // formatCurrency renders \$0 instead of "NaN" (consistent with the
+  // calculateMonthlyContribution guard added for issue #1375).
+  if (!deadline) return [{ label: 'No deadline set', amount: 0 }];
   const deadlineDate = new Date(deadline);
-  if (Number.isNaN(deadlineDate.getTime())) return [{ label: 'No deadline set', amount: NaN }];
+  if (Number.isNaN(deadlineDate.getTime())) return [{ label: 'No deadline set', amount: 0 }];
 
   const now = new Date();
   if (differenceInDays(deadlineDate, now) <= 0) {


### PR DESCRIPTION
## Summary
Fixes #1375

`generateContributionSuggestions` (`src/lib/goalUtils.ts`) returned a `{ label: 'No deadline set', amount: NaN }` sentinel for a missing or unparseable deadline, which surfaced as literal `NaN` to the user via `formatCurrency`.

## Fix
Return `amount: 0` (a safe value) for missing/invalid deadlines so the suggestion renders `/bin/bash` instead of `NaN`, consistent with the `calculateMonthlyContribution` guard:

```diff
- if (!deadline) return [{ label: 'No deadline set', amount: NaN }];
+ if (!deadline) return [{ label: 'No deadline set', amount: 0 }];
  const deadlineDate = new Date(deadline);
- if (Number.isNaN(deadlineDate.getTime())) return [{ label: 'No deadline set', amount: NaN }];
+ if (Number.isNaN(deadlineDate.getTime())) return [{ label: 'No deadline set', amount: 0 }];
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._