### PR TITLE
Report currency default is inconsistent (Preview/ReportExport INR vs reportUtils USD)

### DIFF
--- a/src/components/reports/ReportExport.tsx
+++ b/src/components/reports/ReportExport.tsx
@@ -129,7 +129,7 @@ export function ReportExport() {
   const [transactions, setTransactions] = useState<ReportTransaction[]>([]);
   const [reportData, setReportData] = useState<ReportData | null>(null);
   const [showPreview, setShowPreview] = useState(false);
-  const [baseCurrency, setBaseCurrency] = useState("INR");
+  const [baseCurrency, setBaseCurrency] = useState("USD");
 
   const expenseChartRef = useRef<HTMLDivElement>(null);
   const incomeChartRef = useRef<HTMLDivElement>(null);

--- a/src/components/reports/ReportPreview.tsx
+++ b/src/components/reports/ReportPreview.tsx
@@ -42,7 +42,7 @@ export function ReportPreview({ reportData }: ReportPreviewProps) {
     transactions,
     currency,
   } = reportData;
-  const reportCurrency = currency || "INR";
+  const reportCurrency = currency || "USD";
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Problem

## Description
The report currency default is inconsistent across three surfaces:
- `ReportPreview.tsx:45`: `const reportCurrency = currency || INR;`
- `ReportExport.tsx:132`: `const [baseCurrency, setBaseCurrency] = useState(INR);`
- `reportUtils.ts` (authoritative fallback): `currency = reportData.currency || USD` (multiple sites)

## Expected Behavior
A single default (`USD`) everywhere, matching `CurrencyManager`'s default and `reportUtils`, so the same report renders in the same currency on every surface.

## Actual Behavior
A saved/exported report with an empty `currency` shows **INR** in Preview and PDF/CSV (`reportUtils` falls back to USD), so the same report shows different currencies depending on surface. Worse, `ReportExport` initializes `baseCurrency=INR`, so a brand-new user who never opened `CurrencyManager` (which defaults base to USD) gets reports labelled INR while their transactions were entered in USD — a silent mislabel of every figure.

## Proposed Fix
```ts
// ReportPreview.tsx
const reportCurrency = currency || USD;
// ReportExport.tsx
const [baseCurrency, setBaseCurrency] = useState(USD);
```

## Fix

fix: unify report currency default across Preview/ReportExport/reportUtils (Closes #1268)

## Files changed

- src/components/reports/ReportExport.tsx  | 2 +-
- src/components/reports/ReportPreview.tsx | 2 +-

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1268
