### PR TITLE
fix(plaid-webhook): cap reconciliationLogs buffer to prevent unbounded memory growth (#1545)

### DIFF
--- a/src/api/plaid-webhook.ts
+++ b/src/api/plaid-webhook.ts
@@ -28,6 +28,10 @@ let transactionsDb: Transaction[] = [
 
 let reconciliationLogs: ReconciliationLog[] = [];
 
+// Bound the in-memory log buffer so a long-running server cannot grow memory
+// without limit. Only the most-recent entries are retained.
+const MAX_RECONCILIATION_LOGS = 500;
+
 export async function handlePlaidWebhook(req: any, res: any) {
   try {
     // In production, verify the Plaid webhook signature using plaid-node client
@@ -95,6 +99,10 @@ export async function handlePlaidWebhook(req: any, res: any) {
           confidenceScore,
           merchantName: postedTx.merchant_name
         });
+
+        if (reconciliationLogs.length > MAX_RECONCILIATION_LOGS) {
+          reconciliationLogs.length = MAX_RECONCILIATION_LOGS;
+        }
 
       } else {
         // No match found, safe to insert as a brand new transaction


### PR DESCRIPTION
## Problem

`src/api/plaid-webhook.ts` prepends every reconciliation event to a module-level `reconciliationLogs` array with no upper bound. On every webhook invocation the array grows by one entry and is never trimmed, so a long-running server leaks memory and can eventually OOM. (issue #1545)

## Fix

- Added a `MAX_RECONCILIATION_LOGS` constant (500) bounding the in-memory buffer.
- After each `reconciliationLogs.unshift(...)`, the array length is trimmed to `MAX_RECONCILIATION_LOGS` so only the most-recent entries are retained, preventing unbounded growth.

## Files changed

- src/api/plaid-webhook.ts — capped the reconciliation log buffer.

## Testing

Static review only; dependencies are not installed so no build/lint was run. Verified the trim runs after each append and limits the array to `MAX_RECONCILIATION_LOGS` entries.

Closes #1545
