### PR TITLE
Account erasure does not clear per-user localStorage keys (e.g. privacySettings_<uid>)

### DIFF
--- a/src/lib/privacyUtils.ts
+++ b/src/lib/privacyUtils.ts
@@ -268,7 +268,7 @@ async function deleteUserStorageFiles(userId: string): Promise<void> {
 export async function deleteUserData(userId: string): Promise<void> {
   // Purge the device caches first: the local mirror holds full analysis
   // payloads (records + AI reports) that must not survive account erasure.
-  clearAllLocalData();
+  clearAllLocalData(userId);
   // Write the deletion tombstone (users/<uid>.deletedAt) first so that
   // onAuthStateChanged cannot resurrect the profile even if a later step fails.
   const userRef = doc(db, "users", userId);

--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -283,11 +283,23 @@ export function deleteLocalDocument(documentId: string): void {
  * erasure (and logout) so deleted or abandoned financial data never survives
  * on the device.
  */
-export function clearAllLocalData(): void {
+export function clearAllLocalData(userId?: string): void {
   if (typeof window === "undefined") return;
 
   try {
     window.localStorage.removeItem(LOCAL_DOCS_KEY);
+    if (userId) {
+      // Remove every per-user localStorage key so privacy/retention/analytics
+      // preferences, starting-balance and alert actions don't survive account
+      // erasure. Keys are keyed by `_<uid>` or `:<uid>` suffixes; matching the
+      // uid substring covers all of them without touching global keys.
+      const doomed: string[] = [];
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (key && key.includes(userId)) doomed.push(key);
+      }
+      doomed.forEach((key) => window.localStorage.removeItem(key));
+    }
   } catch (err) {
     console.warn("[FinSight] Failed to clear localStorage:", err);
   }


### PR DESCRIPTION
## Problem

## Description
`clearAllLocalData` (`src/lib/storageUtils.ts:286-320`) is the single "wipe device caches on erasure/logout" function (called first in `deleteUserData`). It only removes its own `LOCAL_DOCS_KEY` and `fin_local_doc_*` session keys. The user's privacy preferences are persisted under a separate `privacySettings_<uid>` key (written by `PrivacyDashboard.tsx`), which survives account deletion on the device.

## Expected Behavior
Erasure must clear all per-user local data, not just the document mirror, so privacy/retention/analytics/sharing choices don't leak after the account is deleted.

## Actual Behavior
`privacySettings_<uid>` (and any other per-user `fin_*` key) remains in `localStorage` after erasure/logout — a real privacy/erasure-compliance gap (GDPR-style "right to be forgotten" on the device).

## Proposed Fix
```ts
export function clearAllLocalData(userId?: string): void {
  if (typeof window === "undefined") return;
  try {
    window.localStorage.removeItem(LOCAL_DOCS_KEY);
    if (userId) {
      window.localStorage.removeItem(`privacySettings_${userId}`);
      for (let i = window.localStorage.length - 1; i >= 0; i--) {
        const k = window.localStorage.key(i);
        if (k && (k.startsWith("fin_") || k.endsWith(`_${userId}`))) window.localStorage.removeItem(k);
      }
    }
  } catch (err) { console.warn("[FinSight] Failed to clear localStorage:", err); }
  // ... existing sessionStorage wipe + event dispatch
}
```
Call `clearAllLocalData(user.uid)` in `deleteUserData` before the tombstone write.

## Fix

fix: clear per-user localStorage keys on account erasure (Closes #1262)

## Files changed

- src/lib/privacyUtils.ts |  2 +-
- src/lib/storageUtils.ts | 14 +++++++++++++-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1262
