### PR TITLE
fix(privacy): enumerate storage objects via paginated list, not listAll

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -16,7 +16,7 @@ import {
   deleteDoc,
   type DocumentReference,
 } from "firebase/firestore";
-import { deleteObject, listAll, ref } from "firebase/storage";
+import { deleteObject, list, ref } from "firebase/storage";
 import { db, auth, storage, handleFirestoreError, OperationType } from "./firebase";
 import { DEFAULT_ROLE } from "./roleConstants";
 import { clearAllLocalData } from "./storageUtils";
@@ -223,11 +223,19 @@ async function collectStoragePaths(
   prefixRef: ReturnType<typeof ref>,
   out: Set<string>,
 ): Promise<void> {
-  const result = await listAll(prefixRef);
-  result.items.forEach((item) => out.add(item.fullPath));
-  for (const prefix of result.prefixes) {
-    await collectStoragePaths(prefix, out);
-  }
+  // Use the paginated `list` API instead of `listAll`, which Firebase
+  // documents as capped at 1000 results. A user with >1000 stored PDFs would
+  // otherwise have the remainder silently truncated and orphaned after
+  // account erasure (issue #1366).
+  let pageToken: string | undefined;
+  do {
+    const result = await list(prefixRef, { maxResults: 1000, pageToken });
+    result.items.forEach((item) => out.add(item.fullPath));
+    for (const prefix of result.prefixes) {
+      await collectStoragePaths(prefix, out);
+    }
+    pageToken = result.nextPageToken;
+  } while (pageToken);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #1366

`deleteUserStorageFiles` (`src/lib/privacyUtils.ts:222-266`) enumerated the user's PDFs solely via Firebase `listAll`, which is documented as returning **at most 1000 items**.

## Actual behavior
A user with >1000 stored documents/PDFs gets only the first ≤1000 paths deleted; the remainder are silently truncated and become **orphaned Storage objects that survive account erasure** — a privacy/data-residue violation.

## Fix
Use the paginated `list` API with `nextPageToken` so every stored object is enumerated:

```diff
- import { deleteObject, listAll, ref } from "firebase/storage";
+ import { deleteObject, list, ref } from "firebase/storage";
  ...
- const result = await listAll(prefixRef);
- result.items.forEach((item) => out.add(item.fullPath));
- for (const prefix of result.prefixes) await collectStoragePaths(prefix, out);
+ let pageToken: string | undefined;
+ do {
+   const result = await list(prefixRef, { maxResults: 1000, pageToken });
+   result.items.forEach((item) => out.add(item.fullPath));
+   for (const prefix of result.prefixes) await collectStoragePaths(prefix, out);
+   pageToken = result.nextPageToken;
+ } while (pageToken);
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._