### PR TITLE
fix(compliance): use local calendar date instead of UTC toISOString (#1533)

### DIFF
--- a/src/components/compliance/ComplianceAuditDashboard.tsx
+++ b/src/components/compliance/ComplianceAuditDashboard.tsx
@@ -29,7 +29,10 @@ export const ComplianceAuditDashboard: React.FC<{ user?: any }> = ({ user }) => 
       const realTransactions = transactions.map((t) => ({
         amount: t.amount,
         description: t.description || "",
-        date: t.date instanceof Date ? t.date.toISOString().split("T")[0] : String(t.date),
+        date: (() => {
+          const d = t.date instanceof Date ? t.date : new Date(t.date);
+          return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        })(),
         category: t.category,
         currency: baseCurrency,
       }));


### PR DESCRIPTION
## Problem

In `src/components/compliance/ComplianceAuditDashboard.tsx` (line 32), each transaction date was converted with `t.date.toISOString().split("T")[0]`. `toISOString()` renders in UTC, so a transaction made at local `2024-03-01 22:00` in a western-hemisphere timezone becomes `2024-03-02T03:00Z` and gets assigned to `2024-03-02`. Date-window compliance rules (structuring/smurfing day windows, large-transaction day windows, FINRA/business-day checks) then evaluate against the wrong calendar day. Covered by issue #1533.

## Fix

Replaced the UTC `toISOString()` conversion with a local-calendar-date formatter that uses `getFullYear()`/`getMonth()`/`getDate()` (the user's local timezone), producing `YYYY-MM-DD` from the transaction's actual local date. This keeps date-window detection aligned with the day the user made the transaction.

## Files changed

- `src/components/compliance/ComplianceAuditDashboard.tsx` — date now formatted from local date components instead of UTC `toISOString()`.

## Testing

Static review only: dependencies are not installed, so no build/run was performed. Verified by re-reading the edited region that the date string is built from local `getFullYear/getMonth/getDate` and matches `YYYY-MM-DD`.

Closes #1533
