### PR TITLE
Serverless /api/analyze and /api/process lack per-user quota and rely on a spoofable X-Forwarded-For rate limit

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -127,6 +127,9 @@ function isPdfBuffer(buffer: Buffer, mimetype?: string): boolean {
 }
 
 const analyzeRateBuckets = new Map<string, number[]>();
+// Per-user in-flight counter so the serverless route enforces the same
+// concurrency cap as the Express backend (max 2 concurrent analyses per user).
+const inFlightAnalyzeByUser = new Map<string, number>();
 
 function acceptAnalyzeRequest(ip: string, limit = 10, windowMs = 10 * 60 * 1000): boolean {
   const now = Date.now();
@@ -534,22 +537,6 @@ export default async function handler(req: VercelReq, res: VercelRes) {
     return;
   }
 
-  const clientIp = String(
-    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
-      req.socket?.remoteAddress ||
-      "unknown",
-  );
-  if (!acceptAnalyzeRequest(clientIp)) {
-    res.status(429).json({
-      error: {
-        stage: "RATE_LIMIT",
-        reason: "Too many analysis requests. Please try again later.",
-        recommendation: "Wait a few minutes before retrying.",
-      },
-    });
-    return;
-  }
-
   try {
     await ensureAdminInitialized();
 
@@ -606,6 +593,35 @@ export default async function handler(req: VercelReq, res: VercelRes) {
       });
       return;
     }
+
+    // Per-user quota keyed on the verified uid, mirroring the Express backend
+    // (server.ts): 5 analyses / 24h per user and max 2 concurrent. The previous
+    // bucket key was the client-supplied X-Forwarded-For IP, which any client
+    // can spoof to mint a fresh bucket per request, voiding the limit.
+    if (!acceptAnalyzeRequest(ownerId, 5, 24 * 60 * 60 * 1000)) {
+      res.status(429).json({
+        error: {
+          stage: "RATE_LIMIT",
+          reason: "Daily analysis quota exceeded (5 analyses per 24 hours per user)",
+          recommendation: "Please try again tomorrow or upgrade your plan.",
+        },
+      });
+      return;
+    }
+
+    const inFlight = inFlightAnalyzeByUser.get(ownerId) || 0;
+    if (inFlight >= 2) {
+      res.status(429).json({
+        error: {
+          stage: "CONCURRENT_LIMIT",
+          reason: "Too many concurrent analysis requests (max 2 at a time)",
+          recommendation:
+            "Please wait for an in-progress analysis to finish before submitting another.",
+        },
+      });
+      return;
+    }
+    inFlightAnalyzeByUser.set(ownerId, inFlight + 1);
 
     const contentType = String(req.headers["content-type"] || "");
     const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^\s;]+))/i);
@@ -851,5 +867,13 @@ full_report MUST be at least 300 words.`;
         stack: isProd ? undefined : error?.stack,
       },
     });
+  } finally {
+    // Release the concurrency slot held for this user once the pipeline settles,
+    // regardless of whether it succeeded or failed.
+    if (ownerId) {
+      const updated = (inFlightAnalyzeByUser.get(ownerId) || 1) - 1;
+      if (updated <= 0) inFlightAnalyzeByUser.delete(ownerId);
+      else inFlightAnalyzeByUser.set(ownerId, updated);
+    }
   }
 }

--- a/api/process.ts
+++ b/api/process.ts
@@ -124,6 +124,9 @@ function isPdfBuffer(buffer: Buffer, mimetype?: string): boolean {
 }
 
 const processRateBuckets = new Map<string, number[]>();
+// Per-user in-flight counter so the serverless route enforces the same
+// concurrency cap as the Express backend (max 2 concurrent per user).
+const inFlightProcessByUser = new Map<string, number>();
 
 function acceptProcessRequest(ip: string, limit = 10, windowMs = 10 * 60 * 1000): boolean {
   const now = Date.now();
@@ -489,22 +492,6 @@ export default async function handler(req: any, res: any) {
   if (req.method === "OPTIONS") { res.status(204).end(); return; }
   if (req.method !== "POST") { res.status(405).json({ error: "Method Not Allowed" }); return; }
 
-  const clientIp = String(
-    (req.headers?.["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
-      req.socket?.remoteAddress ||
-      "unknown",
-  );
-  if (!acceptProcessRequest(clientIp)) {
-    res.status(429).json({
-      error: {
-        stage: "RATE_LIMIT",
-        reason: "Too many upload requests. Please try again later.",
-        recommendation: "Wait a few minutes before retrying.",
-      },
-    });
-    return;
-  }
-
   const startTime = Date.now();
 
   try {
@@ -563,6 +550,35 @@ export default async function handler(req: any, res: any) {
       });
       return;
     }
+
+    // Per-user quota keyed on the verified uid, mirroring the Express backend
+    // (server.ts): 5 analyses / 24h per user and max 2 concurrent. The previous
+    // bucket key was the client-supplied X-Forwarded-For IP, which any client
+    // can spoof to mint a fresh bucket per request, voiding the limit.
+    if (!acceptProcessRequest(ownerId, 5, 24 * 60 * 60 * 1000)) {
+      res.status(429).json({
+        error: {
+          stage: "RATE_LIMIT",
+          reason: "Daily analysis quota exceeded (5 analyses per 24 hours per user)",
+          recommendation: "Please try again tomorrow or upgrade your plan.",
+        },
+      });
+      return;
+    }
+
+    const inFlight = inFlightProcessByUser.get(ownerId) || 0;
+    if (inFlight >= 2) {
+      res.status(429).json({
+        error: {
+          stage: "CONCURRENT_LIMIT",
+          reason: "Too many concurrent analysis requests (max 2 at a time)",
+          recommendation:
+            "Please wait for an in-progress analysis to finish before submitting another.",
+        },
+      });
+      return;
+    }
+    inFlightProcessByUser.set(ownerId, inFlight + 1);
 
     // ------------------------------------------------------------------
     // Step 2: Parse multipart body
@@ -788,5 +804,13 @@ export default async function handler(req: any, res: any) {
         stack: isProd ? undefined : err?.stack,
       },
     });
+  } finally {
+    // Release the concurrency slot held for this user once the pipeline settles,
+    // regardless of whether it succeeded or failed.
+    if (ownerId) {
+      const updated = (inFlightProcessByUser.get(ownerId) || 1) - 1;
+      if (updated <= 0) inFlightProcessByUser.delete(ownerId);
+      else inFlightProcessByUser.set(ownerId, updated);
+    }
   }
 }


### PR DESCRIPTION
## Description
The serverless routes enforce a per-IP, in-memory sliding window only; the Express backend (`server.ts`) enforces a **per-user** daily quota (5/24h) + concurrency cap (≤2). The limiter key is attacker-controlled:
```ts
// api/analyze.ts:537-542 / 129-141 ; api/process.ts:492-497 / 126-138
const clientIp = String((req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() || req.socket?.remoteAddress || "unknown");
if (!acceptAnalyzeRequest(clientIp)) { res.status(429) ... }
```
`acceptAnalyzeRequest` keys a `Map` by `clientIp`; the leftmost `x-forwarded-for` value is fully spoofable.

## Expected Behavior
Limit by the verified `ownerId` (already decoded from the token) with the same daily + concurrency caps as `server.ts`.

## Actual Behavior
Any client can send `X-Forwarded-For: 1.2.3.4`, `1.2.3.5`, … to get a fresh 10/10-min bucket per request, so the limit is effectively void. Each call triggers an expensive `Qwen2.5-Coder-32B` HuggingFace inference, enabling unbounded cost/quota exhaustion and DoS of the analysis pipeline by a single authenticated (or leaked) account.

## Proposed Fix
```ts
// after token verify yields ownerId:
if (!acceptAnalyzeRequest(ownerId)) { res.status(429).json({ error: { stage: "RATE_LIMIT", reason: "Quota exceeded" } }); return; }
// drop reliance on x-forwarded-for for the bucket key; add 5/day + max-2 concurrency like server.ts
```

Closes #1345