### PR TITLE
fix(challenges): merge with latest server value in updateChallengeProgress

### DIFF
--- a/src/lib/challengeUtils.ts
+++ b/src/lib/challengeUtils.ts
@@ -345,18 +345,23 @@ export async function createChallenge(userId: string, data: Omit<Challenge, 'id'
 }
 
 export async function updateChallengeProgress(challengeId: string, currentProgress: number): Promise<void> {
-  const snap = await getDoc(doc(db, 'challenges', challengeId));
+  const ref = doc(db, 'challenges', challengeId);
+  const snap = await getDoc(ref);
   if (!snap.exists()) return;
   const data = snap.data() as Challenge;
   if (data.isCompleted) return;
   const targetAmount = data.targetAmount ?? 0;
-  const completed = currentProgress >= targetAmount && targetAmount > 0;
-  const patch: Record<string, unknown> = { currentProgress };
+  // Take the max of the latest server value and the caller-computed value so
+  // concurrent "Log progress" clicks (both computed from the same stale
+  // onSnapshot snapshot) never clobber each other's increment (issue #1319).
+  const resolvedProgress = Math.max(data.currentProgress ?? 0, currentProgress);
+  const completed = resolvedProgress >= targetAmount && targetAmount > 0;
+  const patch: Record<string, unknown> = { currentProgress: resolvedProgress };
   if (completed) {
     patch.isCompleted = true;
     patch.completedAt = serverTimestamp();
   }
-  await updateDoc(doc(db, 'challenges', challengeId), patch);
+  await updateDoc(ref, patch);
 }
 
 export async function completeChallenge(challengeId: string, badge: BadgeTier): Promise<void> {


### PR DESCRIPTION
## Summary
Fixes #1319

`updateChallengeProgress` (`src/lib/challengeUtils.ts:347-360`) set `currentProgress` to the **absolute** value passed in, sourced from the local `challenge.currentProgress` onSnapshot snapshot. If two "Log progress" clicks (or a log racing the auto-complete write) happened before `onSnapshot` refreshed `challenges`, both computed from the same stale base and the second `updateDoc` overwrote the first increment, silently dropping saved amount.

## Fix
Read the latest server value and write the **max** of (server current, caller-computed) so concurrent logs never clobber each other. The signature is preserved (callers still pass their computed `newProgress`), so no caller changes are needed:

```diff
  const data = snap.data() as Challenge;
  if (data.isCompleted) return;
  const targetAmount = data.targetAmount ?? 0;
- const completed = currentProgress >= targetAmount && targetAmount > 0;
- const patch: Record<string, unknown> = { currentProgress };
+ const resolvedProgress = Math.max(data.currentProgress ?? 0, currentProgress);
+ const completed = resolvedProgress >= targetAmount && targetAmount > 0;
+ const patch: Record<string, unknown> = { currentProgress: resolvedProgress };
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._