### PR TITLE
fix(reconciliation): reflect true in-memory queue backend in dashboard (#1519)

### DIFF
--- a/src/components/ReconciliationDashboard.tsx
+++ b/src/components/ReconciliationDashboard.tsx
@@ -86,7 +86,8 @@ export default function ReconciliationDashboard() {
         </div>
         <div className="bg-slate-50 border border-slate-200 p-5 rounded-2xl flex flex-col justify-center">
           <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">Queue Backend</p>
-          <p className="font-bold text-slate-800">Redis (BullMQ)</p>
+          <p className="font-bold text-slate-800">In-Memory (no persistence)</p>
+          <p className="text-xs text-amber-600 mt-1">State is lost on restart</p>
         </div>
         <div className="bg-slate-50 border border-slate-200 p-5 rounded-2xl flex flex-col justify-center">
           <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">Duplicates Prevented</p>


### PR DESCRIPTION
## Problem

`ReconciliationDashboard.tsx` claims a "Redis (BullMQ)" queue backend (#1519), but the actual implementation in `src/api/plaid-webhook.ts` keeps `transactionsDb` and `reconciliationLogs` as plain in-memory module-level arrays. There is no Redis client, no BullMQ worker, and no queue anywhere. The misleading label hides the real fragility (in-memory state lost on restart).

## Fix

- `src/components/ReconciliationDashboard.tsx`: changed the "Queue Backend" label from "Redis (BullMQ)" to "In-Memory (no persistence)" to accurately reflect the real implementation, and added an explicit "State is lost on restart" warning so operators/auditors understand the limitation.

## Files changed

- `src/components/ReconciliationDashboard.tsx` — corrected false Redis/BullMQ label, surfaced persistence limitation

## Testing

Static review only; dependencies are not installed so no build/run performed. Verified the edited region renders the corrected backend label and warning.

Closes #1519
