### PR TITLE
fix(reconciliation): count only actual merged duplicates, not every log line (#1546)

### DIFF
--- a/src/api/plaid-webhook.ts
+++ b/src/api/plaid-webhook.ts
@@ -17,6 +17,9 @@ interface ReconciliationLog {
   newPostedId: string;
   confidenceScore: number;
   merchantName: string;
+  // True only when a pending transaction was actually matched and de-duplicated.
+  // Logs that do not represent a prevented duplicate must not set this.
+  merged: boolean;
 }
 
 // Mock Database of active transactions
@@ -93,7 +96,8 @@ export async function handlePlaidWebhook(req: any, res: any) {
           mergedPendingId: matchedPending.id,
           newPostedId: postedTx.transaction_id,
           confidenceScore,
-          merchantName: postedTx.merchant_name
+          merchantName: postedTx.merchant_name,
+          merged: true
         });
 
       } else {
@@ -122,5 +126,8 @@ export async function handlePlaidWebhook(req: any, res: any) {
 
 // Endpoint for the UI to fetch the worker logs
 export async function getReconciliationLogs(req: any, res: any) {
-  res.json({ success: true, data: reconciliationLogs });
+  // Count only the reconciliation events where a duplicate was actually
+  // prevented (a pending was matched and merged), not every log line.
+  const duplicatesPrevented = reconciliationLogs.filter(l => l.merged).length;
+  res.json({ success: true, data: reconciliationLogs, duplicatesPrevented });
 }

--- a/src/components/ReconciliationDashboard.tsx
+++ b/src/components/ReconciliationDashboard.tsx
@@ -7,10 +7,12 @@ interface Log {
   newPostedId: string;
   confidenceScore: number;
   merchantName: string;
+  merged?: boolean;
 }
 
 export default function ReconciliationDashboard() {
   const [logs, setLogs] = useState<Log[]>([]);
+  const [duplicatesPrevented, setDuplicatesPrevented] = useState(0);
   const [loading, setLoading] = useState(false);
   const [triggering, setTriggering] = useState(false);
 
@@ -18,7 +20,15 @@ export default function ReconciliationDashboard() {
     try {
       const res = await fetch('/api/plaid/reconciliation-logs');
       const json = await res.json();
-      if (json.success) setLogs(json.data);
+      if (json.success) {
+        setLogs(json.data);
+        // Count actual prevented duplicates from the API, falling back to
+        // logs explicitly flagged as merged rather than the raw log length.
+        const prevented = typeof json.duplicatesPrevented === 'number'
+          ? json.duplicatesPrevented
+          : (json.data || []).filter((l: Log) => l.merged).length;
+        setDuplicatesPrevented(prevented);
+      }
     } catch (err) {
       console.error(err);
     }
@@ -90,7 +100,7 @@ export default function ReconciliationDashboard() {
         </div>
         <div className="bg-slate-50 border border-slate-200 p-5 rounded-2xl flex flex-col justify-center">
           <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">Duplicates Prevented</p>
-          <p className="font-black text-slate-800 text-2xl">{logs.length}</p>
+          <p className="font-black text-slate-800 text-2xl">{duplicatesPrevented}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Problem

`src/components/ReconciliationDashboard.tsx` displayed "Duplicates Prevented" as `{logs.length}`, i.e. every reconciliation log line. This overstates the metric because only logs representing an actual prevented duplicate (a pending transaction matched and merged into a posted one) should count, not routine reconciliations. (issue #1546)

## Fix

- Added an explicit `merged` flag to `ReconciliationLog` in `src/api/plaid-webhook.ts`, set to `true` only when a pending was actually matched and merged.
- `getReconciliationLogs` now returns a distinct `duplicatesPrevented` count computed from logs where `merged` is true, rather than the raw log length.
- The dashboard now reads `json.duplicatesPrevented` (with a fallback to counting `logs.filter(l => l.merged)`), and displays that value instead of `logs.length`.

## Files changed

- src/api/plaid-webhook.ts — added `merged` flag to logs and a `duplicatesPrevented` count in the API response.
- src/components/ReconciliationDashboard.tsx — consume the new count instead of reusing log length.

## Testing

Static review only; dependencies are not installed so no build/lint was run. Verified the API computes the count from merge events and the component no longer derives the metric from total log length.

Closes #1546
