### PR TITLE
fix: resolve issue #1554

### DIFF
--- a/src/lib/rag/textChunker.ts
+++ b/src/lib/rag/textChunker.ts
@@ -62,17 +62,38 @@ export function chunkFinancialDocument(
   // Financial section headers regex patterns
   const sectionHeaderRegex = /(?:BALANCE SHEET|INCOME STATEMENT|CASH FLOWS|NOTES TO FINANCIAL STATEMENTS|RISK FACTORS|MANAGEMENT'S DISCUSSION|AUDITOR'S REPORT|MD&A|NOTE \d+)/i;
 
-  const paragraphs = text.split(/\n\s*\n/);
+  // Split into paragraphs while computing true character offsets in the source
+  // text. Using text.indexOf() would resolve repeated or substring paragraphs
+  // to the wrong offset, corrupting page/citation data.
+  const paragraphBounds: { para: string; start: number; end: number }[] = [];
+  {
+    const paraRegex = /\n\s*\n/g;
+    let segmentStart = 0;
+    let m: RegExpExecArray | null;
+    while ((m = paraRegex.exec(text)) !== null) {
+      paragraphBounds.push({
+        para: text.slice(segmentStart, m.index).trim(),
+        start: segmentStart,
+        end: m.index,
+      });
+      segmentStart = m.index + m[0].length;
+    }
+    paragraphBounds.push({
+      para: text.slice(segmentStart).trim(),
+      start: segmentStart,
+      end: text.length,
+    });
+  }
+
   let currentChunkText = "";
   let currentHeader = "Executive Summary";
   let chunkIndex = 0;
 
-  let searchIndex = 0;
   let currentChunkParas: { start: number; end: number }[] = [];
   let currentChunkCharStart = 0;
 
-  for (let i = 0; i < paragraphs.length; i++) {
-    const para = paragraphs[i].trim();
+  for (let i = 0; i < paragraphBounds.length; i++) {
+    const para = paragraphBounds[i].para;
     if (!para) continue;
 
     // Detect section headers if enabled
@@ -86,11 +107,8 @@ export function chunkFinancialDocument(
     const paraTokens = estimateTokens(para);
     const currentTokens = estimateTokens(currentChunkText);
 
-    const paraStart = text.indexOf(para, searchIndex);
-    const paraEnd = paraStart + para.length;
-    if (paraStart !== -1) {
-      searchIndex = paraEnd;
-    }
+    const paraStart = paragraphBounds[i].start;
+    const paraEnd = paragraphBounds[i].end;
 
     if (currentTokens + paraTokens > chunkSize && currentChunkText.length > 0) {
       const charStart = currentChunkCharStart;


### PR DESCRIPTION
## Problem

In `src/lib/rag/textChunker.ts`, paragraph character offsets were located via `text.indexOf(para, searchIndex)`. For repeated paragraphs (or paragraphs that are substrings of earlier text), `indexOf` resolves to the wrong position, producing incorrect `charStart`/`charEnd` and therefore wrong page/citation data for retrieved chunks. (Issue #1554)

## Fix

- Replace the `text.split(...)` + `text.indexOf()` approach with an explicit paragraph scan that records the true `start`/`end` offsets of each paragraph segment as it walks the source text.
- The offsets now correspond exactly to where each paragraph occurs in the original document, regardless of duplicate or substring content.

## Files changed

- src/lib/rag/textChunker.ts — compute real paragraph offsets during splitting instead of `indexOf`.

## Testing

Static review only (dependencies are not installed). Logic verified by tracing the offset computation against the original text boundaries; no behavioral change to chunk content, only to the accuracy of `charStart`/`charEnd`/`pageNumber`.

Closes #1554
