### PR TITLE
[Bug] Selling a holding overwrites currentPrice with the execution price

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -356,13 +356,14 @@ export async function addTransaction(userId: string, input: TransactionInput): P
                 quantity
               : existing.avgCost || 0;
 
-          tx.update(holdingRef, {
+          const update: Record<string, unknown> = {
             quantity,
             avgCost,
             portfolioId: input.portfolioId,
-            currentPrice: input.price,
             updatedAt: serverTimestamp(),
-          });
+          };
+          if (input.type === "buy") update.currentPrice = input.price;
+          tx.update(holdingRef, update);
         }
 
         resolvedHoldingId = holdingRef.id;


### PR DESCRIPTION
## Problem

addTransaction set currentPrice to input.price for both buys and sells, so a partial sell valued remaining shares at the (often lower) sale price, distorting unrealized P/L.

## Fix

Build the holding update object conditionally: currentPrice is set only on buy (market price). Sells keep the existing market currentPrice.

## Files changed

src/lib/portfolioUtils.ts

## Testing

Unit: after a partial sell, the holding's currentPrice is unchanged; after a buy it is updated to the buy price.

Closes #1161

