### PR TITLE
fix: resolve issue #1548

### DIFF
--- a/src/components/FIRESimulator.tsx
+++ b/src/components/FIRESimulator.tsx
@@ -38,6 +38,16 @@ export default function FIRESimulator() {
   const formatCurrency = (val: number) => 
     new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(val);
 
+  // Axis tick formatter that scales by magnitude so small net-worth values
+  // don't render as ".0M".
+  const formatAxisValue = (val: number) => {
+    const abs = Math.abs(val);
+    if (abs >= 1e9) return `$${(val / 1e9).toFixed(1)}B`;
+    if (abs >= 1e6) return `$${(val / 1e6).toFixed(1)}M`;
+    if (abs >= 1e3) return `$${(val / 1e3).toFixed(0)}K`;
+    return `$${val.toFixed(0)}`;
+  };
+
   return (
     <div className="w-full max-w-5xl mx-auto bg-white p-8 rounded-3xl shadow-sm border border-slate-100 flex flex-col lg:flex-row gap-8">
       
@@ -156,7 +166,7 @@ export default function FIRESimulator() {
                   <YAxis 
                     axisLine={false} tickLine={false} 
                     tick={{ fill: '#64748b', fontSize: 12 }}
-                    tickFormatter={(val) => `$${(val/1000000).toFixed(1)}M`}
+                    tickFormatter={formatAxisValue}
                   />
                   <Tooltip 
                     formatter={(value: number) => [formatCurrency(value), 'Projected Net Worth']}


### PR DESCRIPTION
## Problem

In `src/components/FIRESimulator.tsx`, the Y-axis `tickFormatter` hardcoded `$${(val/1000000).toFixed(1)}M`. For net-worth values below $1,000,000 (e.g. the default $150k start), ticks render as `.0M`, hiding the real scale. (Issue #1548)

## Fix

- Added `formatAxisValue` which picks the unit by magnitude (B / M / K / plain `$`) and used it as the `YAxis` `tickFormatter`, so small portfolios display correctly (e.g. `$150K`).

## Files changed

- src/components/FIRESimulator.tsx — magnitude-aware Y-axis formatting.

## Testing

Static review only (dependencies are not installed). Verified thresholds: `>=1e9`→B, `>=1e6`→M, `>=1e3`→K, else plain; `0` renders `$0`.

Closes #1548
