### PR TITLE
fix(e2ee): chunked base64 encoding for large files and surface upload errors (#1529)

### DIFF
--- a/src/components/E2EEVault.tsx
+++ b/src/components/E2EEVault.tsx
@@ -14,8 +14,21 @@ export default function E2EEVault() {
   const [encrypting, setEncrypting] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [docs, setDocs] = useState<StoredDoc[]>([]);
+  const [error, setError] = useState<string | null>(null);
   
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Convert bytes to base64 in chunks to avoid the engine's argument-count limit
+  // (String.fromCharCode.apply/spead overflow for buffers larger than ~64KB).
+  const bytesToBase64 = (bytes: Uint8Array): string => {
+    let binary = "";
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      const chunk = bytes.subarray(i, i + chunkSize);
+      binary += String.fromCharCode(...chunk);
+    }
+    return btoa(binary);
+  };
 
   // PBKDF2 Key Derivation + AES-GCM Encryption running entirely in the browser
   const encryptFileClientSide = async (file: File, pass: string) => {
@@ -49,12 +62,13 @@ export default function E2EEVault() {
 
     return {
       ciphertextBuffer: ciphertext,
-      ivBase64: btoa(String.fromCharCode(...iv))
+      ivBase64: bytesToBase64(iv)
     };
   };
 
   const handleUpload = async () => {
     if (!selectedFile || !password) return;
+    setError(null);
     
     try {
       // Step 1: Encrypt locally
@@ -63,8 +77,8 @@ export default function E2EEVault() {
       setEncrypting(false);
 
       // Convert buffer to base64 for JSON transport (in prod, use multipart form for large files)
-      const cipherArray = Array.from(new Uint8Array(ciphertextBuffer));
-      const ciphertextBase64 = btoa(String.fromCharCode.apply(null, cipherArray as unknown as number[]));
+      const cipherArray = new Uint8Array(ciphertextBuffer);
+      const ciphertextBase64 = bytesToBase64(cipherArray);
 
       // Step 2: Upload to server
       setUploading(true);
@@ -87,6 +101,7 @@ export default function E2EEVault() {
       }
     } catch (err) {
       console.error("Encryption/Upload failed", err);
+      setError("Encryption or upload failed. Please try again.");
     } finally {
       setEncrypting(false);
       setUploading(false);
@@ -165,6 +180,10 @@ export default function E2EEVault() {
               <><Lock className="w-5 h-5" /> Encrypt & Upload</>
             )}
           </button>
+
+          {error && (
+            <p className="text-xs text-red-500 font-medium">{error}</p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Problem

In `src/components/E2EEVault.tsx`, the encrypted bytes were converted to base64 with `btoa(String.fromCharCode.apply(null, cipherArray))`. `String.fromCharCode.apply` (and spread) pass every byte as a separate function argument, which throws `RangeError: Maximum call stack size exceeded` for buffers larger than ~64KB, so any document above ~64KB fails to encrypt/upload. The failure was only `console.error`'d, giving the user no feedback. Covered by issue #1529.

## Fix

- Added a `bytesToBase64` helper that builds the binary string in 32KB chunks (`String.fromCharCode(...chunk)`), avoiding the argument-count overflow.
- Replaced both the ciphertext (line 67) and IV base64 conversions with the chunked helper.
- Added an `error` state; the catch block now sets a user-visible message (rendered below the upload button) in addition to logging.

## Files changed

- `src/components/E2EEVault.tsx` — chunked base64 encoding for large files and surfaced upload errors in the UI.

## Testing

Static review only: dependencies are not installed, so no build/run was performed. Verified by re-reading the edited region that the base64 conversion is chunked and never spreads the full byte array into a single call.

Closes #1529
