### PR TITLE
fix(bills): use the UTC day-of-month for recurring due-date advancement

### DIFF
--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -190,7 +190,10 @@ export function calculateNextDueDate(
   }
 
   const reference = fromDate ? startOfDay(fromDate) : startOfDay(new Date());
-  const originalDay = base.getDate();
+  // advanceByFrequency is UTC-based, so use the UTC day-of-month to avoid a
+  // local-vs-UTC mismatch that pushes the due date into the wrong day/month
+  // (issue #1358).
+  const originalDay = base.getUTCDate();
   let next = startOfDay(base);
 
   while (isBefore(next, reference)) {
@@ -212,7 +215,7 @@ export function advanceDueDateAfterPayment(
   if (!base) return null;
 
   const reference = startOfDay(paidDate);
-  const originalDay = base.getDate();
+  const originalDay = base.getUTCDate();
   let next = startOfDay(base);
 
   do {
@@ -356,7 +359,7 @@ export function generateRecurringSchedule(
 
   const schedule: string[] = [];
   const start = toDate(bill.nextDueDate || bill.dueDate) || startOfDay(reference);
-  const originalDay = start.getDate();
+  const originalDay = start.getUTCDate();
   let next = startOfDay(start);
   for (let i = 0; i < occurrences; i++) {
     schedule.push(next.toISOString());


### PR DESCRIPTION
## Summary
Fixes #1358

`advanceByFrequency` (`src/lib/billUtils.ts:71-97`) is entirely UTC-based (reads `getUTCFullYear/Month/Date`, builds `Date.UTC(...)`), but its three callers passed `base.getDate()` / `start.getDate()` — the **local** day:

```ts
// calculateNextDueDate ~193
const originalDay = base.getDate();
// advanceDueDateAfterPayment ~215
const originalDay = base.getDate();
// generateBillSchedule ~359
const originalDay = start.getDate();
```

## Actual behavior
In any timezone where the local calendar day differs from UTC (the Americas, and any non-midnight Firestore Timestamp), the intended due day is off by the UTC offset. Near month boundaries `utcMonth` may belong to a different month than `originalDay`, pushing the due date into the wrong month or clamping it via `safeDay`. Due-date reminders and "Upcoming Bills" become wrong by a day (or land in the wrong month).

## Fix
Use `getUTCDate()` so the day passed to the UTC-based `advanceByFrequency` is the UTC day:

```diff
- const originalDay = base.getDate();
+ const originalDay = base.getUTCDate();
- const originalDay = start.getDate();
+ const originalDay = start.getUTCDate();
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._