### PR TITLE
Compliance AML thresholds hardcoded in USD with no currency normalization (false positives/negatives in multi-currency)

### DIFF
--- a/src/components/compliance/ComplianceAuditDashboard.tsx
+++ b/src/components/compliance/ComplianceAuditDashboard.tsx
@@ -4,11 +4,14 @@ import { ShieldAlert, FileText, CheckCircle2, AlertOctagon, Loader2 } from "luci
 import { ComplianceScorecard } from "./ComplianceScorecard";
 import { auditFinancialData } from "@/src/lib/complianceUtils";
 import { fetchUserTransactions } from "@/src/lib/cashflowUtils";
+import { useBaseCurrency } from "@/src/hooks/useBaseCurrency";
+import { fetchExchangeRates } from "@/src/lib/currencyUtils";
 
 export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [auditResult, setAuditResult] = useState<ReturnType<typeof auditFinancialData> | null>(null);
+  const baseCurrency = useBaseCurrency(user || null);
 
   useEffect(() => {
     if (!user) {
@@ -16,7 +19,7 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
       return;
     }
     loadComplianceData();
-  }, [user]);
+  }, [user, baseCurrency]);
 
   async function loadComplianceData() {
     setLoading(true);
@@ -28,8 +31,22 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
         description: t.description || "",
         date: t.date instanceof Date ? t.date.toISOString().split("T")[0] : String(t.date),
         category: t.category,
+        currency: baseCurrency,
       }));
-      const result = auditFinancialData(realTransactions);
+
+      let rates: Record<string, number> = {};
+      try {
+        const fetched = await fetchExchangeRates(baseCurrency);
+        rates = fetched.rates;
+      } catch {
+        rates = {};
+      }
+
+      const result = auditFinancialData(realTransactions, {
+        baseCurrency,
+        rates,
+        country: user?.country,
+      });
       setAuditResult(result);
     } catch (err) {
       setError("Failed to load compliance data. Please try again.");

--- a/src/lib/complianceUtils.ts
+++ b/src/lib/complianceUtils.ts
@@ -1,3 +1,5 @@
+import { convertAmount } from "./currencyUtils";
+
 export interface ComplianceViolation {
   id: string;
   category: "AML" | "SOX" | "FINRA" | "FATCA";
@@ -22,6 +24,13 @@ export interface AuditTransaction {
   date: string | Date;
   category?: string;
   type?: "income" | "expense";
+  currency?: string;
+}
+
+export interface AuditOptions {
+  baseCurrency?: string;
+  rates?: Record<string, number>;
+  country?: string;
 }
 
 const STRUCTURING_WINDOW_DAYS = 7;
@@ -30,6 +39,18 @@ const ROUND_TRIP_WINDOW_DAYS = 7;
 function parseAuditDate(value: string | Date): Date | null {
   const d = value instanceof Date ? value : new Date(value);
   return isNaN(d.getTime()) ? null : d;
+}
+
+// Maps a user's country/region to the relevant financial-intelligence or
+// regulatory authority. Defaults to FinCEN (US) when no country is supplied.
+function regulatoryBodyForCountry(country?: string): string {
+  const c = (country || "").toUpperCase();
+  if (c === "GB" || c === "UK") return "FCA";
+  if (c === "EU") return "EBA";
+  if (c === "CA") return "FINTRAC";
+  if (c === "AU") return "AUSTRAC";
+  if (c === "IN") return "FIU-IND";
+  return "FinCEN";
 }
 
 function normalizeAmount(value: unknown): number {
@@ -55,6 +76,7 @@ function isExpenseTransaction(
  */
 export function auditFinancialData(
   transactions: AuditTransaction[],
+  options: AuditOptions = {},
 ): ComplianceScore {
   const violations: ComplianceViolation[] = [];
 
@@ -93,19 +115,36 @@ export function auditFinancialData(
   }
 
   // Only transactions with a numeric amount participate in the value-based
-  // rules. Amounts are compared with Math.abs so the rules work for both signed
-  // storage (negative expenses) and unsigned storage (positive amounts with a
-  // `type` field), consistent with anomalyUtils/reportUtils.
+  // rules. Amounts are compared in the base currency so the rules work for both
+  // signed storage (negative expenses) and unsigned storage (positive amounts
+  // with a `type` field), consistent with anomalyUtils/reportUtils.
   const valid = parsed.filter((p) => !Number.isNaN(p.amt));
   // Date-dependent rules additionally require a parseable date.
   const dated = valid.filter(
     (p): p is typeof p & { date: Date } => p.date !== null,
   );
 
-  // AML Rule 1: Structuring / Smurfing detection (multiple transactions just under $10,000 threshold)
-  const structuringTxns = dated.filter(
-    (p) => Math.abs(p.amt) >= 9000 && Math.abs(p.amt) < 10000,
-  );
+  const baseCurrency = options.baseCurrency || "USD";
+  const rates = options.rates || {};
+  const regulatoryBody = regulatoryBodyForCountry(options.country);
+
+  // Normalizes a transaction's absolute amount into the base currency so the
+  // AML/SOX thresholds are applied consistently regardless of the transaction's
+  // original currency. When the currency is unknown or missing from the rate
+  // table, convertAmount returns null and we fall back to the raw amount
+  // rather than silently assuming a 1:1 (USD) parity.
+  const toBaseAmount = (t: AuditTransaction, amt: number): number => {
+    const raw = Math.abs(amt);
+    if (!t.currency || t.currency === baseCurrency) return raw;
+    const converted = convertAmount(raw, t.currency, baseCurrency, rates);
+    return converted === null ? raw : converted;
+  };
+
+  // AML Rule 1: Structuring / Smurfing detection (multiple transactions just under the base-currency $10,000-equivalent threshold)
+  const structuringTxns = dated.filter((p) => {
+    const amt = toBaseAmount(p.t, p.amt);
+    return amt >= 9000 && amt < 10000;
+  });
   if (structuringTxns.length >= 2) {
     // Only flag when the transactions actually occur in close succession.
     const inCloseSuccession = structuringTxns.some((p, i) =>
@@ -119,9 +158,8 @@ export function auditFinancialData(
         category: "AML",
         severity: "high",
         title: "Potential Transaction Structuring Detected",
-        description: `Identified ${structuringTxns.length} transactions between $9,000 and $9,999 within ${STRUCTURING_WINDOW_DAYS} days of each other.`,
-        recommendedAction:
-          "File a Currency Transaction Report (CTR) / Suspicious Activity Report (SAR) with FinCEN.",
+        description: `Identified ${structuringTxns.length} transactions between ${baseCurrency} 9,000 and ${baseCurrency} 9,999 within ${STRUCTURING_WINDOW_DAYS} days of each other.`,
+        recommendedAction: `File a Currency Transaction Report (CTR) / Suspicious Activity Report (SAR) with ${regulatoryBody}.`,
       });
     }
   }
@@ -129,10 +167,12 @@ export function auditFinancialData(
   // AML Rule 2: High velocity round-trip transfers (high-value deposit and a
   // rapid withdrawal that actually fall inside the same short window)
   const largeExpenses = dated.filter(
-    (p) => Math.abs(p.amt) > 25000 && isExpenseTransaction(p.amt, p.t.type),
+    (p) =>
+      toBaseAmount(p.t, p.amt) > 25000 && isExpenseTransaction(p.amt, p.t.type),
   );
   const largeIncomes = dated.filter(
-    (p) => Math.abs(p.amt) > 25000 && !isExpenseTransaction(p.amt, p.t.type),
+    (p) =>
+      toBaseAmount(p.t, p.amt) > 25000 && !isExpenseTransaction(p.amt, p.t.type),
   );
   const roundTripDetected =
     largeIncomes.length > 0 &&
@@ -157,7 +197,7 @@ export function auditFinancialData(
   // SOX Rule 1: Off-balance sheet expenditure disclosure
   const unclassifiedLarge = valid.filter(
     (p) =>
-      Math.abs(p.amt) > 50000 &&
+      toBaseAmount(p.t, p.amt) > 50000 &&
       (!p.t.category || p.t.category.toLowerCase() === "other"),
   );
   if (unclassifiedLarge.length > 0) {
@@ -166,7 +206,7 @@ export function auditFinancialData(
       category: "SOX",
       severity: "high",
       title: "Unclassified Major Expenditure (SOX 404)",
-      description: `Found ${unclassifiedLarge.length} uncategorized expenditure(s) exceeding $50,000 threshold.`,
+      description: `Found ${unclassifiedLarge.length} uncategorized expenditure(s) exceeding ${baseCurrency} 50,000 threshold.`,
       recommendedAction: "Reclassify expenditure under GAAP ledger accounts and obtain controller approval.",
     });
   }


### PR DESCRIPTION
## Problem
^GuditFinancialData in src/lib/complianceUtils.ts hardcodes all AML/SOX thresholds in USD and assumes US jurisdiction. Because AuditTransaction carries no currency, raw per-transaction amounts are compared against fixed USD figures, producing false positives (e.g. a ¥9,900 transfer flagged as structuring) and false negatives (e.g. a €12,000 pattern above the real threshold missed). The SAR/CTR recommendation is also hardcoded to FinCEN regardless of the user's location.

## Fix
- Added optional currency?: string to AuditTransaction and a new AuditOptions param { baseCurrency?, rates?, country? } to ^GuditFinancialData.
- Each transaction amount is normalized via convertAmount(amount, t.currency, baseCurrency, rates), falling back to the raw amount when the currency is unknown or missing from the rate table (no silent 1:1 parity). Thresholds (9k/10k structuring, 25k velocity, 50k SOX) are now applied against the base-currency amount.
- Added egulatoryBodyForCountry so the recommended body is jurisdiction-aware (FCA/EBA/FINTRAC/AUSTRAC/FIU-IND, defaulting to FinCEN).
- Updated ComplianceAuditDashboard to pass the user's aseCurrency, fetched exchange ates, and country (transactions default to the user's base currency since the source stores none).

## Files changed
- src/lib/complianceUtils.ts — AuditTransaction, AuditOptions, egulatoryBodyForCountry, 	oBaseAmount helper, base-currency comparisons and jurisdiction-aware action.
- src/components/compliance/ComplianceAuditDashboard.tsx — passes currency/baseCurrency/rates/country into the audit.

## Testing
No build/test environment available. Logic verified by tracing convertAmount (returns null for unknown currencies -> fallback) and confirming EUR/JPY amounts normalize before threshold comparison, while same-currency transactions pass through unchanged.

Closes #1190
