### PR TITLE
Rollover 'Unused %' uses base limit instead of effective limit and ignores already-rolled amount

### DIFF
--- a/src/components/rollover/RolloverManager.tsx
+++ b/src/components/rollover/RolloverManager.tsx
@@ -293,7 +293,12 @@ export function RolloverManager({ user }: RolloverManagerProps) {
               const rolloverAmount = category.rolloverEnabled
                 ? calculateRolloverAmount(unusedBudget, category.rolloverPercentage)
                 : 0;
-              const rolloverPercentage = category.monthlyLimit > 0 ? (unusedBudget / category.monthlyLimit) * 100 : 0;
+              const effectiveLimit = category.rolloverEnabled
+                ? category.monthlyLimit + Math.max(0, category.rolledOverAmount || 0)
+                : category.monthlyLimit;
+              const rolloverPercentage = effectiveLimit > 0 ? (unusedBudget / effectiveLimit) * 100 : 0;
+              const alreadyRolled = category.rolloverEnabled ? Math.max(0, category.rolledOverAmount || 0) : 0;
+              const remainingUnused = Math.max(0, unusedBudget - alreadyRolled);
 
               return (
                 <motion.div
@@ -314,9 +319,9 @@ export function RolloverManager({ user }: RolloverManagerProps) {
                                 Active
                               </Badge>
                             )}
-                            {unusedBudget > 0 && (
+                            {remainingUnused > 0 && (
                               <Badge className="bg-indigo-500/10 text-indigo-400 border-indigo-500/30 text-[10px] font-bold uppercase tracking-wider">
-                                {formatCurrency(unusedBudget)} unused
+                                {formatCurrency(remainingUnused)} unused
                               </Badge>
                             )}
                           </div>
@@ -331,7 +336,7 @@ export function RolloverManager({ user }: RolloverManagerProps) {
                                 className="w-24 h-8 bg-slate-800 border-slate-700 text-white placeholder:text-slate-500 rounded-lg text-xs"
                               />
                             </div>
-                            {category.monthlyLimit > 0 && (
+                            {effectiveLimit > 0 && (
                               <div className="flex items-center gap-2">
                                 <span className="uppercase tracking-wider font-semibold">Unused</span>
                                 <span className="text-slate-300 font-medium tabular-nums">


### PR DESCRIPTION
## Problem

## Description
In `RolloverManager.tsx`, the "Unused %" bar is computed against the **base** monthly limit, not the effective limit:
- `rolloverPercentage` at line 296: `category.monthlyLimit > 0 ? (unusedBudget / category.monthlyLimit) * 100 : 0`
- The "unused" badge at lines 317-321 shows `unusedBudget` even after a rollover has already carried the surplus forward.

`calculateRolloverAmount` and the "Effective Limit" display (lines 345-349) correctly use `monthlyLimit + rolledOverAmount`, so the percentage is internally inconsistent with them.

## Expected Behavior
The utilization percentage and the "unused" badge should be based on the effective limit (`monthlyLimit + rolledOverAmount`) and should subtract whatever has already been rolled over.

## Actual Behavior
Limit 1000, spend 400, already rolled 200 → effective limit 1200, but the bar shows `600/1000 = 60%` instead of `600/1200 = 50%`. After rollover the badge still advertises the full `unusedBudget` as available, double-counting the carry-over.

## Proposed Fix
```ts
const effectiveLimit = category.rolloverEnabled
  ? category.monthlyLimit + Math.max(0, category.rolledOverAmount || 0)
  : category.monthlyLimit;
const rolloverPercentage = effectiveLimit > 0 ? (unusedBudget / effectiveLimit) * 100 : 0;
const alreadyRolled = category.rolloverEnabled ? Math.max(0, category.rolledOverAmount) : 0;
const remainingUnused = Math.max(0, unusedBudget - alreadyRolled);
// show remainingUnused in the badge instead of unusedBudget
```

## Fix

fix: compute rollover Unused % from effective limit and already-rolled amount (Closes #1273)

## Files changed

- src/components/rollover/RolloverManager.tsx | 13 +++++++++----

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1273
