### PR TITLE
fix(crypto): clear reconnect timer on unmount (#1536)

### DIFF
--- a/src/components/CryptoWebSocketProvider.tsx
+++ b/src/components/CryptoWebSocketProvider.tsx
@@ -20,6 +20,7 @@ export const CryptoWebSocketProvider: React.FC<{ children: React.ReactNode }> = 
   const [prices, setPrices] = useState<CryptoPrices>({});
   const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'connecting'>('disconnected');
   const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     // Connect to Binance WebSocket for real-time trade streams
@@ -56,13 +57,15 @@ export const CryptoWebSocketProvider: React.FC<{ children: React.ReactNode }> = 
       wsRef.current.onclose = () => {
         setConnectionStatus('disconnected');
         // Simple exponential backoff or auto-reconnect logic would go here
-        setTimeout(connect, 5000); 
+        if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = setTimeout(connect, 5000); 
       };
     };
 
     connect();
 
     return () => {
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       if (wsRef.current) {
         wsRef.current.close();
       }


### PR DESCRIPTION
## Problem

`src/components/CryptoWebSocketProvider.tsx` scheduled a reconnect via `setTimeout(connect, 5000)` inside `onclose` but never captured the timer id. The unmount cleanup only closed the socket, so a reconnect scheduled just before unmount survived ~5s and then ran `connect()` against an unmounted component (React warning) and opened an orphaned WebSocket that is never closed. (Issue #1536)

## Fix

- Added a `reconnectTimerRef` to hold the pending reconnect timer handle.
- Captured the handle when scheduling the reconnect in `onclose` (clearing any prior one first to avoid overlaps).
- Cleared the pending timer in the effect cleanup before closing the socket.

## Files changed

- `src/components/CryptoWebSocketProvider.tsx` — track and clear the reconnect timer on unmount.

## Testing

Static review only (dependencies not installed). Confirmed the timer id is captured on schedule and cleared in cleanup, so no orphaned reconnect timer or WebSocket survives unmount.

Closes #1536
