### PR TITLE
savePortfolioSnapshot computes profitLoss/totalCost in local currency but totalValue in base currency

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -638,7 +638,7 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
               onClick={async () => {
                 if (!user || !portfolioId) return;
                 setIsSavingSnapshot(true);
-                await savePortfolioSnapshot(user.uid, portfolioId, holdings);
+                await savePortfolioSnapshot(user.uid, portfolioId, holdings, rates ?? undefined, baseCurrency);
                 const history = await fetchPortfolioHistory(user.uid, portfolioId);
                 setPerformanceHistory(history);
                 setIsSavingSnapshot(false);

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -727,10 +727,18 @@ export async function savePortfolioSnapshot(
   userId: string,
   portfolioId: string,
   holdings: Holding[],
+  rates?: Record<string, number>,
+  baseCurrency?: string,
 ): Promise<boolean> {
   try {
-    const totalValue = calculateTotalValue(holdings);
-    const totalCost = holdings.reduce((sum, h) => sum + h.avgCost * h.quantity, 0);
+    const totalValue = calculateTotalValue(holdings, rates, baseCurrency);
+    const totalCost = holdings.reduce((sum, h) => {
+      const local = h.avgCost * h.quantity;
+      if (!rates || !baseCurrency || !h.currency || h.currency === baseCurrency)
+        return sum + local;
+      const converted = convertAmount(local, h.currency, baseCurrency, rates);
+      return sum + (converted == null ? local : converted);
+    }, 0);
     const profitLoss = totalValue - totalCost;
     const profitLossPercent = totalCost > 0 ? (profitLoss / totalCost) * 100 : 0;
 


### PR DESCRIPTION
## Problem
savePortfolioSnapshot computes 	otalCost and profitLoss from holdings expressed in each holding's **local** currency, while 	otalValue is base-currency converted. The stored profitLoss/profitLossPercent compare a base-currency value against local-currency cost for any multi-currency portfolio.

## Fix
savePortfolioSnapshot now accepts optional ates/aseCurrency parameters and computes 	otalCost in the base currency using the same convertAmount conversion used for 	otalValue. The caller in PortfolioTracker.tsx passes ates and aseCurrency.

## Files changed
- src/lib/portfolioUtils.ts
- src/components/portfolio/PortfolioTracker.tsx

## Testing
- Verified an EUR holding in a USD-base portfolio yields a correct all-time return instead of a wildly wrong value.

Closes #1141
