### PR TITLE
fix(subscriptions): use the most recent charge amount when detecting subscriptions

### DIFF
--- a/src/lib/subscriptionUtils.ts
+++ b/src/lib/subscriptionUtils.ts
@@ -580,7 +580,13 @@ export async function detectAndSaveSubscriptions(
     const analysis = analyzeSubscriptionPattern(txns);
     if (!analysis || analysis.confidence < 0.4) continue;
 
-    const name = txns[0].description || key;
+    // Sort chronologically and use the most recent charge for amount/category/id
+    // so the detected cost reflects the current price, not an arbitrary first
+    // transaction in Firestore document/insertion order (issue #1365).
+    const sorted = [...txns].sort((a, b) => a.date.getTime() - b.date.getTime());
+    const latest = sorted[sorted.length - 1];
+
+    const name = latest.description || key;
 
     if (existingNames.has(name.toLowerCase())) continue;
 
@@ -594,12 +600,12 @@ export async function detectAndSaveSubscriptions(
     try {
       const id = await saveSubscription(userId, {
         name: name,
-        amount: txns[0].amount,
+        amount: latest.amount,
         frequency: analysis.frequency,
-        category: txns[0].category || "Other",
+        category: latest.category || "Other",
         nextRenewalDate: nextRenewal,
         isActive: true,
-        detectedFromTransactionId: txns[0].id,
+        detectedFromTransactionId: latest.id,
         annualizationFactor,
       });
 
@@ -607,12 +613,12 @@ export async function detectAndSaveSubscriptions(
         id,
         userId,
         name: name,
-        amount: txns[0].amount,
+        amount: latest.amount,
         frequency: analysis.frequency,
-        category: txns[0].category || "Other",
+        category: latest.category || "Other",
         nextRenewalDate: nextRenewal,
         isActive: true,
-        detectedFromTransactionId: txns[0].id,
+        detectedFromTransactionId: latest.id,
         createdAt: new Date(),
         annualizationFactor,
       });


### PR DESCRIPTION
## Summary
Fixes #1365

`detectSubscriptions` used `txns[0]` (the first transaction in the group) as the persisted `amount`, `category`, and `detectedFromTransactionId` (`src/lib/subscriptionUtils.ts:545-566`). The group order follows the input `transactions` array (Firestore document/insertion order, not chronological), so `txns[0]` is not the earliest or latest charge.

If a subscription's price changed over time (e.g. `.99` → `2.99`), the persisted `amount` captured the *old* price. The `annualizationFactor` (derived from intervals) and the displayed "Annual Cost" then disagreed with the real charge, and downstream budget/burden math used a stale figure.

## Fix
Sort each group chronologically and use the most recent charge for `amount`/`category`/`detectedFromTransactionId`:

```diff
+ const sorted = [...txns].sort((a, b) => a.date.getTime() - b.date.getTime());
+ const latest = sorted[sorted.length - 1];
- const name = txns[0].description || key;
+ const name = latest.description || key;
  ...
- amount: txns[0].amount,
- category: txns[0].category || "Other",
- detectedFromTransactionId: txns[0].id,
+ amount: latest.amount,
+ category: latest.category || "Other",
+ detectedFromTransactionId: latest.id,
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._