### PR TITLE
fix: resolve issue #1550

### DIFF
--- a/src/components/OverdraftProtection.tsx
+++ b/src/components/OverdraftProtection.tsx
@@ -76,7 +76,9 @@ export default function OverdraftProtection() {
           <div>
             <h3 className="text-lg font-bold text-rose-800 mb-1">Overdraft Risk Detected</h3>
             <p className="text-rose-700 text-sm">
-              Your projected balance is expected to drop below $0.00 on <span className="font-bold">{new Date(data.firstOverdraftDate!).toLocaleDateString()}</span>. 
+              Your projected balance is expected to drop below $0.00{data.firstOverdraftDate
+                ? <span className="font-bold"> on {new Date(data.firstOverdraftDate).toLocaleDateString()}</span>
+                : null}. 
               We recommend transferring funds immediately to avoid bank fees.
             </p>
           </div>


### PR DESCRIPTION
## Problem

In `src/components/OverdraftProtection.tsx`, the overdraft warning rendered `new Date(data.firstOverdraftDate!)` with a non-null assertion. When `firstOverdraftDate` is `null` (e.g. risk detected without a concrete date), `new Date(null)` → `new Date(0)` (epoch) and can crash/show a wrong date. (Issue #1550)

## Fix

- Removed the `!` assertion and made the date conditional: only render the formatted date inside the sentence when `firstOverdraftDate` is present; otherwise the message omits the specific date.

## Files changed

- src/components/OverdraftProtection.tsx — guard `firstOverdraftDate` null before formatting.

## Testing

Static review only (dependencies are not installed). Verified the JSX only formats the date when non-null; no assertion remains.

Closes #1550
