### PR TITLE
fix(portfolio): currency-convert per-holding P/L rows and calculateProfitLoss (#1355)

### DIFF
--- a/src/components/portfolio/PortfolioTracker.tsx
+++ b/src/components/portfolio/PortfolioTracker.tsx
@@ -513,8 +513,16 @@ export function PortfolioTracker({ user }: PortfolioTrackerProps) {
               </Card>
             ) : (
               holdings.map((h) => {
-                const value = h.quantity * h.currentPrice;
-                const cost = h.quantity * h.avgCost;
+                const localValue = h.quantity * h.currentPrice;
+                const localCost = h.quantity * h.avgCost;
+                const value =
+                  !rates || !h.currency || h.currency === baseCurrency
+                    ? localValue
+                    : (convertAmount(localValue, h.currency, baseCurrency, rates) ?? localValue);
+                const cost =
+                  !rates || !h.currency || h.currency === baseCurrency
+                    ? localCost
+                    : (convertAmount(localCost, h.currency, baseCurrency, rates) ?? localCost);
                 const pl = value - cost;
                 const plPercent = cost > 0 ? (pl / cost) * 100 : 0;
                 return (

--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -204,8 +204,16 @@ export function calculateTotalValue(
   }, 0);
 }
 
-export function calculateProfitLoss(holding: Holding): { value: number; percent: number } {
-  const value = (holding.currentPrice - holding.avgCost) * holding.quantity;
+export function calculateProfitLoss(
+  holding: Holding,
+  rates?: Record<string, number>,
+  baseCurrency?: string,
+): { value: number; percent: number } {
+  const localValue = (holding.currentPrice - holding.avgCost) * holding.quantity;
+  const value =
+    !rates || !holding.currency || holding.currency === baseCurrency
+      ? localValue
+      : (convertAmount(localValue, holding.currency, baseCurrency, rates) ?? localValue);
   const percent = holding.avgCost > 0 ? ((holding.currentPrice - holding.avgCost) / holding.avgCost) * 100 : 0;
   return { value, percent };
 }


### PR DESCRIPTION
## Problem

For multi-currency portfolios, the per-holding "Value"/"P/L" rows in `PortfolioTracker.tsx` were computed directly in each holding's local currency (`h.quantity * h.currentPrice`, `h.quantity * h.avgCost`) with no FX conversion, so they no longer summed to the FX-converted Total Value card. The `calculateProfitLoss` helper in `src/lib/portfolioUtils.ts` had the same gap (purely local-currency math, no `convertAmount`), which the issue identifies as the source of the silent discrepancy where `profitLoss ≠ totalValue − totalCost`. (Issue #1355)

## Fix

- `src/lib/portfolioUtils.ts` — `calculateProfitLoss` now accepts optional `rates` and `baseCurrency`. When supplied and the holding's currency differs from the base, it converts the local P/L via `convertAmount` (falling back to the local value when a rate is genuinely missing), matching the conversion behavior already used by `holdingBaseValue`. The percentage term is currency-independent so it is unchanged.
- `src/components/portfolio/PortfolioTracker.tsx` — the per-holding rows now convert both the local `value` and `cost` (and thus `pl`) to `baseCurrency` via `convertAmount` before rendering, mirroring the existing `profitLoss`/`totalCost` useMemo logic. This makes the per-holding "Value"/"P/L" rows add up to the Total Value / Profit-Loss cards.

## Files changed

- `src/lib/portfolioUtils.ts` — made `calculateProfitLoss` currency-aware.
- `src/components/portfolio/PortfolioTracker.tsx` — FX-convert per-holding value/cost/P/L rows.

## Testing

- Static review only; dependencies are not installed, so no build/typecheck was run. Changes are localized conversions consistent with the surrounding `convertAmount` usage and the existing SummaryCard P/L logic.

Closes #1355
