### PR TITLE
fix(chat): remove duplicate callModel decl shadowing server-backed impl (#1540)

### DIFF
--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -415,40 +415,6 @@ function summariseObservation(obs: unknown): string {
   }
 }
 
-async function callModel(
-  systemPrompt: string,
-  messages: { role: "user" | "assistant"; content: string }[],
-): Promise<string | null> {
-  const token = getHfToken();
-  if (!token) return null;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const hf = new HfInference(token);
-    // Abort the HF request if the model does not respond within the per-call
-    // budget. Without this a hung API call would block the agent loop until
-    // the platform function/request timeout. (Issue #1036)
-    const controller = new AbortController();
-    timer = setTimeout(() => controller.abort(), MODEL_CALL_TIMEOUT_MS);
-    const completion = await hf.chatCompletion(
-      {
-        model: DEFAULT_AGENT_MODEL,
-        messages: [
-          { role: "system", content: systemPrompt },
-          ...messages,
-        ] as any,
-        max_tokens: 800,
-        temperature: 0.2,
-      },
-      { signal: controller.signal },
-    );
-    return (completion as any)?.choices?.[0]?.message?.content ?? null;
-  } catch {
-    return null;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
 /**
  * Run the agentic tool-calling loop. Returns null when no model/token is
  * configured or the model cannot produce a valid answer, so callers can fall


### PR DESCRIPTION
## Problem

`src/lib/chatAgent.ts` defined `callModel` twice in the same module scope. Because function declarations are hoisted, the second definition (the one that calls `getHfToken()` + `HfInference(token)` directly in the browser) shadowed the server-backed implementation (which routes through `/api/agent-chat` with the bearer token). This caused three problems: (1) the server-backed path was dead code, (2) `getHfToken`/`HfInference` were never imported, so the active path threw a `ReferenceError` caught by its `try/catch`, returning `null` and silently falling back to the keyword router, and (3) even if it worked it would leak the HF token client-side, violating the design in #1341. (Issue #1540)

## Fix

- Removed the duplicate `callModel` declaration (lines 418-450) that referenced the undefined `getHfToken()`/`HfInference`.
- Kept the server-backed `callModel(systemPrompt, messages, getAuthToken)` at line 292, which correctly routes through `/api/agent-chat` with the bearer token, keeping the HuggingFace key server-side.

## Files changed

- `src/lib/chatAgent.ts` — deleted the duplicate client-side `callModel` so the server-backed one is the only definition.

## Testing

Static review only (dependencies are not installed in the worktree). Confirmed that after the removal the only remaining `callModel` is the server-backed one and there are no references to `getHfToken`/`HfInference` in the module.

Closes #1540
