### PR TITLE
fix(text2sql): validate orderBy field/direction against allowed schema (#1544)

### DIFF
--- a/src/api/text-to-sql.ts
+++ b/src/api/text-to-sql.ts
@@ -75,6 +75,28 @@ Output valid JSON only with keys: "collection", "where", "orderBy", "limit".`;
       delete (parsedQuery as any).limit;
     }
 
+    // Harden `orderBy` the same way `where` is sanitized: it must be a single
+    // object with a field restricted to the allowed schema and an optional,
+    // strictly-typed direction. Anything else is dropped so no arbitrary
+    // structure can flow through into the consumer.
+    const ORDER_BY_FIELDS = new Set(["amount", "category", "date", "merchant"]);
+    const orderBy = (parsedQuery as any).orderBy;
+    if (orderBy != null) {
+      const validShape =
+        typeof orderBy === "object" &&
+        !Array.isArray(orderBy) &&
+        typeof orderBy.field === "string" &&
+        ORDER_BY_FIELDS.has(orderBy.field) &&
+        (orderBy.direction == null ||
+          orderBy.direction === "asc" ||
+          orderBy.direction === "desc");
+      if (!validShape) {
+        delete (parsedQuery as any).orderBy;
+      } else if (orderBy.direction == null) {
+        orderBy.direction = "asc";
+      }
+    }
+
     if (!user?.uid) {
       return res.status(401).json({ error: "Unauthorized" });
     }


### PR DESCRIPTION
## Problem

`src/api/text-to-sql.ts` hardens the LLM-produced query by allowlisting keys and recursively sanitizing `where`, but `orderBy` is passed through with no validation. A model or attacker can place arbitrary structure (nested operators, unexpected field names) in `orderBy` and it flows straight into the consumer — a silent injection gap in the same "hardening" routine. (issue #1544)

## Fix

- Added `ORDER_BY_FIELDS` allowlist (`amount`, `category`, `date`, `merchant`), matching the transactions schema advertised in the prompt.
- `orderBy` is now validated: it must be a non-array object with a `field` string present in the allowlist, and an optional `direction` that is exactly `"asc"` or `"desc"`. Any value failing this shape is deleted from the parsed query.
- When valid but `direction` is omitted, it is defaulted to `"asc"`.
- This mirrors the strict sanitization already applied to `where`.

## Files changed

- src/api/text-to-sql.ts — added `orderBy` schema validation/hardening.

## Testing

Static review only; dependencies are not installed so no build/lint was run. Verified the validation rejects malformed/unknown orderBy fields and directions and only permits the allowlisted schema.

Closes #1544
