### PR TITLE
fix(plaid-webhook): require auth and scope reconciliation logs to user (#1515)

### DIFF
--- a/src/api/plaid-webhook.ts
+++ b/src/api/plaid-webhook.ts
@@ -12,6 +12,7 @@ interface Transaction {
 }
 
 interface ReconciliationLog {
+  userId: string;
   timestamp: string;
   mergedPendingId: string;
   newPostedId: string;
@@ -89,6 +90,7 @@ export async function handlePlaidWebhook(req: any, res: any) {
         logger.info(`[RECONCILIATION] Merged pending tx ${matchedPending.id} with posted tx ${postedTx.transaction_id}`);
         
         reconciliationLogs.unshift({
+          userId: matchedPending.userId,
           timestamp: new Date().toISOString(),
           mergedPendingId: matchedPending.id,
           newPostedId: postedTx.transaction_id,
@@ -122,5 +124,13 @@ export async function handlePlaidWebhook(req: any, res: any) {
 
 // Endpoint for the UI to fetch the worker logs
 export async function getReconciliationLogs(req: any, res: any) {
-  res.json({ success: true, data: reconciliationLogs });
+  const user = req.user;
+  if (!user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // Scope results to the authenticated user so cross-account log leakage is prevented.
+  const userLogs = reconciliationLogs.filter(log => log.userId === user.uid);
+
+  res.json({ success: true, data: userLogs });
 }


### PR DESCRIPTION
## Problem

`getReconciliationLogs` in src/api/plaid-webhook.ts returns the global `reconciliationLogs` array with no authentication or authorization check (#1515). Unlike every other handler, it never reads `req.user`, so anyone reaching `/api/plaid/reconciliation-logs` receives the full global log buffer, leaking other users' transaction IDs, merchant names, and match confidence.

## Fix

- Added `userId: string` to the `ReconciliationLog` interface and recorded `matchedPending.userId` when pushing a new log, so logs are attributable to a user.
- `getReconciliationLogs` now requires `req.user` and returns `401 Unauthorized` when missing — consistent with the other handlers.
- Returned logs are filtered to `log.userId === user.uid`, scoping results to the authenticated caller and preventing cross-account leakage.

## Files changed

- `src/api/plaid-webhook.ts` — auth gate + per-user scoping on reconciliation logs

## Testing

Static review only; dependencies are not installed so no build/run performed. Verified the handler rejects unauthenticated calls and filters by `user.uid`. Note: the `ReconciliationDashboard.tsx` UI fetch does not yet attach an auth token; that frontend wiring is out of scope for this backend security fix but would now receive a 401 until it sends credentials.

Closes #1515
