### PR TITLE
fix(api): set Access-Control-Allow-Credentials on credentialed CORS

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -108,6 +108,10 @@ function applyCors(req: IncomingMessage, res: ServerResponse): void {
   if (origin && allowed.has(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
     res.setHeader("Vary", "Origin");
+    // These handlers authenticate via the Authorization header (a credential);
+    // credentialed cross-origin requests require this flag and an exact origin
+    // (not "*"), otherwise browsers block the authenticated call (issue #1353).
+    res.setHeader("Access-Control-Allow-Credentials", "true");
   } else if (!origin && process.env.NODE_ENV !== "production") {
     res.setHeader("Access-Control-Allow-Origin", "*");
   }

--- a/api/process.ts
+++ b/api/process.ts
@@ -104,6 +104,10 @@ function applyCors(req: any, res: any): void {
   if (origin && allowed.has(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
     res.setHeader("Vary", "Origin");
+    // These handlers authenticate via the Authorization header (a credential);
+    // credentialed cross-origin requests require this flag and an exact origin
+    // (not "*"), otherwise browsers block the authenticated call (issue #1353).
+    res.setHeader("Access-Control-Allow-Credentials", "true");
   } else if (!origin && !process.env.NODE_ENV?.includes("production")) {
     // Non-browser / same-origin tooling in development
     res.setHeader("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
## Summary
Fixes #1353

`applyCors` in `api/analyze.ts` and `api/process.ts` echoed the allowed origin and `Vary` header but never set `Access-Control-Allow-Credentials`. These handlers authenticate via the `Authorization` header (a credential).

In a split-origin deployment (frontend host ≠ API host), the browser blocks the authenticated call per the CORS spec, leaving the API effectively broken for its intended SPA frontend — while `server.ts` (which sets the flag correctly) works.

## Fix
Set `Access-Control-Allow-Credentials: true` on the credentialed (exact-origin) branch, matching `server.ts`:

```diff
  if (origin && allowed.has(origin)) {
    res.setHeader("Access-Control-Allow-Origin", origin);
    res.setHeader("Vary", "Origin");
+   res.setHeader("Access-Control-Allow-Credentials", "true");
  }
```

Applied to both `api/analyze.ts` and `api/process.ts`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._