### PR TITLE
fix(wash-sale): track consumed repurchase shares to prevent double-counting (#1547)

### DIFF
--- a/src/api/wash-sale-detector.ts
+++ b/src/api/wash-sale-detector.ts
@@ -47,8 +47,13 @@ export async function detectWashSales(req: any, res: any) {
     const losses = mockTrades.filter(t => t.type === 'SELL' && t.realizedLoss && t.realizedLoss > 0);
     const buys = mockTrades.filter(t => t.type === 'BUY');
 
+    // Track how many shares of each repurchase have already been consumed so a
+    // single rebuy cannot be double-counted across multiple loss events.
+    const consumedByBuy: Record<string, number> = {};
+
     for (const lossTrade of losses) {
       const lossDate = new Date(lossTrade.date).getTime();
+      let coveredShares = 0;
 
       for (const buyTrade of buys) {
         if (buyTrade.ticker === lossTrade.ticker) {
@@ -57,9 +62,17 @@ export async function detectWashSales(req: any, res: any) {
 
           // If the buy is within a 61-day window (30 days before, day of, 30 days after)
           if (daysDiff <= 30) {
-            
-            // Calculate the disallowed portion (pro-rated if they didn't buy back the full amount)
-            const disallowedRatio = Math.min(buyTrade.shares / lossTrade.shares, 1);
+            const remainingBuy = (buyTrade.shares || 0) - (consumedByBuy[buyTrade.id] || 0);
+            const remainingLoss = (lossTrade.shares || 0) - coveredShares;
+            const allocatable = Math.min(remainingBuy, remainingLoss);
+
+            if (allocatable <= 0) continue;
+
+            consumedByBuy[buyTrade.id] = (consumedByBuy[buyTrade.id] || 0) + allocatable;
+            coveredShares += allocatable;
+
+            // Calculate the disallowed portion (pro-rated to shares actually consumed)
+            const disallowedRatio = allocatable / (lossTrade.shares || 1);
             const disallowedLoss = (lossTrade.realizedLoss || 0) * disallowedRatio;
 
             violations.push({
@@ -69,6 +82,8 @@ export async function detectWashSales(req: any, res: any) {
               disallowedLoss,
               daysDifference: Math.round(daysDiff)
             });
+
+            if (coveredShares >= (lossTrade.shares || 0)) break;
           }
         }
       }


### PR DESCRIPTION
## Problem

In `src/api/wash-sale-detector.ts`, a single repurchase (BUY) was matched independently against every loss-making sale (SELL) for the same ticker with no tracking of how many rebuy shares had already been consumed. A 25-share rebuy within 30 days of two separate 50-share loss sales would flag BOTH losses as wash sales using the same 25 shares, double-counting the repurchase and overstating `totalDisallowedLosses`. (issue #1547)

## Fix

- Added a `consumedByBuy` map tracking how many shares of each repurchase have already been allocated.
- For each loss event, only allocate up to the remaining un-consumed rebuy shares and up to the loss trade's own remaining shares (`coveredShares`), so a single rebuy can offset losses only up to its N shares across all loss events.
- The disallowed ratio is now computed from the actually-allocated shares (`allocatable / lossTrade.shares`) instead of the full rebuy shares, so only consumed shares disallow loss.
- Once a loss is fully covered (`coveredShares >= lossTrade.shares`) the inner loop breaks, and once a rebuy is exhausted it is skipped.

## Files changed

- src/api/wash-sale-detector.ts — added consumed-share tracking to the wash-sale matching loop.

## Testing

Static review only; dependencies are not installed so no build/lint was run. Logic verified against the described scenario (25-share rebuy vs two 50-share losses now offsets only the first 25 shares of loss, not both losses).

Closes #1547
