### PR TITLE
MonteCarloSimulator treats volatility/expectedReturn as decimals but labels them as %

### DIFF
--- a/src/components/portfolio/MonteCarloSimulator.tsx
+++ b/src/components/portfolio/MonteCarloSimulator.tsx
@@ -8,8 +8,8 @@ export const MonteCarloSimulator: React.FC = () => {
   const [initialValue, setInitialValue] = useState<number>(100000);
   const [days, setDays] = useState<number>(252); // 1 trading year
   const [numSimulations, setNumSimulations] = useState<number>(1000);
-  const [volatility, setVolatility] = useState<number>(0.2); // 20% annualized vol
-  const [expectedReturn, setExpectedReturn] = useState<number>(0.08); // 8% drift
+  const [volatility, setVolatility] = useState<number>(20); // 20% annualized vol
+  const [expectedReturn, setExpectedReturn] = useState<number>(8); // 8% drift
   const [isSimulating, setIsSimulating] = useState<boolean>(false);
   const [trajectories, setTrajectories] = useState<TrajectoryPoint[]>([]);
   const [var95, setVar95] = useState<number | null>(null);
@@ -19,8 +19,10 @@ export const MonteCarloSimulator: React.FC = () => {
 
     setTimeout(() => {
       const dt = 1 / 252;
-      const drift = (expectedReturn - 0.5 * Math.pow(volatility, 2)) * dt;
-      const volStep = volatility * Math.sqrt(dt);
+      const mu = expectedReturn / 100;
+      const sigma = volatility / 100;
+      const drift = (mu - 0.5 * Math.pow(sigma, 2)) * dt;
+      const volStep = sigma * Math.sqrt(dt);
 
       const allPaths: number[][] = Array.from({ length: numSimulations }, () => [initialValue]);
 


### PR DESCRIPTION
## Problem
MonteCarloSimulator.tsx labels olatility and expectedReturn inputs as percentages ("Annual Volatility (%)") but uses them directly as decimal fractions in the GBM math. A user entering 20 for volatility yields olatility = 20, making the price path explode to Infinity/NaN.

## Fix
Converted the percentage inputs to fractions at the point of use (mu = expectedReturn / 100, sigma = volatility / 100) and updated the default state values to 20 and 8 to match the "%" labels.

## Files changed
- src/components/portfolio/MonteCarloSimulator.tsx

## Testing
- Verified entering 20 for volatility and 8 for expected return now produces a plausible price path (no Infinity/NaN).

Closes #1143
