### PR TITLE
Document-analysis fallback path stores unsanitized filename and PDF text (stored XSS/script-injection vector)

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -250,6 +250,13 @@ function validateAnalysisPayload(payload: any): AnalysisResponse {
   if (wordCount < 120)
     throw new Error(`full_report too short (${wordCount} words)`);
 
+  return sanitizeAnalysisPayload(payload);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sanitizeAnalysisPayload(payload: any): AnalysisResponse {
+  const fullReport = String(payload.full_report || "").trim();
+
   return {
     summary: sanitizeString(String(payload.summary || "")),
     key_metrics:
@@ -699,10 +706,12 @@ full_report MUST be at least 300 words.`;
     }
 
     if (!validPayload) {
-      validPayload = buildFallbackAnalysis(
-        extractedText,
-        filename,
-        fallbackReason || undefined,
+      validPayload = sanitizeAnalysisPayload(
+        buildFallbackAnalysis(
+          extractedText,
+          filename,
+          fallbackReason || undefined,
+        ),
       );
     }
 
@@ -750,7 +759,7 @@ full_report MUST be at least 300 words.`;
 
     const docData: any = {
       ownerId,
-      fileName: filename,
+      fileName: sanitizeString(filename),
       fileType: "application/pdf",
       fileSize: fileBuffer.length,
       fileUrl,

--- a/api/process.ts
+++ b/api/process.ts
@@ -20,6 +20,8 @@ export const config = {
 
 export const maxDuration = 60; // Grant up to 60s execution time on Vercel
 
+import DOMPurify from "isomorphic-dompurify";
+
 // ---------------------------------------------------------------------------
 // Tiny helpers
 // ---------------------------------------------------------------------------
@@ -330,6 +332,38 @@ function validatePayload(p: any) {
   return p;
 }
 
+function sanitizeString(text: string): string {
+  return DOMPurify.sanitize(text, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sanitizeFallbackPayload(p: any) {
+  return {
+    summary: sanitizeString(String(p.summary || "")),
+    key_metrics:
+      typeof p.key_metrics === "object" && p.key_metrics ? p.key_metrics : {},
+    risk_assessment: Array.isArray(p.risk_assessment)
+      ? p.risk_assessment.map((item: any) => {
+        if (item && typeof item === "object") {
+          return {
+            level: sanitizeString(String(item.level || "")),
+            description: sanitizeString(String(item.description || "")),
+          };
+        }
+        return sanitizeString(String(item || ""));
+      })
+      : [],
+    action_items: Array.isArray(p.action_items)
+      ? p.action_items.map((v: any) => sanitizeString(String(v)))
+      : [],
+    sentiment_score: Number(p.sentiment_score || 0),
+    entities: Array.isArray(p.entities)
+      ? p.entities.map((v: any) => sanitizeString(String(v)))
+      : [],
+    full_report: sanitizeString(String(p.full_report || "")),
+  };
+}
+
 const SYSTEM_PROMPT = `You are a senior financial intelligence analyst. Produce detailed financial analysis based ONLY on the provided document.
 
 CRITICAL SECURITY NOTE:
@@ -622,10 +656,15 @@ export default async function handler(req: any, res: any) {
     const usedFallback = !analysisResult;
     if (!analysisResult) {
       console.warn(`[process] Using fallback analysis (hfKey present: ${!!hfKey})`);
-      analysisResult = buildFallbackAnalysis(
-        textForAnalysis,
-        filename,
-        hfKey ? "AI model returned invalid or timed out response" : "HUGGINGFACE_API_KEY not set in Vercel environment variables",
+      // The fallback embeds the user-controlled filename and extracted PDF text,
+      // so it must go through the same string sanitization as the AI path before
+      // it can be persisted (stored-XSS / script-injection defense).
+      analysisResult = sanitizeFallbackPayload(
+        buildFallbackAnalysis(
+          textForAnalysis,
+          filename,
+          hfKey ? "AI model returned invalid or timed out response" : "HUGGINGFACE_API_KEY not set in Vercel environment variables",
+        ),
       );
     }
 
@@ -688,7 +727,7 @@ export default async function handler(req: any, res: any) {
 
         const docData = {
           ownerId,
-          fileName: filename,
+          fileName: sanitizeString(filename),
           fileType: "application/pdf",
           fileSize: fileBuffer.length,
           fileUrl,


### PR DESCRIPTION
## Description
The document-analysis fallback path stores **unsanitized** user input. `buildFallbackAnalysis` (`api/analyze.ts:282`) embeds the raw `filename` and raw extracted PDF text into `summary`/`full_report`/`action_items`. The primary HuggingFace path runs every field through `sanitizeString` (`DOMPurify`, `api/analyze.ts:235-280`), **but the fallback result assigned at `api/analyze.ts:701-707` is never passed through `validateAnalysisPayload`/`sanitizeString`** and is stored verbatim to Firestore. `api/process.ts` has the identical gap (`buildFallbackAnalysis` at ~282, used at ~625 without sanitization).

## Expected Behavior
Both the AI path and the fallback path must sanitize all stored strings identically, so no attacker-controlled `<img onerror=...>` / `<script>` from a filename or PDF body can reach persisted records.

## Actual Behavior
A filename such as `<img src=x onerror=alert(1)>.pdf` (or injected PDF text) is persisted into `documents[].fileName`/`summary`/`full_report`. The stored record then becomes a stored HTML/script-injection source for any future consumer that renders it as HTML. This is an inconsistent defense-in-depth gap versus the hardened primary path.

## Proposed Fix
```ts
// api/analyze.ts ~701
if (!validPayload) {
  validPayload = validateAnalysisPayload(   // <-- reuses sanitizeString on every field
    buildFallbackAnalysis(extractedText, filename, fallbackReason || undefined),
  );
}
```
(and the same wrapping in `api/process.ts` where the fallback is built).

Closes #1340