### PR TITLE
generatePlainSummary renders figures in the default currency, contradicting the dashboard's base currency

### DIFF
--- a/src/components/insights/InsightsDashboard.tsx
+++ b/src/components/insights/InsightsDashboard.tsx
@@ -195,7 +195,7 @@ function WeeklySection({
   baseCurrency: string;
 }) {
   const { weeklySummary, weekly } = bundle;
-  const summary = generatePlainSummary(weeklySummary);
+  const summary = generatePlainSummary(weeklySummary, baseCurrency);
   const topDeltas = weekly.slice(0, 6);
 
   return (
@@ -263,7 +263,7 @@ function MonthlySection({
   baseCurrency: string;
 }) {
   const { monthlySummary } = bundle;
-  const summary = generatePlainSummary(monthlySummary);
+  const summary = generatePlainSummary(monthlySummary, baseCurrency);
 
   return (
     <section>

--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -559,7 +559,7 @@ function buildPeriodSummary(
 /**
  * Produce a friendly, plain-language sentence describing a period summary.
  */
-export function generatePlainSummary(summary: PeriodSummary): string {
+export function generatePlainSummary(summary: PeriodSummary, currency?: string): string {
   if (summary.transactionCount === 0) {
     return `No spending recorded for ${summary.label.toLowerCase()} yet. Once you add transactions, we'll break down where your money goes.`;
   }
@@ -567,16 +567,16 @@ export function generatePlainSummary(summary: PeriodSummary): string {
   const top = summary.topCategories[0];
   const parts: string[] = [];
   parts.push(
-    `You spent ${formatCurrency(summary.total)} across ${summary.transactionCount} transaction${
-      summary.transactionCount === 1 ? "" : "s"
-    } ${summary.label.toLowerCase()}.`,
+    `You spent ${formatCurrency(summary.total, currency)} across ${summary.transactionCount} transaction${
+       summary.transactionCount === 1 ? "" : "s"
+     } ${summary.label.toLowerCase()}.`,
   );
 
   if (top) {
     const share =
       summary.total > 0 ? Math.round((top.total / summary.total) * 100) : 0;
     parts.push(
-      `${top.category} was your biggest category at ${formatCurrency(top.total)} (${share}% of spend).`,
+      `${top.category} was your biggest category at ${formatCurrency(top.total, currency)} (${share}% of spend).`,
     );
   }
 


### PR DESCRIPTION
## Problem

## Description
`generatePlainSummary` (`src/lib/insightsUtils.ts:562-579`, called from `InsightsDashboard.tsx`) calls `formatCurrency(summary.total, ...)` and `formatCurrency(top.total, ...)` with **no currency argument**, so the plain-language sentence always uses `getDefaultCurrency()` while the surrounding card renders the big number with the user's `baseCurrency`.

## Expected Behavior
The summary prose must use the same `baseCurrency` as the rest of the dashboard.

## Actual Behavior
A user with a non-default base currency sees, e.g., "You spent $1,200" in the prose but "€1,200" in the headline number — contradicting figures in the same card.

## Proposed Fix
```ts
export function generatePlainSummary(summary: PeriodSummary, currency?: string): string { ... }
parts.push(`You spent ${formatCurrency(summary.total, currency)} across ...`);
parts.push(`${top.category} was your biggest category at ${formatCurrency(top.total, currency)} (${share}% of spend).`);
// Callers: const summary = generatePlainSummary(weeklySummary, baseCurrency);
```

## Fix

fix: render generatePlainSummary figures in the dashboard base currency (Closes #1270)

## Files changed

- src/components/insights/InsightsDashboard.tsx |  4 ++--
- src/lib/insightsUtils.ts                      | 10 +++++-----

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1270
