### PR TITLE
fix(e2ee): persist ciphertext on upload and add download endpoint (#1538)

### DIFF
--- a/src/api/e2ee-vault.ts
+++ b/src/api/e2ee-vault.ts
@@ -9,10 +9,14 @@ interface EncryptedDocumentRecord {
   fileSize: number;
   iv: string; // Base64 Initialization Vector used by the client for AES-GCM
   ciphertextBlobId: string; // Reference to S3/GCS bucket object
+  ciphertextBase64: string; // The actual client-encrypted document, persisted zero-knowledge
 }
 
-// Mock Database Table
+// Mock Database Table (records) keyed by blob id -> stored ciphertext.
+// In production the ciphertext would be streamed to S3/GCS; here we keep it
+// in-memory alongside the metadata so it can be retrieved and decrypted locally.
 const vaultDb: EncryptedDocumentRecord[] = [];
+const ciphertextStore = new Map<string, string>();
 
 export async function uploadEncryptedDocument(req: any, res: any) {
   try {
@@ -25,10 +29,22 @@ export async function uploadEncryptedDocument(req: any, res: any) {
       return res.status(400).json({ error: "Missing required encryption parameters." });
     }
 
+    if (typeof ciphertextBase64 !== "string" || ciphertextBase64.length === 0) {
+      return res.status(400).json({ error: "Invalid ciphertext payload." });
+    }
+    // Guard against runaway payloads (e.g. accidental plaintext / oversized blob).
+    if (ciphertextBase64.length > 50 * 1024 * 1024) {
+      return res.status(413).json({ error: "Ciphertext exceeds maximum allowed size." });
+    }
+
     // In a production environment, we would stream the `ciphertextBase64` buffer 
     // directly to an AWS S3 bucket or Google Cloud Storage.
     // The server NEVER receives the AES key or the plaintext file.
     const mockBlobId = `s3://finsight-vault-e2ee/${user.uid}/${crypto.randomUUID()}.enc`;
+
+    // Persist the actual ciphertext under the blob id that the client will
+    // later request, so the document remains recoverable (zero-knowledge).
+    ciphertextStore.set(mockBlobId, ciphertextBase64);
 
     const newRecord: EncryptedDocumentRecord = {
       id: `doc_${Date.now()}`,
@@ -37,7 +53,8 @@ export async function uploadEncryptedDocument(req: any, res: any) {
       uploadDate: new Date().toISOString(),
       fileSize,
       iv,
-      ciphertextBlobId: mockBlobId
+      ciphertextBlobId: mockBlobId,
+      ciphertextBase64
     };
 
     vaultDb.push(newRecord);
@@ -80,5 +97,39 @@ export async function getVaultDocuments(req: any, res: any) {
   } catch (error: any) {
     logger.error("E2EE_FETCH_ERROR", { message: error.message });
     res.status(500).json({ error: "Failed to fetch vault metadata" });
+  }
+}
+
+export async function downloadEncryptedDocument(req: any, res: any) {
+  try {
+    const user = req.user;
+    if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+    const { id } = req.params;
+    const record = vaultDb.find((d) => d.id === id && d.userId === user.uid);
+    if (!record) {
+      return res.status(404).json({ error: "Document not found" });
+    }
+
+    // Return the stored ciphertext so the owner can decrypt it locally.
+    // The server never possesses the AES key or the plaintext.
+    const ciphertextBase64 = ciphertextStore.get(record.ciphertextBlobId) ?? record.ciphertextBase64;
+    if (!ciphertextBase64) {
+      return res.status(404).json({ error: "Ciphertext unavailable" });
+    }
+
+    res.json({
+      success: true,
+      data: {
+        id: record.id,
+        filename: record.filename,
+        iv: record.iv,
+        ciphertextBlobId: record.ciphertextBlobId,
+        ciphertextBase64
+      }
+    });
+  } catch (error: any) {
+    logger.error("E2EE_DOWNLOAD_ERROR", { message: error.message });
+    res.status(500).json({ error: "Failed to fetch encrypted document" });
   }
 }


### PR DESCRIPTION
## Problem

`src/api/e2ee-vault.ts` `uploadEncryptedDocument` destructured `ciphertextBase64` from the request body but never stored it. The `EncryptedDocumentRecord` only kept `ciphertextBlobId` (a random `s3://...` id) while the actual encrypted document was discarded, and `getVaultDocuments` returned only metadata + `iv`. Uploaded E2EE documents were therefore unrecoverable — a silent zero-knowledge data-loss bug. (Issue #1538)

## Fix

- Added a `ciphertextBase64` field to `EncryptedDocumentRecord` and persisted the client-encrypted ciphertext (keyed by the blob id in an in-memory `ciphertextStore`) so the document can be retrieved later.
- Added input validation for `ciphertextBase64` (must be a non-empty string, capped at 50 MB) before storing.
- Added a `downloadEncryptedDocument(req, res)` endpoint that returns the stored ciphertext (plus `iv` and `ciphertextBlobId`) for the owning user to decrypt locally. The server still never sees the AES key or plaintext.

## Files changed

- `src/api/e2ee-vault.ts` — persist ciphertext on upload, validate it, and add a download endpoint to retrieve it.

## Testing

Static review only (dependencies not installed). Verified TypeScript syntax by careful review; the mock store keeps ciphertext referenced by the same `ciphertextBlobId` used during upload, and `downloadEncryptedDocument` scopes the lookup by `userId` so only the owner can fetch their data.

Closes #1538
