### PR TITLE
fix(forecast): drop spurious month-index multiplier in MultiScenarioMatrix

### DIFF
--- a/src/components/forecast/MultiScenarioMatrix.tsx
+++ b/src/components/forecast/MultiScenarioMatrix.tsx
@@ -32,7 +32,7 @@ export const MultiScenarioMatrix: React.FC = () => {
       const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * ((idx + 1) / 12);
       const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * ((idx + 1) / 12);
       const realization = Math.max(0, 1 - (scen.defaultProbabilityModifier / 100) * ((idx + 1) / 12));
-      const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor) * realization);
+      const netCash = Math.round(baseMonthlyCash * (growthFactor / expenseFactor) * realization);
       dataPoint[scen.name] = netCash;
     });
     return dataPoint;


### PR DESCRIPTION
## Summary
Fixes #1357

`MultiScenarioMatrix.tsx:34` multiplied the per-month net cash by the month index:

```tsx
const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor));
```

`growthFactor`/`expenseFactor` are already the per-month multipliers; the extra `* (idx + 1)` had no legitimate role. For December (`idx = 11`) the value was ~12× the January value, so the scenario curves and the "Net Balance" tooltip were inflated ~12× and showed a meaningless monotonic ramp.

## Fix
Compute `netCash` as the per-month figure:

```diff
- const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor));
+ const netCash = Math.round(baseMonthlyCash * (growthFactor / expenseFactor));
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._