### PR TITLE
handleDeleteContribution uses a non-transactional absolute overwrite, causing lost-update balance corruption

### DIFF
--- a/src/components/emergency/EmergencyFundPlanner.tsx
+++ b/src/components/emergency/EmergencyFundPlanner.tsx
@@ -51,6 +51,7 @@ import {
   createEmergencyFund,
   updateEmergencyFund,
   addContribution,
+  removeContribution,
   isFundComplete,
   DEFAULT_MAX_MONTHS,
 } from '@/src/lib/emergencyUtils';
@@ -231,18 +232,16 @@ export function EmergencyFundPlanner({ user }: EmergencyFundPlannerProps) {
 
   const handleDeleteContribution = async (contribution: Contribution) => {
     if (!fund) return;
-    const contributions = fund.contributions.filter((c) => c.id !== contribution.id);
-    const currentAmount = Math.max(0, fund.currentAmount - contribution.amount);
-    await updateGoal({
-      contributions,
-      currentAmount,
-      estimatedCompletionDate: estimateCompletionDate(
-        fund.targetAmount,
-        currentAmount,
-        fund.monthlyContribution
-      ),
-    });
-    toast.success('Contribution removed');
+    // Removal runs as a Firestore transaction with increment(-amount) /
+    // arrayRemove (mirroring addContribution) so a concurrent add cannot be
+    // lost to an absolute overwrite of currentAmount/contributions.
+    const updated = await removeContribution(fund, contribution);
+    if (updated) {
+      setFund(updated);
+      toast.success('Contribution removed');
+    } else {
+      toast.error('Failed to remove contribution');
+    }
   };
 
   return (

--- a/src/lib/emergencyUtils.ts
+++ b/src/lib/emergencyUtils.ts
@@ -17,6 +17,7 @@ import {
   runTransaction,
   increment,
   arrayUnion,
+  arrayRemove,
 } from 'firebase/firestore';
 import { addMonths, differenceInCalendarDays } from 'date-fns';
 import { db, handleFirestoreError, OperationType } from './firebase';
@@ -272,6 +273,51 @@ export async function addContribution(
     return updated;
   } catch (error) {
     console.error('Error adding emergency fund contribution:', error);
+    handleFirestoreError(error, OperationType.UPDATE, `emergency_funds/${fund.id}`);
+    return null;
+  }
+}
+
+export async function removeContribution(
+  fund: EmergencyFund,
+  contribution: Contribution,
+): Promise<EmergencyFund | null> {
+  if (!fund || !contribution || !contribution.id) return null;
+
+  try {
+    // Deletion must be transactional, mirroring addContribution: applying the
+    // delta against a fresh snapshot prevents a concurrent addContribution from
+    // being clobbered by an absolute overwrite of currentAmount/contributions.
+    const updated = await runTransaction(db, async (tx) => {
+      const fundRef = doc(db, 'emergency_funds', fund.id);
+      const snapshot = await tx.get(fundRef);
+      if (!snapshot.exists()) throw new Error('Emergency fund no longer exists');
+
+      const current = normalizeFund(fund.id, snapshot.data());
+      const currentAmount = Math.max(0, current.currentAmount - contribution.amount);
+      const estimatedCompletionDate = estimateCompletionDate(
+        current.targetAmount,
+        currentAmount,
+        current.monthlyContribution || 0,
+      );
+
+      tx.update(fundRef, {
+        currentAmount: increment(-contribution.amount),
+        contributions: arrayRemove(contribution),
+        estimatedCompletionDate,
+        updatedAt: serverTimestamp(),
+      });
+
+      return {
+        ...current,
+        currentAmount,
+        estimatedCompletionDate,
+        contributions: current.contributions.filter((c) => c.id !== contribution.id),
+      };
+    });
+    return updated;
+  } catch (error) {
+    console.error('Error removing emergency fund contribution:', error);
     handleFirestoreError(error, OperationType.UPDATE, `emergency_funds/${fund.id}`);
     return null;
   }


### PR DESCRIPTION
## Description
`handleDeleteContribution` issues an absolute `updateDoc` with the client's `currentAmount`/`contributions` (`src/components/emergency/EmergencyFundPlanner.tsx:232-246`):
```ts
const contributions = fund.contributions.filter((c) => c.id !== contribution.id);
const currentAmount = Math.max(0, fund.currentAmount - contribution.amount);
await updateGoal({ contributions, currentAmount, estimatedCompletionDate: ... });
```
By contrast, `addContribution` correctly uses a Firestore transaction with `increment(contribution.amount)`.

## Expected Behavior
Deletion should be transactional and use `increment(-contribution.amount)` / `arrayRemove`, like the add path.

## Actual Behavior
If `addContribution` commits between the client's last sync and this delete, the delete's absolute `currentAmount`/`contributions` **clobbers the concurrently-added contribution's effect on the balance** — a silent lost update / corrupted emergency-fund balance. Mirrors the TOCTOU class already filed for portfolio, but here in the emergency module and unaddressed.

## Proposed Fix
```ts
const updated = await runTransaction(db, async (tx) => {
  const ref = doc(db, 'emergency_funds', fund.id);
  const snap = await tx.get(ref);
  if (!snap.exists()) throw new Error('Emergency fund no longer exists');
  const current = normalizeFund(fund.id, snap.data());
  const newAmount = Math.max(0, current.currentAmount - contribution.amount);
  tx.update(ref, {
    currentAmount: increment(-contribution.amount),
    contributions: arrayRemove(contribution),
    estimatedCompletionDate: estimateCompletionDate(current.targetAmount, newAmount, current.monthlyContribution || 0),
    updatedAt: serverTimestamp(),
  });
  return { ...current, currentAmount: newAmount, contributions: current.contributions.filter((c) => c.id !== contribution.id) };
});
if (updated) setFund(updated);
```

Closes #1376