### PR TITLE
fix(privacy): include currencies and privacy_settings in data export

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -135,6 +135,8 @@ const USER_COLLECTIONS = [
   "tax_estimates",
   "bills",
   "activity_log",
+  "currencies",
+  "privacy_settings",
 ];
 
 export async function exportUserData(


### PR DESCRIPTION
## Summary
Fixes #1322

`exportUserData` (`src/lib/privacyUtils.ts:115-138`) walks `USER_COLLECTIONS` to build the GDPR "export my data" JSON, but the list omits the `currencies` collection (and `privacy_settings`).

## Actual behavior
A user's base currency, supported-currency list, and full `conversionHistory` are never included in their own data export — an incomplete export of personal settings, which undermines the data-portability guarantee.

## Fix
Add `currencies` and `privacy_settings` to `USER_COLLECTIONS`:

```diff
  "bills",
  "activity_log",
+ "currencies",
+ "privacy_settings",
];
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._