### PR TITLE
EmergencyFundPlanner.handleAdjustTarget overwrites targetAmount with the monthly-contribution value

### DIFF
--- a/src/components/emergency/EmergencyFundPlanner.tsx
+++ b/src/components/emergency/EmergencyFundPlanner.tsx
@@ -210,8 +210,8 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
 
   const handleAdjustTarget = async () => {
     if (!fund) return;
-    const targetAmount = parseFloat(monthlyContribution) || fund.targetAmount;
-    const months = parseInt((document.getElementById('ef-months') as HTMLSelectElement)?.value || '6', 10) || fund.monthsCovered;
+    const targetAmount = fund.targetAmount;
+    const months = targetMonths || fund.monthsCovered;
     const newContribution = calculateMonthlySavings(targetAmount, fund.currentAmount, months);
     await updateGoal({
       targetAmount,


### PR DESCRIPTION
## Problem
EmergencyFundPlanner.tsx's handleAdjustTarget reads the **monthly-contribution** input as the new 	argetAmount, and reads a document.getElementById('ef-months') element that does not exist in the DOM. Adjusting the plan corrupts the fund's target.

## Fix
handleAdjustTarget now keeps 	argetAmount intact (und.targetAmount) and reads the months-covered value from the real 	argetMonths control, removing the nonexistent DOM lookup. The monthly contribution is recomputed from the existing target and selected months.

## Files changed
- src/components/emergency/EmergencyFundPlanner.tsx

## Testing
- Verified adjusting the plan recomputes the monthly contribution without overwriting 	argetAmount.

Closes #1150
