### PR TITLE
fix(chat): sort spending-pattern month keys lexicographically

### DIFF
--- a/src/lib/chatUtils.ts
+++ b/src/lib/chatUtils.ts
@@ -356,7 +356,10 @@ export function generateBudgetAdvice(context: FinancialContext): ChatResponse {
 
 export function analyzeSpendingPatterns(context: FinancialContext): ChatResponse {
   const { monthlySpending, spendingByMonth } = context;
-  const months = Object.keys(monthlySpending).sort((a: any, b: any) => Number(a) - Number(b));
+  // "yyyy-MM" keys sort lexicographically = chronologically; Number("2024-01")
+  // is NaN, so the previous comparator left the order undefined and paired
+  // non-consecutive months when computing increases/decreases (issue #1326).
+  const months = Object.keys(monthlySpending).sort();
   let response = '';
 
   if (months.length < 2) {


### PR DESCRIPTION
## Summary
Fixes #1326

`analyzeSpendingPatterns` (`src/lib/chatUtils.ts:359`) sorted month keys with `Number(a) - Number(b)`:

```ts
const months = Object.keys(monthlySpending).sort((a, b) => Number(a) - Number(b));
```

The keys are strings like `"2024-01"`. `Number("2024-01")` is `NaN`, so the comparator returned `NaN` and the sort order was undefined/implementation-dependent. The `months` array pairs consecutive months when computing increases/decreases, so a `NaN` sort could pair non-consecutive months and report false trends.

## Fix
Sort lexicographically (which for zero-padded `yyyy-MM` equals chronological order):

```diff
- const months = Object.keys(monthlySpending).sort((a, b) => Number(a) - Number(b));
+ const months = Object.keys(monthlySpending).sort();
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._