### PR TITLE
fix(portfolio): dedupe migrateEmbeddedHoldings by id, not symbol

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -513,7 +513,6 @@ export async function migrateEmbeddedHoldings(userId: string): Promise<number> {
     const portfolios = await fetchUserPortfolios(userId);
     const existing = await fetchUserHoldings(userId);
     const existingIds = new Set(existing.map((h) => h.id));
-    const existingSymbols = new Set(existing.map((h) => h.symbol.toUpperCase()));
     let migrated = 0;
 
     for (const portfolio of portfolios) {
@@ -526,8 +525,12 @@ export async function migrateEmbeddedHoldings(userId: string): Promise<number> {
           raw as unknown as Record<string, unknown>,
           userId,
         );
+        // Dedupe only by stable id, not symbol. Two portfolios that merely
+        // share a ticker (e.g. the same stock in "Retirement" and "Taxable")
+        // are distinct positions and must both survive; symbol dedup
+        // permanently lost the non-first portfolios' holdings after clearing
+        // the embedded arrays (issue #1356).
         if (existingIds.has(holding.id)) continue;
-        if (holding.symbol && existingSymbols.has(holding.symbol.toUpperCase())) continue;
 
         await setDoc(doc(db, 'portfolioHoldings', holding.id), {
           ...holding,
@@ -536,7 +539,6 @@ export async function migrateEmbeddedHoldings(userId: string): Promise<number> {
           updatedAt: serverTimestamp(),
         });
         existingIds.add(holding.id);
-        if (holding.symbol) existingSymbols.add(holding.symbol.toUpperCase());
         migrated += 1;
       }
 


### PR DESCRIPTION
## Summary
Fixes #1356

`migrateEmbeddedHoldings` (`src/lib/portfolioUtils.ts:500-536`) deduped purely on `symbol.toUpperCase()` (`existingSymbols`, lines 505 & 519) and then cleared **every** portfolio's embedded array (lines 532-535).

If two portfolios each hold the same ticker with different quantity/cost, only the first is migrated and the rest are skipped, then all embedded arrays are cleared — permanently losing the non-first portfolios' holdings. Symbol dedup conflates distinct positions.

## Fix
Dedupe only by stable `id` (not symbol); distinct positions that merely share a ticker (e.g. the same stock in "Retirement" and "Taxable" portfolios) must both survive:

```diff
  const existingIds = new Set(existing.map((h) => h.id));
- const existingSymbols = new Set(existing.map((h) => h.symbol.toUpperCase()));
  ...
  if (existingIds.has(holding.id)) continue;
- if (holding.symbol && existingSymbols.has(holding.symbol.toUpperCase())) continue;
  ...
  existingIds.add(holding.id);
- if (holding.symbol) existingSymbols.add(holding.symbol.toUpperCase());
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._