### PR TITLE
fix(chat): render forecast_cash_flow tool output as a chart

### DIFF
--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -401,6 +401,39 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
       );
     }
 
+    if (data[0]?.month !== undefined && data[0]?.projectedIncome !== undefined) {
+      // forecast_cash_flow tool output: { month, projectedIncome, projectedExpenses, projectedNet }
+      return (
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+            <XAxis
+              dataKey="month"
+              stroke="#94a3b8"
+              fontSize={11}
+              tickFormatter={(value) => format(parseISO(`${value}-01`), 'MMM yyyy')}
+            />
+            <YAxis stroke="#94a3b8" fontSize={11} tickFormatter={(value) => formatCurrency(value)} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#0f1219',
+                border: '1px solid #1e293b',
+                borderRadius: '8px',
+                color: '#f8fafc',
+              }}
+              formatter={(value: number, name: string) => [
+                formatCurrency(value),
+                name === 'projectedIncome' ? 'Income' : name === 'projectedExpenses' ? 'Expenses' : 'Net',
+              ]}
+            />
+            <Legend />
+            <Bar dataKey="projectedIncome" name="projectedIncome" fill="#10b981" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="projectedExpenses" name="projectedExpenses" fill="#ef4444" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      );
+    }
+
     if (data[0]?.name !== undefined && data[0]?.amount !== undefined) {
       return (
         <ResponsiveContainer width="100%" height={200}>


### PR DESCRIPTION
## Summary
Fixes #1369

`renderChart` (`src/components/chat/ChatAssistant.tsx:377,404`) only drew a chart when the data had an `amount` field (bar) or `name` + `amount` (pie):

```tsx
if (data[0]?.month !== undefined && data[0]?.amount !== undefined) { /* BarChart */ }
if (data[0]?.name !== undefined && data[0]?.amount !== undefined) { /* PieChart */ }
```

The agent's `forecast_cash_flow` tool returns `calculateMonthlyForecast(...)` whose elements are `{ month, projectedIncome, projectedExpenses, projectedNet, categories }` — there is **no `amount` and no `name`**. Both guards failed, so `renderChart` returned `null` and the forecast chart the agent produced was silently dropped.

## Fix
Add a forecast branch that renders projected income/expense over months (reusing the `parseISO` month-label fix from #1368 to avoid the UTC off-by-one):

```tsx
if (data[0]?.month !== undefined && data[0]?.projectedIncome !== undefined) {
  return ( /* BarChart with dataKey="projectedIncome" / "projectedExpenses" */ );
}
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._