### PR TITLE
fix(portfolio): convert holdings to base currency before summing profit/loss

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -48,7 +48,6 @@ import {
   type Transaction,
   type PortfolioSnapshot,
   calculateTotalValue,
-  calculateProfitLoss,
   calculateAllocation,
   fetchUserHoldings,
   fetchUserTransactions,
@@ -187,8 +186,18 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
     [holdings, rates, baseCurrency],
   );
   const profitLoss = useMemo(() => {
-    return holdings.reduce((sum, h) => sum + calculateProfitLoss(h).value, 0);
-  }, [holdings]);
+    // Convert each holding's value and cost to the base currency before
+    // summing, otherwise multi-currency portfolios produce profitLoss !=
+    // totalValue - totalCost and a wrong SummaryCard (issue #1355).
+    return holdings.reduce((sum, h) => {
+      const localValue = h.quantity * h.currentPrice;
+      const localCost = h.quantity * h.avgCost;
+      if (!rates || h.currency === baseCurrency) return sum + (localValue - localCost);
+      const value = h.currency ? convertAmount(localValue, h.currency, baseCurrency, rates) : null;
+      const cost = h.currency ? convertAmount(localCost, h.currency, baseCurrency, rates) : null;
+      return sum + ((value == null ? localValue : value) - (cost == null ? localCost : cost));
+    }, 0);
+  }, [holdings, rates, baseCurrency]);
   const allocation = useMemo(
     () => calculateAllocation(holdings, rates ?? undefined, baseCurrency),
     [holdings, rates, baseCurrency],


### PR DESCRIPTION
## Summary
Fixes #1355

`calculateProfitLoss` (`src/lib/portfolioUtils.ts:187-191`) computed P/L purely in each holding's **local** currency with no `convertAmount`. The SummaryCard "Total Value"/"Total Cost" used `calculateTotalValue(..., rates, baseCurrency)` (FX-converted).

For any multi-currency portfolio, `profitLoss ≠ totalValue − totalCost`, the SummaryCard "Profit / Loss" was silently wrong, and per-holding rows showed a base-currency symbol next to a local-currency amount.

## Fix
Convert each holding's value and cost to the base currency before summing, mirroring the `totalValue`/`totalCost` useMemo:

```diff
- const profitLoss = useMemo(() => {
-   return holdings.reduce((sum, h) => sum + calculateProfitLoss(h).value, 0);
- }, [holdings]);
+ const profitLoss = useMemo(() => {
+   return holdings.reduce((sum, h) => {
+     const localValue = h.quantity * h.currentPrice;
+     const localCost = h.quantity * h.avgCost;
+     if (!rates || h.currency === baseCurrency) return sum + (localValue - localCost);
+     const value = convertAmount(localValue, h.currency, baseCurrency, rates);
+     const cost = convertAmount(localCost, h.currency, baseCurrency, rates);
+     return sum + ((value ?? localValue) - (cost ?? localCost));
+   }, 0);
+ }, [holdings, rates, baseCurrency]);
```

The now-unused `calculateProfitLoss` import is removed.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._