### PR TITLE
fix(text2sql): parse fenced/balanced JSON object in safeJsonParse (#1543)

### DIFF
--- a/src/api/text-to-sql.ts
+++ b/src/api/text-to-sql.ts
@@ -5,14 +5,70 @@ import logger from "../lib/logger.js";
 function safeJsonParse(text: string): unknown {
   const cleaned = (text || "").trim();
   if (!cleaned) throw new Error("Empty model response");
-  
-  let extracted = cleaned;
-  const firstObj = cleaned.indexOf("{");
-  const lastObj = cleaned.lastIndexOf("}");
-  if (firstObj !== -1 && lastObj !== -1) {
-    extracted = cleaned.substring(firstObj, lastObj + 1);
+
+  let extracted: string | null = null;
+
+  // 1. Prefer a fenced ```json ... ``` block if the model emitted one.
+  const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenceMatch) {
+    extracted = fenceMatch[1].trim();
   }
-  return JSON.parse(extracted);
+
+  // 2. Otherwise locate the balanced outermost `{...}` object by tracking
+  //    brace depth, so prose containing stray `{`/`}` or multiple JSON
+  //    objects no longer corrupts the slice.
+  if (!extracted) {
+    extracted = extractBalancedObject(cleaned);
+  }
+
+  if (!extracted) throw new Error("No JSON object found in model response");
+
+  const parsed = JSON.parse(extracted);
+  // The query is expected to be a single object, not an array or primitive.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Model response did not contain a single JSON object");
+  }
+  return parsed;
+}
+
+// Scans `text` for the first balanced `{...}` span (matching braces, ignoring
+// braces inside string literals) and returns it, or null if none is found.
+function extractBalancedObject(text: string): string | null {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0 && start !== -1) {
+          return text.substring(start, i + 1);
+        }
+      }
+    }
+  }
+
+  return null;
 }
 
 export async function handleTextToQuery(req: any, res: any) {


### PR DESCRIPTION
## Problem

`src/api/text-to-sql.ts` `safeJsonParse` extracted the model output using `indexOf("{")` to `lastIndexOf("}")`. Taking the first `{` to the last `}` is unsafe when the model emits multiple JSON objects (e.g. a reasoning object then the query), or when surrounding prose contains `{`/`}` — producing malformed or wrong JSON that fails parsing (→ 500) or, worse, a structurally-valid incorrect query. (issue #1543)

## Fix

- Prefer a fenced ```json block when present (extract its inner content).
- Otherwise scan for the balanced outermost `{...}` object via a new `extractBalancedObject` helper that tracks brace depth while ignoring braces inside string literals (handles escapes), so stray braces in prose or multiple JSON objects no longer corrupt the slice.
- The parsed result is validated to be a single non-array object before use; otherwise an error is thrown (handled by the existing 500 path).

## Files changed

- src/api/text-to-sql.ts — rewrote `safeJsonParse` to use fenced/balanced object extraction.

## Testing

Static review only; dependencies are not installed so no build/lint was run. Logic verified by reasoning through the multi-object and prose-brace cases; `extractBalancedObject` correctly returns the first balanced outermost object and ignores braces within quoted strings.

Closes #1543
