### PR TITLE
fix(budget): align fetchLast3MonthsTransactions to exactly 3 months (#1539)

### DIFF
--- a/src/lib/budgetUtils.ts
+++ b/src/lib/budgetUtils.ts
@@ -377,7 +377,7 @@ async function fetchUserTransactionsInRange(
 
 export async function fetchLast3MonthsTransactions(userId: string): Promise<Transaction[]> {
   const now = new Date();
-  const startDate = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+  const startDate = new Date(now.getFullYear(), now.getMonth() - 2, 1);
   const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
   return fetchUserTransactionsInRange(userId, startDate, endDate);
 }


### PR DESCRIPTION
## Problem

`src/lib/budgetUtils.ts` `fetchLast3MonthsTransactions` set `startDate = month - 3` while `endDate = month + 1` (exclusive). That window covers four calendar months (-3, -2, -1, current), not the promised "last 3 months". `generateBudgetSuggestions` derives `windowMonths` from the actual returned span (which became 4), so suggested budgets/averages were divided by 4 instead of 3, understating the amounts. (Issue #1539)

## Fix

- Changed `startDate` from `now.getMonth() - 3` to `now.getMonth() - 2`, so the window covers exactly the last three calendar months (-2, -1, current) with the exclusive `month + 1` end.
- `generateBudgetSuggestions` already computes `windowMonths` dynamically from the actual expense months present, so it now correctly yields 3 for a fully-populated window.

## Files changed

- `src/lib/budgetUtils.ts` — one-line change to the start month of `fetchLast3MonthsTransactions`.

## Testing

Static review only (dependencies not installed). Confirmed the window now spans 3 calendar months and that `windowMonths` is data-derived, so the divisor is correct.

Closes #1539
