### PR TITLE
fix(expense-approval): enforce shared  threshold server-side and pass it from UI (#1513)

### DIFF
--- a/src/api/expense-approval.ts
+++ b/src/api/expense-approval.ts
@@ -14,17 +14,29 @@ interface ExpenseApproval {
 let sharedExpenseInbox: ExpenseApproval[] = [
   { id: "exp_101", initiator: "Partner A", merchant: "Apple Store", amount: 1299.00, category: "Electronics", date: new Date().toISOString(), status: 'PENDING' },
   { id: "exp_102", initiator: "Partner A", merchant: "Delta Airlines", amount: 645.50, category: "Travel", date: new Date(Date.now() - 86400000).toISOString(), status: 'PENDING' },
+  { id: "exp_103", initiator: "Partner A", merchant: "Corner Coffee", amount: 12.00, category: "Food", date: new Date(Date.now() - 3600000).toISOString(), status: 'PENDING' },
 ];
+
+// Shared multi-signature threshold. Expenses at or above this amount require
+// joint approval; the same value is used by the UI for display and by the API
+// for filtering so the shown list always matches the stated threshold.
+const APPROVAL_THRESHOLD = 500.00;
 
 export async function getPendingApprovals(req: any, res: any) {
   try {
     const user = req.user;
     if (!user) return res.status(401).json({ error: "Unauthorized" });
 
-    // Filter to only show PENDING in the inbox
-    const pending = sharedExpenseInbox.filter(exp => exp.status === 'PENDING');
+    // Accept an explicit threshold from the caller, falling back to the shared default.
+    const parsed = parseFloat(req.query.threshold as string);
+    const threshold = Number.isFinite(parsed) && parsed > 0 ? parsed : APPROVAL_THRESHOLD;
+
+    // Show only PENDING expenses at or above the approval threshold.
+    const pending = sharedExpenseInbox.filter(
+      exp => exp.status === 'PENDING' && exp.amount >= threshold
+    );
     
-    res.json({ success: true, data: pending });
+    res.json({ success: true, data: pending, threshold });
   } catch (error: any) {
     logger.error("APPROVAL_FETCH_ERROR", { message: error.message });
     res.status(500).json({ error: "Failed to fetch inbox" });

--- a/src/components/ExpenseApprovalInbox.tsx
+++ b/src/components/ExpenseApprovalInbox.tsx
@@ -16,12 +16,13 @@ export default function ExpenseApprovalInbox() {
   const [loading, setLoading] = useState(true);
   const [processingId, setProcessingId] = useState<string | null>(null);
   
-  // Shared threshold mock value
+  // Shared approval threshold. Sent to the API so the server filters by the exact
+  // same value that is displayed, keeping the list consistent with the label.
   const threshold = 500.00; 
 
   const fetchInbox = async () => {
     try {
-      const res = await fetch('/api/shared-accounts/approvals');
+      const res = await fetch(`/api/shared-accounts/approvals?threshold=${threshold}`);
       const json = await res.json();
       if (json.success) setInbox(json.data);
     } catch (err) {


### PR DESCRIPTION
## Problem

`ExpenseApprovalInbox.tsx` hardcodes a $500 threshold purely for display, but `getPendingApprovals` in src/api/expense-approval.ts returns every `PENDING` expense with no amount filter (#1513). The inbox shows the "$500" label while rendering all pending expenses (e.g. a $12 coffee appears under "expenses over $500"), misleading users about what needs multi-sig approval.

## Fix

- `src/api/expense-approval.ts`: introduced a shared `APPROVAL_THRESHOLD = 500.00`, and `getPendingApprovals` now filters PENDING expenses to those `amount >= threshold`. The threshold is accepted from the caller via `?threshold=` query param (falling back to the shared default), and the used value is returned in the response so the UI can confirm it matches. Added a third mock pending expense ($12) to prove the filter.
- `src/components/ExpenseApprovalInbox.tsx`: the fetch now passes `?threshold=${threshold}` so the server enforces the exact value displayed, guaranteeing the shown list matches the "$500" label.

## Files changed

- `src/api/expense-approval.ts` — server-side threshold filtering + shared constant
- `src/components/ExpenseApprovalInbox.tsx` — pass threshold to API, keep display consistent

## Testing

Static review only; dependencies are not installed so no build/run performed. Verified the backend filters by threshold and returns it, and the UI sends the same threshold it displays.

Closes #1513
