### PR TITLE
fix(portfolio): guard rebalancer against zero total/price divide-by-zero (#1532)

### DIFF
--- a/src/api/portfolio-rebalance.ts
+++ b/src/api/portfolio-rebalance.ts
@@ -34,12 +34,23 @@ export async function calculateRebalance(req: any, res: any) {
     }
 
     // 1. Calculate total portfolio value
+    const invalidPrice = assets.find(
+      asset => !isFinite(asset.currentPrice) || asset.currentPrice <= 0
+    );
+    if (invalidPrice) {
+      return res.status(400).json({ error: "Invalid asset price." });
+    }
+
     let totalValue = 0;
     const currentAllocations = assets.map(asset => {
       const value = asset.shares * asset.currentPrice;
       totalValue += value;
       return { ...asset, currentValue: value };
     });
+
+    if (!isFinite(totalValue) || totalValue <= 0) {
+      return res.status(400).json({ error: "Portfolio total value must be greater than zero." });
+    }
 
     const orders: RebalanceOrder[] = [];
     let driftWarning = false;


### PR DESCRIPTION
## Problem

In `src/api/portfolio-rebalance.ts`, the rebalancer computes `currentPercentage = (asset.currentValue / totalValue) * 100` and `sharesToTrade = Math.abs(valueDelta) / asset.currentPrice` with no guards for zero. When the portfolio is all-zero (or shares/price are zero) `totalValue === 0` yields `NaN` percentages; a zero `currentPrice` yields `Infinity` share orders. These invalid values flow into `recommendedOrders` and the UI. Covered by issue #1532.

## Fix

- Added a per-asset price validation before the value computation: any non-finite or `<= 0` `currentPrice` returns HTTP `400` with `"Invalid asset price."`.
- Added a `totalValue` guard after the allocation map: a non-finite or `<= 0` total returns HTTP `400` with `"Portfolio total value must be greater than zero."`.
- Since price is now guaranteed `> 0`, the per-order division `Math.abs(valueDelta) / asset.currentPrice` can no longer produce `Infinity`.

## Files changed

- `src/api/portfolio-rebalance.ts` — added zero/non-finite guards for total value and asset price before any division.

## Testing

Static review only: dependencies are not installed in this environment, so no build/run was performed. Verified by re-reading the edited region that all division paths are now preceded by a guard and that invalid inputs are rejected with 400 before reaching the math.

Closes #1532
