### PR TITLE
fix(challenges,emergency): resolve the user's base currency for display

### DIFF
--- a/src/components/challenges/ChallengeCard.tsx
+++ b/src/components/challenges/ChallengeCard.tsx
@@ -18,6 +18,7 @@ import {
 
 interface ChallengeCardProps {
   challenge: Challenge;
+  baseCurrency?: string;
   onLogProgress: (challengeId: string, amount: number) => void;
   onComplete: (challenge: Challenge) => void;
 }
@@ -33,7 +34,7 @@ const TYPE_ICON = {
   monthly: TrendingDown,
 };
 
-export function ChallengeCard({ challenge, onLogProgress, onComplete }: ChallengeCardProps) {
+export function ChallengeCard({ challenge, baseCurrency, onLogProgress, onComplete }: ChallengeCardProps) {
   const [amountInput, setAmountInput] = useState('');
   const progress = getProgressPercentage(challenge.currentProgress, challenge.targetAmount);
   const TypeIcon = TYPE_ICON[challenge.type];
@@ -90,7 +91,7 @@ export function ChallengeCard({ challenge, onLogProgress, onComplete }: Challeng
         <div className="space-y-2">
           <div className="flex items-center justify-between text-sm">
             <span className="text-slate-400">
-              {formatCurrency(challenge.currentProgress)} of {formatCurrency(challenge.targetAmount)}
+              {formatCurrency(challenge.currentProgress, baseCurrency)} of {formatCurrency(challenge.targetAmount, baseCurrency)}
             </span>
             <span className="text-white font-semibold tabular-nums">{progress}%</span>
           </div>

--- a/src/components/challenges/ChallengesDashboard.tsx
+++ b/src/components/challenges/ChallengesDashboard.tsx
@@ -23,6 +23,7 @@ import { Button } from '@/src/components/ui/button';
 import { Badge } from '@/src/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/src/components/ui/tabs';
 import { cn, formatCurrency } from '@/src/lib/utils';
+import { useBaseCurrency } from '@/src/hooks/useBaseCurrency';
 import { db, handleFirestoreError, OperationType } from '@/src/lib/firebase';
 import {
   type Challenge,
@@ -49,6 +50,7 @@ interface ChallengesDashboardProps {
 }
 
 export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
+  const baseCurrency = useBaseCurrency(user);
   const [challenges, setChallenges] = useState<Challenge[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
@@ -179,13 +181,13 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
       const newProgress = Math.min(challenge.currentProgress + amount, challenge.targetAmount);
       try {
         await updateChallengeProgress(challengeId, newProgress);
-        toast.success(`Logged ${formatCurrency(amount)} saved`);
+        toast.success(`Logged ${formatCurrency(amount, baseCurrency)} saved`);
       } catch (error) {
         handleFirestoreError(error, OperationType.UPDATE, `challenges/${challengeId}`);
         toast.error('Failed to log progress');
       }
     },
-    [challenges]
+    [challenges, baseCurrency]
   );
 
   const handleComplete = useCallback(
@@ -269,6 +271,7 @@ export function ChallengesDashboard({ user }: ChallengesDashboardProps) {
           >
             <ChallengeCard
               challenge={challenge}
+              baseCurrency={baseCurrency}
               onLogProgress={handleLogProgress}
               onComplete={handleComplete}
             />

--- a/src/components/emergency/EmergencyFundPlanner.tsx
+++ b/src/components/emergency/EmergencyFundPlanner.tsx
@@ -40,6 +40,7 @@ import { Input } from '@/src/components/ui/input';
 import { Badge } from '@/src/components/ui/badge';
 import { Progress, ProgressTrack, ProgressIndicator } from '@/src/components/ui/progress';
 import { cn, formatCurrency, toDate } from '@/src/lib/utils';
+import { useBaseCurrency } from '@/src/hooks/useBaseCurrency';
 import {
   type EmergencyFund,
   type Contribution,
@@ -62,6 +63,7 @@ interface EmergencyFundPlannerProps {
 const MONTH_OPTIONS = [3, 4, 5, 6];
 
 export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
+  const baseCurrency = useBaseCurrency(user);
   const [fund, setFund] = useState<EmergencyFund | null>(null);
   const [loading, setLoading] = useState(true);
   const [setupOpen, setSetupOpen] = useState(false);
@@ -200,7 +202,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
     const updated = await addContribution(fund, amount, contributeNote);
     if (updated) {
       setFund(updated);
-      toast.success(`Added ${formatCurrency(amount)} to your fund`);
+      toast.success(`Added ${formatCurrency(amount, baseCurrency)} to your fund`);
       setContributeAmount('');
       setContributeNote('');
     } else {
@@ -341,7 +343,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                     </label>
                     <div className="h-12 flex items-center justify-between px-4 rounded-lg bg-emerald-500/10 border border-emerald-500/30">
                       <span className="text-emerald-300 font-semibold text-lg tabular-nums">
-                        {formatCurrency(recommendedTarget)}
+                        {formatCurrency(recommendedTarget, baseCurrency)}
                       </span>
                       <span className="text-[10px] uppercase tracking-wider text-slate-500">
                         {targetMonths} × expenses
@@ -432,7 +434,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                     <div>
                       <p className="text-[10px] uppercase tracking-wider text-slate-500">Current Balance</p>
                       <p className="text-2xl font-bold text-white tabular-nums">
-                        {formatCurrency(fund.currentAmount)}
+                        {formatCurrency(fund.currentAmount, baseCurrency)}
                       </p>
                     </div>
                     <Badge
@@ -449,9 +451,9 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                   </div>
                   <div className="space-y-2">
                     <div className="flex items-center justify-between text-xs text-slate-500">
-                      <span>Progress to {formatCurrency(fund.targetAmount)}</span>
+                      <span>Progress to {formatCurrency(fund.targetAmount, baseCurrency)}</span>
                       <span className="tabular-nums">
-                        {formatCurrency(Math.max(0, fund.targetAmount - fund.currentAmount))} to go
+                        {formatCurrency(Math.max(0, fund.targetAmount - fund.currentAmount), baseCurrency)} to go
                       </span>
                     </div>
                     <Progress value={progress}>
@@ -464,7 +466,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                     </Progress>
                   </div>
                   <div className="grid grid-cols-3 gap-3">
-                    <Stat label="Monthly Save" value={formatCurrency(monthlySuggestion || fund.monthlyContribution)} />
+                    <Stat label="Monthly Save" value={formatCurrency(monthlySuggestion || fund.monthlyContribution, baseCurrency)} />
                     <Stat label="Months Covered" value={String(fund.monthsCovered)} />
                     <Stat
                       label="Est. Completion"
@@ -524,7 +526,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                     Projection
                   </CardTitle>
                   <CardDescription className="text-slate-500 text-xs">
-                    Balance growth at {formatCurrency(parseFloat(monthlyContribution) || fund.monthlyContribution)}/month
+                    Balance growth at {formatCurrency(parseFloat(monthlyContribution) || fund.monthlyContribution, baseCurrency)}/month
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -543,7 +545,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                         <Tooltip
                           contentStyle={{ backgroundColor: '#0f172a', border: '1px solid #1e293b', borderRadius: '8px', fontSize: '12px' }}
                           labelStyle={{ color: '#94a3b8' }}
-                          formatter={(value: number) => [formatCurrency(value), 'Projected']}
+                          formatter={(value: number) => [formatCurrency(value, baseCurrency), 'Projected']}
                         />
                         <Area type="monotone" dataKey="projected" stroke="#10b981" strokeWidth={2} fill="url(#efGradient)" />
                       </AreaChart>
@@ -605,7 +607,7 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
                     >
                       <div className="min-w-0">
                         <p className="text-sm font-semibold text-white tabular-nums">
-                          {formatCurrency(c.amount)}
+                          {formatCurrency(c.amount, baseCurrency)}
                         </p>
                         <p className="text-[10px] text-slate-500">
                           {format(toDate(c.date) || new Date(), 'MMM d, yyyy')}


### PR DESCRIPTION
## Summary
Fixes #1316

`ChallengesDashboard.tsx` and `EmergencyFundPlanner.tsx` never call `useBaseCurrency`. A repo-wide grep confirms neither component imports it, so every `formatCurrency` call resolves to the module-global default (USD) regardless of the user's actual base currency.

## Actual behavior
If either route is opened standalone, or before `GoalPlanner` (the only component that calls `useBaseCurrency`) has mounted, all displayed amounts — challenge targets, "saved $X" toasts, emergency fund balances and projections — render in hard-coded USD, contradicting the user's chosen base currency elsewhere in the app.

## Fix
Resolve the user's `baseCurrency` explicitly via `useBaseCurrency(user)` in both components and pass it to every `formatCurrency(...)` call:

```ts
import { useBaseCurrency } from '@/src/hooks/useBaseCurrency';
const baseCurrency = useBaseCurrency(user);
toast.success(`Logged ${formatCurrency(amount, baseCurrency)} saved`);
```

`baseCurrency` is also threaded into `ChallengeCard` (challenge target/current display) and added to `handleLogProgress`'s `useCallback` deps to avoid a stale-closure toast.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._