### PR TITLE
Serverless routes persist a fabricated 'completed' analysis when PDF text extraction fails

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -652,15 +652,19 @@ export default async function handler(req: VercelReq, res: VercelRes) {
       );
     }
 
-    if (!extractedText || extractedText.length < 20) {
-      extractedText = `Document: ${filename}\nFile Size: ${fileBuffer.length} bytes.\nNotice: Scanned PDF or non-standard text layer.`;
-    }
+    const hasExtractableText = Boolean(extractedText) && extractedText.trim().length >= 20;
 
     const hfApiKey = getEnv("HUGGINGFACE_API_KEY");
     let validPayload: AnalysisResponse | null = null;
     let fallbackReason = "";
 
-    if (hfApiKey) {
+    if (!hasExtractableText) {
+      // Never feed a placeholder string to the model and then persist the
+      // result as a genuine "completed" analysis. A scanned/image PDF produces
+      // only an explicit fallback record so users are not shown a fabricated
+      // financial analysis of a document the system could not read.
+      fallbackReason = "Insufficient extractable text (scanned/image PDF)";
+    } else if (hfApiKey) {
       try {
         const { InferenceClient } = await import("@huggingface/inference");
         const hfClient = new InferenceClient(hfApiKey);

--- a/api/process.ts
+++ b/api/process.ts
@@ -610,22 +610,35 @@ export default async function handler(req: any, res: any) {
     // Step 3: Extract PDF text
     // ------------------------------------------------------------------
     const extractedText = await extractPdfText(fileBuffer);
-    const textForAnalysis = extractedText.length >= 50
-      ? extractedText
-      : `Document: ${filename}\nSize: ${fileBuffer.length} bytes\n(Insufficient text extracted — may be a scanned PDF)`;
 
     // ------------------------------------------------------------------
     // Step 4: AI analysis or fallback
     // ------------------------------------------------------------------
     const hfKey = getEnv("HUGGINGFACE_API_KEY") || getEnv("VITE_HUGGINGFACE_API_KEY");
-    let analysisResult = hfKey ? await runHfAnalysis(textForAnalysis, hfKey) : null;
+    let analysisResult: any = null;
+    let fallbackReason = "";
+
+    if (extractedText.length < 50) {
+      // Never feed a placeholder string to the model and persist its output as
+      // a genuine "completed" analysis. A scanned/image PDF yields only an
+      // explicit fallback record so users never see a fabricated financial
+      // analysis of a document the system could not read.
+      fallbackReason = "Insufficient extractable text (scanned/image PDF)";
+    } else {
+      analysisResult = hfKey ? await runHfAnalysis(extractedText, hfKey) : null;
+      if (!analysisResult) {
+        fallbackReason = hfKey
+          ? "AI model returned invalid or timed out response"
+          : "HUGGINGFACE_API_KEY not set in Vercel environment variables";
+      }
+    }
     const usedFallback = !analysisResult;
     if (!analysisResult) {
       console.warn(`[process] Using fallback analysis (hfKey present: ${!!hfKey})`);
       analysisResult = buildFallbackAnalysis(
-        textForAnalysis,
+        extractedText,
         filename,
-        hfKey ? "AI model returned invalid or timed out response" : "HUGGINGFACE_API_KEY not set in Vercel environment variables",
+        fallbackReason,
       );
     }
 


### PR DESCRIPTION
## Description
When PDF text extraction yields little/no text, the serverless routes feed a **placeholder string** to the model and then persist the result as a normal "completed" analysis:
```ts
// api/process.ts:613-622
const textForAnalysis = extractedText.length >= 50
  ? extractedText
  : `Document: ${filename}\nSize: ${fileBuffer.length} bytes\n(Insufficient text extracted — may be a scanned PDF)`;
let analysisResult = hfKey ? await runHfAnalysis(textForAnalysis, hfKey) : null;
const usedFallback = !analysisResult;
if (!analysisResult) { analysisResult = buildFallbackAnalysis(textForAnalysis, filename, ...); }
```
If `hfKey` is set and the model returns anything parseable, `analysisResult` is truthy so `usedFallback` is `false` and the placeholder-derived result is stored with `status: "completed"`. `api/analyze.ts:655-656,701-707` has the same flaw.

## Expected Behavior
For an unreadable/scanned PDF, persist only an explicit fallback/error record (never a fabricated "completed" analysis). The Express `server.ts` correctly *throws* on `<100` chars of extracted text; the serverless routes silently degrade into a false positive.

## Actual Behavior
A scanned/image PDF produces a confidently-worded "financial analysis" fabricated from the model's priors about a non-existent document, while the system reports it as a genuine completed analysis. Users get misleading results and the UI shows a false "Analysis complete" state.

## Proposed Fix
```ts
if (extractedText.length < 50) {
  analysisResult = buildFallbackAnalysis("", filename, "Insufficient extractable text (scanned/image PDF)");
} else {
  analysisResult = hfKey ? await runHfAnalysis(extractedText, hfKey) : null;
  if (!analysisResult) analysisResult = buildFallbackAnalysis(extractedText, filename, "model unavailable");
}
```

Closes #1344