### PR TITLE
Paused but fully-funded goals are force-completed by the auto-complete effect

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -132,7 +132,7 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
   useEffect(() => {
     if (!user) return;
     goals.forEach((goal) => {
-      if (goal.status === 'completed') return;
+      if (goal.status === 'completed' || goal.status === 'paused') return;
       if (notifiedGoalIds.current.has(goal.id)) return;
       if (updatingGoalIds.current.has(goal.id)) return;
       const isComplete = goal.currentAmount >= goal.targetAmount;


### PR DESCRIPTION
## Problem

## Description
The goal-auto-complete effect (`src/components/goals/GoalPlanner.tsx:134-150`) only skips `goal.status === 'completed'`. It does **not** skip `paused` goals.

## Expected Behavior
A paused goal must remain paused; the effect should never auto-complete a paused goal.

## Actual Behavior
A goal the user deliberately paused that happens to be fully funded (`currentAmount >= targetAmount`) is silently flipped to `completed` on the next `goals` change. Users cannot keep a funded goal paused.

## Proposed Fix
```ts
goals.forEach((goal) => {
  if (goal.status === 'completed' || goal.status === 'paused') return;
  if (notifiedGoalIds.current.has(goal.id)) return;
  if (updatingGoalIds.current.has(goal.id)) return;
  const isComplete = goal.currentAmount >= goal.targetAmount;
  if (isComplete) { /* unchanged */ }
});
```

## Fix

fix: do not auto-complete paused goals in GoalPlanner effect (Closes #1267)

## Files changed

- src/components/goals/GoalPlanner.tsx | 2 +-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1267
