### PR TITLE
normalizeRiskLevel downgrades 'critical'/'severe'/'extreme' risk to 'low'

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -381,8 +381,8 @@ function buildFallbackAnalysis(
 
 function normalizeRiskLevel(value: unknown): "low" | "medium" | "high" {
   const n = String(value || "").toLowerCase();
-  if (n.includes("high")) return "high";
-  if (n.includes("medium") || n.includes("moderate")) return "medium";
+  if (/(high|critical|severe|extreme|danger|alarm)/.test(n)) return "high";
+  if (/(medium|moderate|elevated|warning|caution)/.test(n)) return "medium";
   return "low";
 }
 

--- a/server.ts
+++ b/server.ts
@@ -406,9 +406,8 @@ function sanitizeDeep(value: any): any {
 
 function normalizeRiskLevel(value: unknown): "low" | "medium" | "high" {
   const normalized = String(value || "").toLowerCase();
-  if (normalized.includes("high")) return "high";
-  if (normalized.includes("medium") || normalized.includes("moderate"))
-    return "medium";
+  if (/(high|critical|severe|extreme|danger|alarm)/.test(normalized)) return "high";
+  if (/(medium|moderate|elevated|warning|caution)/.test(normalized)) return "medium";
   return "low";
 }
 


### PR DESCRIPTION
## Problem

## Description
`normalizeRiskLevel` (`server.ts:394-400`) maps risk text using substring checks for "high" and "medium"/"moderate" only, otherwise returning `"low"`.

## Expected Behavior
The full severity vocabulary should map correctly: "critical", "severe", "extreme", "high" -> high; "medium"/"moderate"/"elevated" -> medium; everything else -> low.

## Actual Behavior
`normalizeRiskLevel("critical")` -> `"low"` (no "high"/"medium" substring). Same for `"severe"` and `"extreme"`. A document the model flags as **critical** therefore surfaces as the **lowest** risk tier in the stored `riskLevel`, which drives UI badges and any access/escalation logic. This is a direct misclassification safety bug in a financial app. The same narrowing exists in `api/process.ts`.

## Proposed Fix
```ts
function normalizeRiskLevel(value: unknown): "low" | "medium" | "high" {
  const n = String(value || "").toLowerCase();
  if (/(high|critical|severe|extreme|danger|alarm)/.test(n)) return "high";
  if (/(medium|moderate|elevated|warning|caution)/.test(n)) return "medium";
  return "low";
}
```
Apply identically in `api/process.ts`.

## Fix

fix: preserve critical/severe/extreme risk levels in normalizeRiskLevel (Closes #1260)

## Files changed

- api/analyze.ts | 4 ++--
- server.ts      | 5 ++---

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1260
