### PR TITLE
fix(subscriptions): anchor monthly renewal advance on the 1st to avoid day drift

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -354,11 +354,15 @@ function advanceByFrequency(
     }
     case "monthly":
     default: {
+      // Advance from the 1st of the month (a stable anchor) so the original
+      // day survives short months. Advancing from a clamped date (e.g. Feb 28
+      // for a 31st subscription) permanently shifted renewals to the 28th,
+      // predicting them ~3 days early every month thereafter (issue #1350).
       const day = originalDay ?? date.getDate();
-      const next = addMonths(date, 1);
-      const lastDayOfNextMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
-      next.setDate(Math.min(day, lastDayOfNextMonth));
-      return next;
+      const base = new Date(date.getFullYear(), date.getMonth(), 1);
+      const advanced = addMonths(base, 1);
+      const lastDay = new Date(advanced.getFullYear(), advanced.getMonth() + 1, 0).getDate();
+      return new Date(advanced.getFullYear(), advanced.getMonth(), Math.min(day, lastDay));
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1350

`advanceByFrequency` for monthly (`src/lib/subscriptionUtils.ts`) clamped the day onto the next month from the **current date**, so once a 31st-of-month subscription hit February it was clamped to the 28th and stayed there forever (`addMonths(Feb28, 1) = Mar28`).

A "31st-of-month" subscription silently and permanently shifted to the 28th after the first short month, predicting renewals ~3 days early every month thereafter. Upcoming-renewal reminders and proration were wrong.

## Fix
Advance from the **1st of the month** (a stable anchor) and re-apply the original day with a per-month clamp, so the original day survives in months that have it and only clamps in short months:

```diff
  case "monthly":
  default: {
    const day = originalDay ?? date.getDate();
-   const next = addMonths(date, 1);
-   const lastDayOfNextMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
-   next.setDate(Math.min(day, lastDayOfNextMonth));
-   return next;
+   const base = new Date(date.getFullYear(), date.getMonth(), 1);
+   const advanced = addMonths(base, 1);
+   const lastDay = new Date(advanced.getFullYear(), advanced.getMonth() + 1, 0).getDate();
+   return new Date(advanced.getFullYear(), advanced.getMonth(), Math.min(day, lastDay));
  }
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._