### PR TITLE
fix(tax): aggregate replacement shares to cap wash-sale disallowed loss (#1530)

### DIFF
--- a/src/api/wash-sale-detector.ts
+++ b/src/api/wash-sale-detector.ts
@@ -50,27 +50,39 @@ export async function detectWashSales(req: any, res: any) {
     for (const lossTrade of losses) {
       const lossDate = new Date(lossTrade.date).getTime();
 
-      for (const buyTrade of buys) {
-        if (buyTrade.ticker === lossTrade.ticker) {
-          const buyDate = new Date(buyTrade.date).getTime();
-          const daysDiff = Math.abs((buyDate - lossDate) / DAY_IN_MS);
+      // Aggregate replacement shares across all matching buys within the 30-day window.
+      const replacementShares = buys.reduce((sum, buyTrade) => {
+        if (buyTrade.ticker !== lossTrade.ticker) return sum;
+        const buyDate = new Date(buyTrade.date).getTime();
+        const daysDiff = Math.abs((buyDate - lossDate) / DAY_IN_MS);
+        return daysDiff <= 30 ? sum + buyTrade.shares : sum;
+      }, 0);
 
-          // If the buy is within a 61-day window (30 days before, day of, 30 days after)
-          if (daysDiff <= 30) {
-            
-            // Calculate the disallowed portion (pro-rated if they didn't buy back the full amount)
-            const disallowedRatio = Math.min(buyTrade.shares / lossTrade.shares, 1);
-            const disallowedLoss = (lossTrade.realizedLoss || 0) * disallowedRatio;
+      if (replacementShares > 0) {
+        // The disallowed loss is capped at the realized loss (ratio never exceeds 1).
+        const disallowedRatio = Math.min(replacementShares / lossTrade.shares, 1);
+        const disallowedLoss = (lossTrade.realizedLoss || 0) * disallowedRatio;
 
-            violations.push({
-              sellTradeId: lossTrade.id,
-              buyTradeId: buyTrade.id,
-              ticker: lossTrade.ticker,
-              disallowedLoss,
-              daysDifference: Math.round(daysDiff)
-            });
-          }
-        }
+        const nearestBuy = buys
+          .filter(b => b.ticker === lossTrade.ticker)
+          .reduce((closest, buyTrade) => {
+            const buyDate = new Date(buyTrade.date).getTime();
+            const daysDiff = Math.abs((buyDate - lossDate) / DAY_IN_MS);
+            if (daysDiff > 30) return closest;
+            return !closest || daysDiff < Math.abs((new Date(closest.date).getTime() - lossDate) / DAY_IN_MS)
+              ? buyTrade
+              : closest;
+          }, null as Trade | null);
+
+        violations.push({
+          sellTradeId: lossTrade.id,
+          buyTradeId: nearestBuy ? nearestBuy.id : "",
+          ticker: lossTrade.ticker,
+          disallowedLoss,
+          daysDifference: nearestBuy
+            ? Math.round(Math.abs((new Date(nearestBuy.date).getTime() - lossDate) / DAY_IN_MS))
+            : 0
+        });
       }
     }
 


### PR DESCRIPTION
## Problem

In `src/api/wash-sale-detector.ts`, the disallowed loss was computed and pushed per matching replacement buy, then summed — so multiple replacement buys within the 30-day window could sum to more than the realized loss (e.g. two 60-share buybacks against a 100-share $2,500 loss produced $3,000 disallowed, 1.2× the actual loss). The disallowed amount can never exceed the realized loss. Covered by issue #1530.

## Fix

- Aggregated all replacement shares for a given loss trade across every matching buy within the 30-day window before computing the ratio.
- Computed the disallowed loss once per loss trade with `Math.min(replacementShares / lossTrade.shares, 1)`, capping the ratio at 1 so `totalDisallowedLosses` can never exceed the realized loss.
- The violation record now references the nearest replacement buy (by `daysDifference`) for traceability while the reported `disallowedLoss` reflects the aggregated, capped amount.

## Files changed

- `src/api/wash-sale-detector.ts` — replaced per-buy disallowed-loss summation with aggregated, capped computation.

## Testing

Static review only: dependencies are not installed, so no build/run was performed. Verified by re-reading the edited region that `disallowedRatio` is `Math.min(..., 1)` and that replacement shares are summed across all in-window buys.

Closes #1530
