### PR TITLE
Forecasts loaded in descending month order, reversing charts and inverting the trend indicator

### DIFF
--- a/src/components/forecast/ForecastComparison.tsx
+++ b/src/components/forecast/ForecastComparison.tsx
@@ -112,13 +112,15 @@ export function ForecastComparison({ user }: ForecastComparisonProps) {
       try {
         const existing = await getForecasts(user.uid);
         if (existing.length > 0 && active) {
-          const mapped: MonthlyForecast[] = existing.map((f) => ({
-            month: f.month,
-            income: f.projectedIncome,
-            expenses: f.projectedExpenses,
-            net: f.netBalance,
-            confidence: f.confidence,
-          }));
+          const mapped: MonthlyForecast[] = existing
+            .map((f) => ({
+              month: f.month,
+              income: f.projectedIncome,
+              expenses: f.projectedExpenses,
+              net: f.netBalance,
+              confidence: f.confidence,
+            }))
+            .sort((a, b) => a.month.localeCompare(b.month));
           setMonthly(mapped);
           setQuarterly(generateQuarterlyForecast(mapped));
         } else if (active) {


### PR DESCRIPTION
## Problem

## Description
`getForecasts` (`src/lib/forecastUtils.ts:235`) orders by `month desc`, so the loaded `monthly` (and derived `quarterly`) arrays are newest-first. `ForecastComparison.tsx` feeds that array straight into the charts and calls `calculateTrend` on it.

## Expected Behavior
Chart data and trend calculations must be ascending by month.

## Actual Behavior
- The time axis runs right-to-left (e.g. 2027-08 -> 2026-09) and the "Net Balance Trend" is backwards.
- `calculateTrend` (`forecastUtils.ts:165`) takes `data.slice(-3)` as "recent", but on a desc array `slice(-3)` is the **oldest** three entries, so the up/down arrow is **inverted**.

The freshly-generated branch returns ascending months, so the bug only appears after the first reload/persist — making it intermittent and easy to miss.

## Proposed Fix
Sort ascending when mapping results in the load effect:
```ts
const mapped = existing
  .map((f) => ({ month: f.month, income: f.projectedIncome, expenses: f.projectedExpenses, net: f.netBalance, confidence: f.confidence }))
  .sort((a, b) => a.month.localeCompare(b.month));
setMonthly(mapped);
setQuarterly(generateQuarterlyForecast(mapped));
```

## Fix

fix: sort forecasts ascending by month so charts and trend indicators are correct (Closes #1258)

## Files changed

- src/components/forecast/ForecastComparison.tsx | 16 +++++++++-------

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1258
