### PR TITLE
Cashflow aggregation uses raw transaction amounts with no sign normalization, mismatching the rest of the app

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -152,7 +152,7 @@ export async function fetchUserTransactions(
       return {
         id: doc.id,
         userId: data.userId || "",
-        amount: Number(data.amount) || 0,
+        amount: Math.abs(Number(data.amount)) || 0,
         category: data.category || "Other",
         type: data.type === "income" ? "income" : "expense",
         date: toDate(data.date) || new Date(),
@@ -174,7 +174,7 @@ export async function fetchUserTransactions(
         return {
           id: doc.id,
           userId: data.userId || "",
-          amount: Number(data.amount) || 0,
+          amount: Math.abs(Number(data.amount)) || 0,
           category: data.category || "Other",
           type: normalizeTransactionType(data.type),
           date: parseTransactionDate(data.date),
@@ -206,11 +206,11 @@ export function calculateMonthlyForecast(
     // independent of `now` (deterministic for a given history).
     if (monthKey === currentMonth) return;
     if (t.type === "income") {
-      incomeByMonth[monthKey] = (incomeByMonth[monthKey] || 0) + t.amount;
+      incomeByMonth[monthKey] = (incomeByMonth[monthKey] || 0) + Math.abs(t.amount);
     } else {
       if (!expenseByMonth[monthKey]) expenseByMonth[monthKey] = {};
       expenseByMonth[monthKey][t.category] =
-        (expenseByMonth[monthKey][t.category] || 0) + t.amount;
+        (expenseByMonth[monthKey][t.category] || 0) + Math.abs(t.amount);
     }
   });
 


### PR DESCRIPTION
## Problem

## Description
`cashflowUtils` reads amounts without normalizing their sign by `type`, unlike every other subsystem (`insightsUtils.normalizeAmount`, `trendsUtils`) which uses `Math.abs(t.amount)` and relies on the `type` field. In `fetchUserTransactionsInRange` (`src/lib/cashflowUtils.ts:131`, `:153`) and `calculateMonthlyForecast` (`:178`, `:182`), raw `t.amount` is summed directly into `incomeByMonth`/`expenseByMonth`.

## Expected Behavior
Magnitudes should be normalized by `type` (income positive, expense positive magnitude), consistent with the rest of the app, so the data contract is uniform.

## Actual Behavior
If expenses are ever stored as negative numbers (common double-entry/import schemas), `projectedExpenses` becomes negative, `projectedNet = avgIncome - (negative)` hugely overstates the balance, and `calculateBalanceProjection` explodes. Even when amounts are positive, the asymmetry with the rest of the codebase is a latent correctness bug.

## Proposed Fix
```ts
amount: Math.abs(Number(data.amount)) || 0,
// and in calculateMonthlyForecast:
if (t.type === income) incomeByMonth[monthKey] = (incomeByMonth[monthKey]||0) + Math.abs(t.amount);
else expenseByMonth[monthKey][t.category] = (expenseByMonth[monthKey][t.category]||0) + Math.abs(t.amount);
```

## Fix

fix: normalize transaction sign in cashflow aggregation (Closes #1264)

## Files changed

- src/lib/cashflowUtils.ts | 8 ++++----

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1264
