### PR TITLE
identifyRecurringTransactions merges across categories and uses loose substring/category keys

### DIFF
--- a/src/lib/cashflowUtils.ts
+++ b/src/lib/cashflowUtils.ts
@@ -286,18 +286,26 @@ export function identifyRecurringTransactions(
   const groups: Group[] = [];
 
   transactions.forEach((t) => {
-    const key = normalizeDescriptionKey(t.description) || t.category;
+    const key = normalizeDescriptionKey(t.description);
+    // Without a description we cannot reliably group the transaction, so it is
+    // never merged into a recurring series. Collapsing whole categories into a
+    // single "recurring" charge (old `|| t.category` fallback) mislabels varied
+    // spending as one uniform subscription.
+    if (!key) return;
     let group: Group | null = null;
     for (const g of groups) {
-      if (g.type !== t.type) continue;
-      const exactMatch = g.key === key;
-      const textMatch = g.key.includes(key) || key.includes(g.key);
+      // Never merge across types or categories: a "netflix" subscription must
+      // not be grouped with a same-named merchant in another category.
+      if (g.type !== t.type || g.category !== t.category) continue;
+      // Require an exact key match; a loose substring match (e.g. "uber" vs
+      // "uber eats") merges distinct merchants into a single series.
+      const strong = g.key === key;
       const amountMatch = g.txns.some(
         (gt) =>
           Math.abs(gt.amount - t.amount) <
           0.01 * Math.max(1, Math.abs(gt.amount)),
       );
-      if (exactMatch || (textMatch && amountMatch)) {
+      if (strong && amountMatch) {
         group = g;
         break;
       }


### PR DESCRIPTION
## Description
`identifyRecurringTransactions` groups by a key that falls back to the **category** and uses a loose **substring** match, while freezing `group.category` to the first transaction's category (`src/lib/cashflowUtils.ts:270-291`):
```ts
const key = normalizeDescriptionKey(t.description) || t.category;   // no-description -> category
...
const textMatch = g.key.includes(key) || key.includes(g.key);      // substring!
const amountMatch = g.txns.some((gt) => Math.abs(gt.amount - t.amount) < 0.01 * Math.max(1, Math.abs(gt.amount)));
if (exactMatch || (textMatch && amountMatch)) group = g;
...
groups.push({ key, category: t.category, type: t.type, txns: [t] }); // category frozen to first
```

## Expected Behavior
Group only transactions of the **same category** with an exact/strong key match; never collapse no-description transactions of a whole category into one "recurring" series.

## Actual Behavior
Two defects:
1. **Cross-category merge:** `textMatch` merges transactions sharing a description substring (e.g. `"uber"`/`"uber eats"`, `"netflix"`/`"netflix gift"`) when amounts are within 1%, then reports the group under the *first* transaction's category with a blended average — wrong category and wrong amount.
2. **Category as group key:** when `description` is empty, `key = t.category`, so every no-description expense of a category collapses into one "recurring" charge — a category with ≥3 uniform no-description expenses across ≥2 months is flagged as a single recurring charge of mean spend, which is wrong for varied spending.

## Proposed Fix
```ts
const key = normalizeDescriptionKey(t.description);
if (!key) return;                       // no description -> cannot reliably group
for (const g of groups) {
  if (g.type !== t.type || g.category !== t.category) continue;  // category must match
  const strong = g.key === key;        // require exact key match, no loose substring
  const amountMatch = g.txns.some((gt) => Math.abs(gt.amount - t.amount) < 0.01 * Math.max(1, Math.abs(gt.amount)));
  if (strong && amountMatch) { group = g; break; }
}
```

Closes #1377