### PR TITLE
fix(chat): properly unsubscribe CommandPalette onSnapshot on auth change/unmount (#1531)

### DIFF
--- a/src/components/dashboard/CommandPalette.tsx
+++ b/src/components/dashboard/CommandPalette.tsx
@@ -48,7 +48,11 @@ export function CommandPalette({ onAction, onDocSelect }: CommandPaletteProps) {
 
   // Self-contained Firestore & local document subscription
   useEffect(() => {
+    let unsubscribeDocs: () => void = () => {};
+
     const unsubscribeAuth = auth.onAuthStateChanged((user) => {
+      unsubscribeDocs();
+
       if (!user) {
         setRecentDocs([]);
         return;
@@ -75,7 +79,7 @@ export function CommandPalette({ onAction, onDocSelect }: CommandPaletteProps) {
         setRecentDocs(combined.slice(0, 8));
       };
 
-      const unsubscribeDocs = onSnapshot(
+      unsubscribeDocs = onSnapshot(
         docsQuery,
         (snapshot) => {
           const docs = snapshot.docs.map((doc) => ({
@@ -89,11 +93,12 @@ export function CommandPalette({ onAction, onDocSelect }: CommandPaletteProps) {
           updateCombinedDocs([]);
         },
       );
-
-      return () => unsubscribeDocs();
     });
 
-    return () => unsubscribeAuth();
+    return () => {
+      unsubscribeDocs();
+      unsubscribeAuth();
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

In `src/components/dashboard/CommandPalette.tsx`, the `onSnapshot` subscription was created inside the `onAuthStateChanged` callback and returned from that callback as a "cleanup". Firebase's `onAuthStateChanged` ignores the callback's return value, so the docs listener was never unsubscribed — it leaked on every auth state change and could render stale data from a prior session. Covered by issue #1531.

## Fix

- Declared `unsubscribeDocs` in the effect's outer scope (initialized to a no-op).
- Called `unsubscribeDocs()` at the start of the auth callback to tear down any previous listener before re-subscribing.
- In the effect cleanup, both `unsubscribeDocs()` and `unsubscribeAuth()` are now invoked.
- Removed the ignored `return () => unsubscribeDocs();` from the auth callback.

## Files changed

- `src/components/dashboard/CommandPalette.tsx` — store docs unsubscribe in outer scope and clean up on auth change and unmount.

## Testing

Static review only: dependencies are not installed, so no build/run was performed. Verified by re-reading the edited region that `unsubscribeDocs()` is called before each (re)subscription and in the effect cleanup.

Closes #1531
