### PR TITLE
fix(wash-sale): carry sign of repurchase timing so UI shows before/after (#1518)

### DIFF
--- a/src/api/wash-sale-detector.ts
+++ b/src/api/wash-sale-detector.ts
@@ -15,7 +15,7 @@ interface WashSaleViolation {
   buyTradeId: string;
   ticker: string;
   disallowedLoss: number;
-  daysDifference: number;
+  daysDifference: number; // signed: positive = re-bought after the loss, negative = before
 }
 
 export async function detectWashSales(req: any, res: any) {
@@ -53,7 +53,8 @@ export async function detectWashSales(req: any, res: any) {
       for (const buyTrade of buys) {
         if (buyTrade.ticker === lossTrade.ticker) {
           const buyDate = new Date(buyTrade.date).getTime();
-          const daysDiff = Math.abs((buyDate - lossDate) / DAY_IN_MS);
+          const signedDaysDiff = (buyDate - lossDate) / DAY_IN_MS;
+          const daysDiff = Math.abs(signedDaysDiff);
 
           // If the buy is within a 61-day window (30 days before, day of, 30 days after)
           if (daysDiff <= 30) {
@@ -67,7 +68,7 @@ export async function detectWashSales(req: any, res: any) {
               buyTradeId: buyTrade.id,
               ticker: lossTrade.ticker,
               disallowedLoss,
-              daysDifference: Math.round(daysDiff)
+              daysDifference: Math.round(signedDaysDiff)
             });
           }
         }

--- a/src/components/WashSaleDetector.tsx
+++ b/src/components/WashSaleDetector.tsx
@@ -6,7 +6,7 @@ interface WashSaleViolation {
   buyTradeId: string;
   ticker: string;
   disallowedLoss: number;
-  daysDifference: number;
+  daysDifference: number; // signed: positive = re-bought after the loss, negative = before
 }
 
 interface DetectorData {
@@ -105,7 +105,10 @@ export default function WashSaleDetector() {
                       </span>
                     </div>
                     <p className="text-sm text-slate-500 flex items-center gap-1">
-                      <Clock className="w-3.5 h-3.5" /> Re-bought {violation.daysDifference} days after realizing loss
+                      <Clock className="w-3.5 h-3.5" />
+                      {violation.daysDifference >= 0
+                        ? `Re-bought ${violation.daysDifference} days after realizing loss`
+                        : `Re-bought ${Math.abs(violation.daysDifference)} days before realizing loss`}
                     </p>
                   </div>
                   


### PR DESCRIPTION
## Problem

`WashSaleDetector.tsx` always renders the repurchase timing as "Re-bought X days after realizing loss" (#1518). The backend (`src/api/wash-sale-detector.ts`) computes `daysDiff = Math.abs((buyDate - lossDate) / DAY_IN_MS)` and loses the sign, so a repurchase that happened *before* the loss sale is displayed as occurring *after* — factually wrong and confusing since before/after direction matters for interpreting the IRS rule.

## Fix

- `src/api/wash-sale-detector.ts`: compute the signed day difference `(buyDate - lossDate) / DAY_IN_MS`, keep `Math.abs(...)` only for the 30-day threshold check, and store the **signed** value in `daysDifference` (positive = after, negative = before). Updated the interface comment to document the sign.
- `src/components/WashSaleDetector.tsx`: render "Re-bought X days after realizing loss" when `daysDifference >= 0`, and "Re-bought X days before realizing loss" (using the absolute value) otherwise. Updated the component interface to document the sign.

## Files changed

- `src/api/wash-sale-detector.ts` — carry signed repurchase timing
- `src/components/WashSaleDetector.tsx` — render before/after based on sign

## Testing

Static review only; dependencies are not installed so no build/run performed. Logic verified by reading the edited regions: threshold check still uses the absolute value, and the UI branches on the sign.

Closes #1518
