### PR TITLE
fix: resolve issue #1551

### DIFF
--- a/src/api/anomaly-detection.ts
+++ b/src/api/anomaly-detection.ts
@@ -9,6 +9,25 @@ import logger from "../lib/logger.js";
 // Windows/non-shell environments.
 const execFilePromise = util.promisify(execFile);
 
+// Resolve the Python interpreter from configuration so it is portable across
+// platforms. Windows commonly ships `python` rather than `python3`.
+const PYTHON_INTERPRETER =
+  process.env.ANOMALY_PYTHON_INTERPRETER ||
+  (process.platform === "win32" ? "python" : "python3");
+
+// Only a vetted, known script may be executed. Prevent arbitrary script paths
+// (e.g. via misconfiguration or path traversal) from being run.
+const ALLOWED_SCRIPTS = new Set(["anomaly_model.py"]);
+const ALLOWED_SCRIPT_DIR = path.resolve(process.cwd(), "scripts");
+
+function resolveAllowedScript(name: string): string | null {
+  if (!ALLOWED_SCRIPTS.has(name)) return null;
+  const resolved = path.resolve(ALLOWED_SCRIPT_DIR, name);
+  // Ensure the resolved path cannot escape the allowed directory.
+  if (path.relative(ALLOWED_SCRIPT_DIR, resolved).startsWith("..")) return null;
+  return resolved;
+}
+
 export async function detectAnomalies(req: any, res: any) {
   try {
     const user = req.user;
@@ -19,13 +38,18 @@ export async function detectAnomalies(req: any, res: any) {
     // In a real production scenario, we'd fetch the last 30 days of transactions
     // from Firestore for this user, format them to a CSV or JSON, and pass it
     // to our Python microservice or script running scikit-learn Isolation Forest.
-    
-    // Stub: Passing user ID to the python script
-    const scriptPath = path.resolve(process.cwd(), "scripts/anomaly_model.py");
+
+    // Stub: Passing user ID to the python script. The interpreter and script
+    // path are validated against an allowlist and never interpolated into a shell.
+    const scriptPath = resolveAllowedScript("anomaly_model.py");
+    if (!scriptPath) {
+      logger.error("ANOMALY_DETECTION_ERROR", { message: "Invalid script configuration" });
+      return res.status(500).json({ error: "Invalid anomaly detection script configuration" });
+    }
 
     // Note: Python script must be executed in an environment with scikit-learn installed.
     // Pass the uid as a discrete argument — never interpolate it into a shell string.
-    const { stdout, stderr } = await execFilePromise("python3", [
+    const { stdout, stderr } = await execFilePromise(PYTHON_INTERPRETER, [
       scriptPath,
       "--uid",
       user.uid,


### PR DESCRIPTION
## Problem

`src/api/anomaly-detection.ts` hardcoded the `"python3"` interpreter (which does not exist on Windows, where it is typically `python`), breaking execution on Windows/portable environments. It also resolved the script path from `process.cwd()` with no allowlist, allowing arbitrary/unsanitized paths to be executed. (Issue #1551)

## Fix

- Interpreter is now resolved from `process.env.ANOMALY_PYTHON_INTERPRETER`, defaulting to `python` on Windows and `python3` elsewhere.
- Added a script-path allowlist (`ALLOWED_SCRIPTS`) and `resolveAllowedScript()` that confirms the resolved script stays inside the `scripts/` directory (no traversal) before execution.
- Returns a `500` with a clear error if the configured script is not on the allowlist.

## Files changed

- src/api/anomaly-detection.ts — configurable/portable interpreter and script allowlist.

## Testing

Static review only (dependencies are not installed). Verified the interpreter fallback by platform, allowlist membership check, and path-traversal guard via `path.relative(...).startsWith("..")`.

Closes #1551
