### PR TITLE
RAG vector store uses raw term-frequency (no IDF), producing poor retrieval ranking

### DIFF
--- a/src/lib/rag/vectorStore.ts
+++ b/src/lib/rag/vectorStore.ts
@@ -27,7 +27,8 @@ export function cosineSimilarity(vecA: number[], vecB: number[]): number {
 }
 
 /**
- * Generates lightweight TF-IDF-like pseudo-embedding vector for text similarity scoring.
+ * Generates a raw term-frequency pseudo-embedding vector for text similarity scoring.
+ * IDF weighting is applied separately by the vector store.
  */
 export function generateSparseEmbedding(text: string, vocabulary: string[]): number[] {
   const words = text.toLowerCase().match(/\b[a-z0-9_]+\b/g) || [];
@@ -43,6 +44,7 @@ export class InMemoryVectorStore {
   private chunks: DocumentChunk[] = [];
   private embeddings: number[][] = [];
   private vocabulary: string[] = [];
+  private idf: number[] = [];
 
   /**
    * Indexes document chunks into the store.
@@ -60,8 +62,23 @@ export class InMemoryVectorStore {
     });
 
     this.vocabulary = Array.from(vocabSet);
-    this.embeddings = chunks.map((chunk) =>
-      generateSparseEmbedding(chunk.text, this.vocabulary)
+
+    // Compute document frequencies and IDF weights.
+    const df = new Array(this.vocabulary.length).fill(0);
+    this.embeddings = chunks.map((chunk) => {
+      const e = generateSparseEmbedding(chunk.text, this.vocabulary);
+      e.forEach((c, i) => {
+        if (c > 0) df[i]++;
+      });
+      return e;
+    });
+
+    const N = chunks.length;
+    this.idf = df.map((d) => (d > 0 ? Math.log((N + 1) / (d + 1)) + 1 : 0));
+
+    // Weight stored embeddings by IDF.
+    this.embeddings = this.embeddings.map((e) =>
+      e.map((c, i) => c * this.idf[i])
     );
   }
 
@@ -71,7 +88,9 @@ export class InMemoryVectorStore {
   public similaritySearch(query: string, topK: number = 3): ScoredChunk[] {
     if (this.chunks.length === 0 || this.vocabulary.length === 0) return [];
 
-    const queryEmbedding = generateSparseEmbedding(query, this.vocabulary);
+    const queryEmbedding = generateSparseEmbedding(query, this.vocabulary).map(
+      (c, i) => c * this.idf[i]
+    );
 
     const scored = this.chunks.map((chunk, index) => {
       const score = cosineSimilarity(queryEmbedding, this.embeddings[index]);


### PR DESCRIPTION
## Problem

## Description
`generateSparseEmbedding` (`src/lib/rag/vectorStore.ts:32-40`) returns raw term-frequency counts, and `similaritySearch` (lines 71-84) scores purely on cosine of those raw frequencies. The doc-comment claims a "TF-IDF-like pseudo-embedding" but there is **no IDF** and no length/sublinear scaling.

## Expected Behavior
Retrieval ranking should be discriminative — rare, specific terms (e.g. "EBITDA", an account code) should dominate over ubiquitous stopwords.

## Actual Behavior
A long chunk that merely repeats query words ranks above a short, precise match, and common terms carry as much weight as rare ones. Top-k passages for finance Q&A are often the longest/most repetitive, not the most relevant, so the model is fed wrong context.

## Proposed Fix
Compute document frequencies once in `addChunks` and weight by IDF:
```ts
const df = new Array(this.vocabulary.length).fill(0);
this.embeddings = chunks.map((chunk) => {
  const e = generateSparseEmbedding(chunk.text, this.vocabulary);
  e.forEach((c, i) => { if (c > 0) df[i]++; });
  return e;
});
const N = chunks.length;
this.idf = df.map((d) => (d > 0 ? Math.log((N + 1) / (d + 1)) + 1 : 0));
// multiply tf by idf when scoring query and stored embeddings.
```

## Fix

fix: weight RAG retrieval by IDF instead of raw term-frequency (Closes #1274)

## Files changed

- src/lib/rag/vectorStore.ts | 27 +++++++++++++++++++++++----

## Testing

- Change is scoped to the issue; reviewed against surrounding code for correctness.
- Type checking / lint could not be executed locally (node_modules not installed in the working copy), so a CI typecheck is recommended on the PR.

Closes #1274
