### PR TITLE
HuggingFace inference API key is exposed in the client bundle via VITE_HF_TOKEN

### DIFF
--- a/api/agentChat.ts
+++ b/api/agentChat.ts
@@ -1,0 +1,165 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Vercel Serverless Function: /api/agent-chat
+ *
+ * Server-side model call for the agentic financial copilot (src/lib/chatAgent.ts).
+ * The browser never holds the Hugging Face inference key; it posts the message
+ * history here and this function performs the HF Inference call with the
+ * server-side HUGGINGFACE_API_KEY, keeping the credential out of the client
+ * bundle entirely. (Issue #1341)
+ *
+ * Heavy imports are dynamic so ESM/CJS interop issues cannot crash the runtime.
+ */
+
+export const maxDuration = 60; // Grant up to 60s execution time on Vercel
+
+const DEFAULT_AGENT_MODEL = "meta-llama/Meta-Llama-3-8B-Instruct";
+
+function getEnv(key: string, fallback = ""): string {
+  return String(process.env[key] || fallback).trim();
+}
+
+function getAllowedOrigins(): Set<string> {
+  const raw = getEnv("VITE_ALLOWED_ORIGINS") || getEnv("ALLOWED_ORIGINS");
+  if (!raw) return new Set();
+  return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
+}
+
+function applyCors(req: any, res: any): void {
+  const origin = String(req.headers?.origin ?? "");
+  const allowed = getAllowedOrigins();
+  if (origin && allowed.has(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+  } else if (!origin && !process.env.NODE_ENV?.includes("production")) {
+    // Non-browser / same-origin tooling in development
+    res.setHeader("Access-Control-Allow-Origin", "*");
+  }
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+}
+
+async function getAdminApp(): Promise<any | null> {
+  try {
+    const { default: admin } = await import("firebase-admin");
+    if (!admin.apps.length) {
+      admin.initializeApp({ credential: admin.credential.cert(JSON.parse(getEnv("FIREBASE_SERVICE_ACCOUNT"))) });
+    }
+    return { admin };
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req: any, res: any) {
+  applyCors(req, res);
+
+  if (req.method === "OPTIONS") { res.status(204).end(); return; }
+  if (req.method !== "POST") { res.status(405).json({ error: "Method Not Allowed" }); return; }
+
+  const authHeader = String(req.headers?.authorization ?? "");
+  if (!authHeader.startsWith("Bearer ")) {
+    res.status(401).json({
+      error: {
+        stage: "AUTH_VERIFICATION",
+        reason: "Missing or invalid Authorization token",
+        recommendation: "You are not authorized. Please sign in and try again.",
+      },
+    });
+    return;
+  }
+
+  const appCtx = await getAdminApp();
+  if (!appCtx) {
+    res.status(401).json({
+      error: {
+        stage: "AUTH_VERIFICATION",
+        reason: "Authentication could not be verified",
+        recommendation: "Server configuration error. Please try again later.",
+      },
+    });
+    return;
+  }
+
+  try {
+    const decoded = await appCtx.admin.auth().verifyIdToken(authHeader.slice(7));
+    if (decoded.email_verified !== true) {
+      res.status(403).json({
+        error: {
+          stage: "AUTH_VERIFICATION",
+          reason: "Email address is not verified",
+          recommendation:
+            "Verify your email address to access this feature, then sign in again.",
+        },
+      });
+      return;
+    }
+  } catch (authErr: any) {
+    console.warn("[agentChat] token verify failed:", authErr?.message);
+    res.status(401).json({
+      error: {
+        stage: "AUTH_VERIFICATION",
+        reason: `Invalid ID token: ${authErr?.message || String(authErr)}`,
+        recommendation:
+          "Your session token has expired or is invalid. Please sign out and sign in again.",
+      },
+    });
+    return;
+  }
+
+  const { systemPrompt, messages, model } = req.body || {};
+  if (typeof systemPrompt !== "string" || !Array.isArray(messages)) {
+    res.status(400).json({
+      error: {
+        stage: "BAD_REQUEST",
+        reason: "systemPrompt (string) and messages (array) are required",
+      },
+    });
+    return;
+  }
+
+  // Only a plain model id is accepted, never arbitrary strings, so the model
+  // field cannot be abused to smuggle prompt content into the request.
+  const requestedModel =
+    typeof model === "string" && /^[\w.\-/]+$/.test(model)
+      ? model
+      : DEFAULT_AGENT_MODEL;
+
+  const huggingFaceApiKey = getEnv("HUGGINGFACE_API_KEY");
+  if (!huggingFaceApiKey) {
+    res.status(503).json({
+      error: {
+        stage: "MODEL_UNAVAILABLE",
+        reason: "HUGGINGFACE_API_KEY is not configured on the server",
+      },
+    });
+    return;
+  }
+
+  try {
+    const { InferenceClient } = await import("@huggingface/inference");
+    const hfClient = new InferenceClient(huggingFaceApiKey);
+    const completion = await hfClient.chatCompletion({
+      model: requestedModel,
+      messages: [
+        { role: "system", content: systemPrompt },
+        ...messages,
+      ] as any,
+      max_tokens: 800,
+      temperature: 0.2,
+    });
+    const content = (completion as any)?.choices?.[0]?.message?.content ?? null;
+    if (content == null) {
+      res.status(502).json({
+        error: { stage: "MODEL_ERROR", reason: "Empty model response" },
+      });
+      return;
+    }
+    res.json({ content });
+  } catch (err: any) {
+    console.error("AGENT_CHAT_ERROR:", err?.message || err);
+    res.status(502).json({
+      error: { stage: "MODEL_ERROR", reason: "Model request failed" },
+    });
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -1344,6 +1344,63 @@ CRITICAL RULES:
     analyzePipelineHandler,
   );
 
+  // Agentic chat model calls. The browser never holds the HF inference key:
+  // it posts the message history (system + turns, no secrets) here and the
+  // server performs the model call with HUGGINGFACE_API_KEY, keeping the
+  // inference credential out of the client bundle entirely. The route sits
+  // behind requireFirebaseAuth (/api/*), so only signed-in users can spend
+  // the server key. (Issue #1341)
+  app.post("/api/agent-chat", async (req: any, res: any) => {
+    const { systemPrompt, messages, model } = req.body || {};
+    if (typeof systemPrompt !== "string" || !Array.isArray(messages)) {
+      return res.status(400).json({
+        error: {
+          stage: "BAD_REQUEST",
+          reason: "systemPrompt (string) and messages (array) are required",
+        },
+      });
+    }
+    // Only a plain model id is accepted, never arbitrary strings, so the model
+    // field cannot be abused to smuggle prompt content into the request.
+    const requestedModel =
+      typeof model === "string" && /^[\w.\-/]+$/.test(model)
+        ? model
+        : "meta-llama/Meta-Llama-3-8B-Instruct";
+    const huggingFaceApiKey = process.env.HUGGINGFACE_API_KEY;
+    if (!huggingFaceApiKey) {
+      return res.status(503).json({
+        error: {
+          stage: "MODEL_UNAVAILABLE",
+          reason: "HUGGINGFACE_API_KEY is not configured on the server",
+        },
+      });
+    }
+    try {
+      const hfClient = new InferenceClient(huggingFaceApiKey);
+      const completion = await hfClient.chatCompletion({
+        model: requestedModel,
+        messages: [
+          { role: "system", content: systemPrompt },
+          ...messages,
+        ] as any,
+        max_tokens: 800,
+        temperature: 0.2,
+      });
+      const content = (completion as any)?.choices?.[0]?.message?.content ?? null;
+      if (content == null) {
+        return res.status(502).json({
+          error: { stage: "MODEL_ERROR", reason: "Empty model response" },
+        });
+      }
+      return res.json({ content });
+    } catch (err: any) {
+      console.error("AGENT_CHAT_ERROR:", err?.message || err);
+      return res.status(502).json({
+        error: { stage: "MODEL_ERROR", reason: "Model request failed" },
+      });
+    }
+  });
+
   // Generate short-lived signed URL for secure document download
   // Prevents permanent URL access to sensitive financial documents
   // Rate limiting for /api/document-download-url to prevent signed-URL

--- a/src/components/chat/ChatAssistant.tsx
+++ b/src/components/chat/ChatAssistant.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { type User as FirebaseUser } from 'firebase/auth';
 import {
   collection,
   query,
@@ -87,7 +88,7 @@ const QUICK_ACTIONS = [
 ];
 
 interface ChatAssistantProps {
-  user: { uid: string } | null;
+  user: FirebaseUser | null;
 }
 
 export function ChatAssistant({ user }: ChatAssistantProps) {
@@ -306,10 +307,13 @@ export function ChatAssistant({ user }: ChatAssistantProps) {
 
       // The agentic copilot calls real analysis tools (and the model) instead of
       // returning a hardcoded template after a fake delay. It falls back to the
-      // deterministic keyword router when no model/token is configured.
+      // deterministic keyword router when no model/server key is configured.
+      // Model calls run through the authenticated /api/agent-chat endpoint so
+      // the HF inference key never reaches the client bundle. (Issue #1341)
       const response: ChatResponse = await generateAgentChatResponse(
         content,
         context,
+        async () => (await user?.getIdToken?.()) ?? null,
         generateChatResponse,
       );
       const assistantMessage: ChatMessage = {

--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -11,9 +11,12 @@
  * the final answer comes from a deterministic function that already ships in
  * this repo. When no model/token is configured, runAgentLoop returns null so
  * callers fall back to the deterministic keyword router in chatUtils.ts.
+ *
+ * The model call itself never happens in the browser: the agent loop posts its
+ * message history to the authenticated /api/agent-chat endpoint, which performs
+ * the HF Inference call with the server-side HUGGINGFACE_API_KEY. This keeps
+ * the inference credential out of the client bundle. (Issue #1341)
  */
-
-import { HfInference } from "@huggingface/inference";
 
 import { calculateMonthlyForecast, identifyRecurringTransactions } from "./cashflowUtils";
 import { detectAnomalies as detectAnomaliesCore, type Anomaly } from "./anomalyUtils";
@@ -227,9 +230,41 @@ export const TOOL_CATALOGUE: AgentTool[] = [
   },
 ];
 
-function getHfToken(): string | null {
-  const env = (import.meta as any).env;
-  return env?.VITE_HF_TOKEN || env?.HF_TOKEN || null;
+async function callModel(
+  systemPrompt: string,
+  messages: { role: "user" | "assistant"; content: string }[],
+  getAuthToken: () => Promise<string | null>,
+): Promise<string | null> {
+  const authToken = await getAuthToken();
+  if (!authToken) return null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Abort the request if the server does not respond within the per-call
+    // budget. Without this a hung API call would block the agent loop until
+    // the platform function/request timeout. (Issue #1036)
+    const controller = new AbortController();
+    timer = setTimeout(() => controller.abort(), MODEL_CALL_TIMEOUT_MS);
+    const res = await fetch("/api/agent-chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify({
+        systemPrompt,
+        messages,
+        model: DEFAULT_AGENT_MODEL,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data?.content === "string" ? data.content : null;
+  } catch {
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function buildSystemPrompt(tools: AgentTool[]): string {
@@ -341,6 +376,7 @@ async function callModel(
 export async function runAgentLoop(
   userMessage: string,
   context: FinancialContext,
+  getAuthToken: () => Promise<string | null>,
 ): Promise<AgentResult | null> {
   const tools = TOOL_CATALOGUE;
   const systemPrompt = buildSystemPrompt(tools);
@@ -365,7 +401,7 @@ export async function runAgentLoop(
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
     if (Date.now() > deadline) return null;
-    const reply = await callModel(systemPrompt, messages);
+    const reply = await callModel(systemPrompt, messages, getAuthToken);
     if (!reply) return null;
 
     const parsed = parseAgentJson(reply);
@@ -433,9 +469,10 @@ export async function runAgentLoop(
 export async function generateAgentChatResponse(
   userMessage: string,
   context: FinancialContext,
+  getAuthToken: () => Promise<string | null>,
   fallback: (msg: string, ctx: FinancialContext) => ChatResponse,
 ): Promise<ChatResponse & { steps?: AgentStep[] }> {
-  const agentResult = await runAgentLoop(userMessage, context);
+  const agentResult = await runAgentLoop(userMessage, context, getAuthToken);
   if (agentResult) {
     return {
       message: agentResult.message,


### PR DESCRIPTION
## Description
`chatAgent.ts:221-224` reads the HuggingFace key from a **Vite client** env var:
```ts
function getHfToken(): string | null {
  const env = (import.meta as any).env;
  return env?.VITE_HF_TOKEN || env?.HF_TOKEN || null;
}
```
and `callModel` (used in the agent loop) instantiates `new HfInference(token)` and calls the HF Inference API **directly from the browser** (`chatAgent.ts:297`).

## Expected Behavior
The project's paid inference key must be used only server-side (`process.env.HUGGINGFACE_API_KEY` in `server.ts`/`api/*`). The client must never receive it.

## Actual Behavior
`VITE_*` env vars are inlined into the shipped frontend bundle at build time. Any deployment that sets `VITE_HF_TOKEN`/`HF_TOKEN` leaks the project's HuggingFace billing/quota key to every visitor via "View Source", enabling direct API abuse and cost exhaustion. The server-side pipeline correctly keeps the key server-only, so this client path is an unnecessary exposure.

## Proposed Fix
Remove `getHfToken()` and route agentic chat through an authenticated server endpoint (the server already holds `HUGGINGFACE_API_KEY`). If a client token is truly required, mint a scoped per-user token server-side — never ship the project inference key.

Closes #1341