### PR TITLE
fix(bills): include one-off bills due this month in monthly obligations

### DIFF
--- a/src/lib/billUtils.ts
+++ b/src/lib/billUtils.ts
@@ -292,7 +292,7 @@ export function getDaysUntilDue(bill: Bill, reference: Date = new Date()): numbe
   return differenceInCalendarDays(startOfDay(due), startOfDay(reference));
 }
 
-export function calculateMonthlyObligations(bills: Bill[]): number {
+export function calculateMonthlyObligations(bills: Bill[], reference: Date = new Date()): number {
   return bills.reduce((total, bill) => {
     if (bill.deleted || bill.isPaid) return total;
     switch (bill.frequency) {
@@ -302,8 +302,18 @@ export function calculateMonthlyObligations(bills: Bill[]): number {
         return total + bill.amount;
       case 'yearly':
         return total + bill.amount / 12;
-      default:
-        return total;
+      default: {
+        // Custom / one-off bills are not recurring, but they are still a real
+        // cash-flow obligation in the month they fall due. Surface a one-off
+        // bill whose next/initial due date is in the current month so the
+        // per-month obligation picture agrees with the per-week "Due This
+        // Week" summary (issue #1315).
+        const due = toDate(bill.nextDueDate || bill.dueDate);
+        if (!due) return total;
+        const refMonth = reference.getUTCFullYear() * 12 + reference.getUTCMonth();
+        const dueMonth = due.getUTCFullYear() * 12 + due.getUTCMonth();
+        return dueMonth === refMonth ? total + bill.amount : total;
+      }
     }
   }, 0);
 }


### PR DESCRIPTION
## Summary
Fixes #1315

`calculateMonthlyObligations` (`src/lib/billUtils.ts:295-309`) only summed `weekly`/`monthly`/`yearly` bills; the `default` case returned `total` unchanged, so **custom / one-off bills are silently excluded** from the monthly obligation total.

## Actual behavior
A one-off `,000` tax bill due this week inflates the per-week "Due This Week" summary (via `getUpcomingBills`/`isUpcoming`, which don't filter by frequency) yet is excluded from "Monthly Obligations", so the per-week and per-month cash-flow pictures disagree and the user under-plans for known upcoming large expenses.

## Fix
Surface a one-off bill whose next/initial due date falls in the current month (matching the per-week summary's lack of frequency filter, and using UTC month comparison consistent with `advanceByFrequency`):

```diff
- export function calculateMonthlyObligations(bills: Bill[]): number {
+ export function calculateMonthlyObligations(bills: Bill[], reference: Date = new Date()): number {
  ...
  default:
-   return total;
+   const due = toDate(bill.nextDueDate || bill.dueDate);
+   if (!due) return total;
+   const refMonth = reference.getUTCFullYear() * 12 + reference.getUTCMonth();
+   const dueMonth = due.getUTCFullYear() * 12 + due.getUTCMonth();
+   return dueMonth === refMonth ? total + bill.amount : total;
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._