### PR TITLE
/api/document-download-url and /api/documents/delete have no rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1364,6 +1364,25 @@ CRITICAL RULES:
     standardHeaders: false,
   });
 
+  // /api/documents/delete performs a Firestore read, a Storage metadata get, a
+  // batched delete, and a Storage object delete per call. It is state-changing
+  // and cost-amplifying, so it must be throttled just like the analyze and
+  // download-URL endpoints instead of being freely loopable.
+  const documentDeleteRateLimiter = rateLimit({
+    keyGenerator: (req: any) => req.ownerId || req.ip,
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 60, // 60 deletions per user per 15 minutes
+    message: {
+      error: {
+        stage: "RATE_LIMIT",
+        reason:
+          "Too many document deletion requests (max 60 per 15 minutes per user)",
+        recommendation: "Please slow down and try again later.",
+      },
+    },
+    standardHeaders: false,
+  });
+
   app.post("/api/document-download-url", downloadUrlRateLimiter, async (req: any, res) => {
     try {
       const { storagePath, documentId } = req.body;
@@ -1522,7 +1541,7 @@ CRITICAL RULES:
   // client-side deleteDoc would leave the PDF readable via signed URLs
   // forever. Ownership is verified against the Firestore record before any
   // metadata or object is removed.
-  app.post("/api/documents/delete", async (req: any, res) => {
+  app.post("/api/documents/delete", documentDeleteRateLimiter, async (req: any, res) => {
     try {
       const { documentId } = req.body;
 


### PR DESCRIPTION
## Description
`/api/document-download-url` (`server.ts:1336`) and `/api/documents/delete` (`server.ts:1494`) have **no rate limiter** attached, unlike `/api/analyze` and `/api/process` which get `concurrentAnalyzeLimiter` + `analyzeRateLimiter`:
```ts
app.post("/api/document-download-url", async (req, res) => { ... });
app.post("/api/documents/delete", async (req, res) => { ... });
```

## Expected Behavior
All state-changing/expensive authenticated endpoints should be rate-limited.

## Actual Behavior
Each `/api/document-download-url` call performs a Storage `getMetadata` + a Firestore query + signed-URL generation; each `/api/documents/delete` performs a Firestore get, a Storage metadata get, a batched delete, and a Storage delete. A logged-in user (or a stolen token) can loop these to amplify backend cost and churn Storage/Firestore operations with zero throttle. (The serverless `/api/analyze`/`/api/process` routes have a separate, spoofable-per-IP limit, filed separately.)

## Proposed Fix
```ts
const gentleLimiter = rateLimit({ windowMs: 60*1000, max: 30, ... });
app.post("/api/document-download-url", gentleLimiter, async (req, res) => { ... });
app.post("/api/documents/delete", gentleLimiter, async (req, res) => { ... });
```

Closes #1374