### PR TITLE
fix(forecast): remove erroneous month-index multiplier in multi-scenario chart (#1357)

### DIFF
--- a/src/components/forecast/MultiScenarioMatrix.tsx
+++ b/src/components/forecast/MultiScenarioMatrix.tsx
@@ -32,7 +32,7 @@ export const MultiScenarioMatrix: React.FC = () => {
       const growthFactor = 1 + (scen.revenueGrowthModifier / 100) * ((idx + 1) / 12);
       const expenseFactor = 1 + (scen.expenseInflationModifier / 100) * ((idx + 1) / 12);
       const realization = Math.max(0, 1 - (scen.defaultProbabilityModifier / 100) * ((idx + 1) / 12));
-      const netCash = Math.round(baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor) * realization);
+      const netCash = Math.round(baseMonthlyCash * (growthFactor / expenseFactor) * realization);
       dataPoint[scen.name] = netCash;
     });
     return dataPoint;


### PR DESCRIPTION
## Problem

In `src/components/forecast/MultiScenarioMatrix.tsx`, the per-month `netCash` was computed as `baseMonthlyCash * (idx + 1) * (growthFactor / expenseFactor) * realization`. The extra `* (idx + 1)` has no legitimate role: `growthFactor`, `expenseFactor`, and `realization` already incorporate the month progression. For December (`idx = 11`) this inflated the value ~12× relative to January, making the scenario curves and the "Net Balance" tooltip show a meaningless monotonic ramp rather than a per-month projection. (Issue #1357)

## Fix

- Removed the erroneous `* (idx + 1)` multiplier so `netCash = Math.round(baseMonthlyCash * (growthFactor / expenseFactor) * realization)`. Each monthly point is now a correct per-month figure, while the month-over-month drift still comes from the per-month `growthFactor`/`expenseFactor`/`realization` terms (which already scale with `idx`).

## Files changed

- `src/components/forecast/MultiScenarioMatrix.tsx` — dropped the `* (idx + 1)` factor from the `netCash` calculation.

## Testing

- Static review only; dependencies are not installed, so no build/typecheck was run. The change is a single-term removal and preserves the existing chart data shape and types.

Closes #1357
