### PR TITLE
fix(portfolio): normalize transaction symbol to uppercase to prevent duplicate holdings (#1363)

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -308,7 +308,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
   try {
     const transactionRef = doc(collection(db, 'portfolioTransactions'));
     const holdings = collection(db, 'portfolioHoldings');
-    const symbol = input.symbol.trim();
+    const symbol = input.symbol.trim().toUpperCase();
     const now = new Date().toISOString();
 
     // Resolve the user's base currency so a new holding created by a first buy


### PR DESCRIPTION
## Problem

In `src/lib/portfolioUtils.ts`, `addHolding` stores the symbol uppercased (`input.symbol.trim().toUpperCase()`), but `addTransaction` only trimmed it (`input.symbol.trim()`). The symbol lookup query is case-sensitive, so a holding created via "Add Holding" as `aapl` (stored `AAPL`) never matches a later BUY recorded as `aapl`, causing `addTransaction` to mint a second holding for the same instrument. This produces deterministic duplicate holdings distinct from the TOCTOU/soft-delete duplication issues. (Issue #1363)

## Fix

- Normalized the `symbol` variable in `addTransaction` to `input.symbol.trim().toUpperCase()` so it matches the normalization already used by `addHolding`.
- Because the same `symbol` value is used for the case-sensitive lookup query, the new-holding doc id (`${userId}_${symbol.toUpperCase()}`), the stored holding `symbol`/`name` fields, and the ledger transaction `symbol`, all paths now store and compare the symbol identically (uppercase), guaranteeing one holding per instrument.

## Files changed

- `src/lib/portfolioUtils.ts` — changed `const symbol = input.symbol.trim();` to `input.symbol.trim().toUpperCase()` in `addTransaction`.

## Testing

- Static review only; dependencies are not installed in this environment, so no build/typecheck was run. The change is a one-line normalization consistent with the existing `addHolding` behavior and the already-uppercased doc id construction.

Closes #1363
