### PR TITLE
fix(challenges): average spending over the true analysis window

### DIFF
--- a/src/lib/challengeUtils.ts
+++ b/src/lib/challengeUtils.ts
@@ -81,15 +81,20 @@ export function deriveSpendingPattern(
   const totalIncome = income.reduce((sum, t) => sum + (Number(t.amount) || 0), 0);
   const totalExpenses = expenses.reduce((sum, t) => sum + (Number(t.amount) || 0), 0);
 
-  const months = new Set(
-    expenses
-      .map((t) => {
-        const d = toDate(t.date);
-        return d ? `${d.getFullYear()}-${d.getMonth()}` : null;
-      })
-      .filter((m): m is string => Boolean(m)),
-  ).size || 1;
-  const totalMonthlySpend = totalExpenses / months;
+  // Divide by the true analysis-window length (min month -> max month across
+  // the fetched transactions), not the count of distinct months that contain
+  // an expense. A sporadic spender (2 of 6 fetched months) previously got
+  // totalExpenses / 2, inflating the monthly baseline and every challenge
+  // target derived from it (issue #1318).
+  const allDates = transactions
+    .map((t) => toDate(t.date))
+    .filter((d): d is Date => Boolean(d));
+  const monthNums = allDates.map((d) => d.getFullYear() * 12 + d.getMonth());
+  const windowMonths =
+    allDates.length > 0
+      ? Math.max(1, Math.max(...monthNums) - Math.min(...monthNums) + 1)
+      : 1;
+  const totalMonthlySpend = totalExpenses / windowMonths;
 
   const spendIn = (predicate: (category: string) => boolean): number =>
     expenses


### PR DESCRIPTION
## Summary
Fixes #1318

`deriveSpendingPattern` (`src/lib/challengeUtils.ts:84-92`) computed the monthly average by dividing total spend by the number of **distinct months that contain at least one expense**, not the actual analysis window.

If a user spent in only 2 of 6 fetched months, `totalMonthlySpend = totalExpenses / 2`, inflating the monthly average. This skewed `calculateDifficulty`, `scaleTarget`, and every challenge target (`coffeeSpend`, `diningSpend`, etc.), setting unrealistically high "monthly" baselines for sporadic spenders.

## Fix
Divide by the true window length (min month → max month across the fetched transactions):

```diff
- const months = new Set(expenses.map(...).filter(...)).size || 1;
- const totalMonthlySpend = totalExpenses / months;
+ const allDates = transactions.map((t) => toDate(t.date)).filter((d): d is Date => Boolean(d));
+ const monthNums = allDates.map((d) => d.getFullYear() * 12 + d.getMonth());
+ const windowMonths = allDates.length
+   ? Math.max(1, Math.max(...monthNums) - Math.min(...monthNums) + 1)
+   : 1;
+ const totalMonthlySpend = totalExpenses / windowMonths;
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._