### PR TITLE
Storage object path / documentId collisions allow uploaded-document overwrite and corruption

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -5,6 +5,7 @@ import admin from "firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
 import DOMPurify from "isomorphic-dompurify";
 import type { IncomingMessage, ServerResponse } from "http";
+import { randomUUID } from "crypto";
 
 dotenv.config({ quiet: true });
 
@@ -714,7 +715,7 @@ full_report MUST be at least 300 words.`;
     const riskLevel = normalizeRiskLevel(rawRisk);
     const now = new Date();
     const safeFilename = sanitizeStorageFilename(filename);
-    const storagePath = `analyses/${ownerId}/${now.getTime()}_${safeFilename}`;
+    const storagePath = `analyses/${ownerId}/${now.getTime()}_${randomUUID()}_${safeFilename}`;
 
     // SECURITY: upload the PDF to Firebase Storage before persisting metadata,
     // then derive fileUrl from the real object URL instead of a placeholder domain.
@@ -769,7 +770,7 @@ full_report MUST be at least 300 words.`;
       processedAt: now,
     };
 
-    let documentId = `local-${ownerId}-${now.getTime()}`;
+    let documentId = `local-${ownerId}-${now.getTime()}-${randomUUID()}`;
     let firestorePersisted = false;
 
     if (admin.apps.length) {
@@ -799,7 +800,7 @@ full_report MUST be at least 300 words.`;
         firestorePersisted = true;
       } catch (writeErr: any) {
         console.warn("[analyze] Firestore server write skipped:", writeErr?.message);
-        documentId = `local-${ownerId}-${now.getTime()}`;
+        documentId = `local-${ownerId}-${now.getTime()}-${randomUUID()}`;
         // The PDF was already uploaded to Storage above, but without a
         // Firestore record it can never be downloaded, so clean it up.
         if (storagePath) {

--- a/api/process.ts
+++ b/api/process.ts
@@ -20,10 +20,11 @@ export const config = {
 
 export const maxDuration = 60; // Grant up to 60s execution time on Vercel
 
+import { randomUUID } from "crypto";
+
 // ---------------------------------------------------------------------------
 // Tiny helpers
 // ---------------------------------------------------------------------------
-
 function getEnv(key: string, fallback = ""): string {
   return String(process.env[key] ?? fallback).trim();
 }
@@ -641,7 +642,7 @@ export default async function handler(req: any, res: any) {
       : "low";
 
     const safeFilename = sanitizeStorageFilename(filename);
-    const storagePath = `analyses/${ownerId}/${now.getTime()}_${safeFilename}`;
+    const storagePath = `analyses/${ownerId}/${now.getTime()}_${randomUUID()}_${safeFilename}`;
 
     const processAppCtx = await getAdminApp();
 
@@ -677,7 +678,7 @@ export default async function handler(req: any, res: any) {
       }
     }
 
-    let documentId = `local-${ownerId}-${now.getTime()}`;
+    let documentId = `local-${ownerId}-${now.getTime()}-${randomUUID()}`;
     let persistenceMode = "local";
     let firestorePersisted = false;
 

--- a/server.ts
+++ b/server.ts
@@ -11,6 +11,7 @@ import admin from "firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
 import cors from "cors";
+import { randomUUID } from "crypto";
 import rateLimit from "express-rate-limit";
 import DOMPurify from "isomorphic-dompurify";
 import logger from "./src/lib/logger.js";
@@ -1082,7 +1083,7 @@ CRITICAL RULES:
         // SECURITY: For security, store only the storage path, not a permanent download URL
         // Signed URLs will be generated on-demand with short expiration (15 minutes)
         const safeFilename = sanitizeStorageFilename(file.originalname);
-        const storagePath = `analyses/${ownerId}/${now.getTime()}_${safeFilename}`;
+        const storagePath = `analyses/${ownerId}/${now.getTime()}_${randomUUID()}_${safeFilename}`;
         // Real Storage object URL, derived after upload. Included in docData and
         // every response record so client-side Firestore fallback writes pass
         // firestore.rules isValidDocument (requires a https `fileUrl`).
@@ -1262,7 +1263,7 @@ CRITICAL RULES:
             // Local-fallback: keep the uploaded Storage object so the owner can
             // download the source PDF (Issue #1029). Orphan cleanup for these
             // records is handled when the local document is deleted.
-            documentId = `local-${ownerId}-${now.getTime()}`;
+            documentId = `local-${ownerId}-${now.getTime()}-${randomUUID()}`;
             console.warn(
               "FIRESTORE_WRITE_FALLBACK: returning local analysis record because Firestore writes are not available",
             );


### PR DESCRIPTION
## Description
Uploaded-document Storage paths and local `documentId`s are built from the current millisecond plus the (user-controlled) filename, with no uniqueness/random component:
```ts
// api/analyze.ts:716-717
const safeFilename = sanitizeStorageFilename(filename);
const storagePath = `analyses/${ownerId}/${now.getTime()}_${safeFilename}`;
// api/process.ts:644  (same)  and  api/process.ts:680  documentId = `local-${ownerId}-${now.getTime()}`
```

## Expected Behavior
Object names must be unique per upload (e.g. include a UUID) so concurrent or sub-millisecond uploads cannot target the same Storage key.

## Actual Behavior
Two uploads by the same user within the same millisecond using the same filename produce an **identical `storagePath`**. The later `bucket.file(storagePath).save(...)` overwrites the earlier object, so the earlier document record now points at the wrong (or vanished) file — silent data corruption / ID collision, especially under programmatic or concurrent uploads. Same risk for `local-*` documentIds.

## Proposed Fix
```ts
import { randomUUID } from "crypto";
const storagePath = `analyses/${ownerId}/${now.getTime()}_${randomUUID()}_${safeFilename}`;
const documentId = `${ownerId}-${now.getTime()}-${randomUUID()}`;
```

Closes #1342