### PR TITLE
ForecastComparison summary cards ignore the active monthly/quarterly view

### DIFF
--- a/src/components/forecast/ForecastComparison.tsx
+++ b/src/components/forecast/ForecastComparison.tsx
@@ -167,18 +167,30 @@ export function ForecastComparison({ user }: ForecastComparisonProps) {
   }, [filteredMonthly]);
 
   const totalProjectedIncome = useMemo(
-    () => filteredMonthly.reduce((s, m) => s + m.income, 0),
-    [filteredMonthly]
+    () =>
+      (activeView === "monthly"
+        ? filteredMonthly
+        : filteredQuarterly.map((q) => ({ ...q, month: q.quarter }))
+      ).reduce((s, m) => s + m.income, 0),
+    [activeView, filteredMonthly, filteredQuarterly]
   );
 
   const totalProjectedExpenses = useMemo(
-    () => filteredMonthly.reduce((s, m) => s + m.expenses, 0),
-    [filteredMonthly]
+    () =>
+      (activeView === "monthly"
+        ? filteredMonthly
+        : filteredQuarterly.map((q) => ({ ...q, month: q.quarter }))
+      ).reduce((s, m) => s + m.expenses, 0),
+    [activeView, filteredMonthly, filteredQuarterly]
   );
 
   const totalNet = useMemo(
-    () => filteredMonthly.reduce((s, m) => s + m.net, 0),
-    [filteredMonthly]
+    () =>
+      (activeView === "monthly"
+        ? filteredMonthly
+        : filteredQuarterly.map((q) => ({ ...q, month: q.quarter }))
+      ).reduce((s, m) => s + m.net, 0),
+    [activeView, filteredMonthly, filteredQuarterly]
   );
 
   const handleExport = () => {


### PR DESCRIPTION
## Problem
ForecastComparison.tsx always computes its three Summary cards from ilteredMonthly (12 monthly rows), even when the user switched the active view to **Quarterly**, so the summary disagrees with the visible chart.

## Fix
Summary totals are now derived from the active dataset: ilteredMonthly for the monthly view, or the quarterly data (mapped with month: q.quarter) for the quarterly view.

## Files changed
- src/components/forecast/ForecastComparison.tsx

## Testing
- Verified the summary cards match the chart on both the Monthly and Quarterly tabs.

Closes #1146
