### PR TITLE
Selling shares overwrites holding currentPrice with the execution price, corrupting market valuation

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -360,7 +360,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
             quantity,
             avgCost,
             portfolioId: input.portfolioId,
-            currentPrice: input.price,
+            ...(input.type === 'buy' ? { currentPrice: input.price } : {}),
             updatedAt: serverTimestamp(),
           });
         }


### PR DESCRIPTION
## Problem

## Description
In `addTransaction` (`src/lib/portfolioUtils.ts:352-355`), a **sell** updates the holding with `currentPrice: input.price`. `currentPrice` is the field used everywhere as the *market* price for valuation (`calculateTotalValue`, holdings card, snapshots). On a partial sell, `currentPrice` is therefore set to the sell *execution* price rather than the true market price.

## Expected Behavior
Market price must be independent of the trade price. `currentPrice` should only be updated by buys (or never derived from a trade), so remaining shares keep their real market valuation.

## Actual Behavior
If you sell 5 of 10 shares of a stock whose true market price is `$60` but you sold at `$50`, the remaining 5 shares are valued at `5 x $50 = $250` instead of `$300`. Portfolio value, P/L, allocation and snapshots are all corrupted after every sale.

## Proposed Fix
Only write `currentPrice` on buys:
```ts
tx.update(holdingRef, {
  quantity,
  avgCost,
  ...(input.type === 'buy' ? { currentPrice: input.price } : {}),
  updatedAt: serverTimestamp(),
});
```
For sells, keep the existing `currentPrice` (or refresh it from a market-price source if available).

## Fix

fix: do not overwrite holding currentPrice with execution price on sell (Closes #1249)

## Files changed

- src/lib/portfolioUtils.ts | 2 +-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1249
