### PR TITLE
fix(debt): fix negative monthsSaved text and mismatched chart merge (#1528)

### DIFF
--- a/src/components/DebtVisualizer.tsx
+++ b/src/components/DebtVisualizer.tsx
@@ -60,14 +60,15 @@ export default function DebtVisualizer() {
     for (let i = 0; i < maxMonths; i++) {
       chartData.push({
         month: `Month ${i}`,
-        snowball: result.snowball.trajectory[i] || 0,
-        avalanche: result.avalanche.trajectory[i] || 0
+        snowball: i < result.snowball.trajectory.length ? result.snowball.trajectory[i] : undefined,
+        avalanche: i < result.avalanche.trajectory.length ? result.avalanche.trajectory[i] : undefined
       });
     }
   }
 
   const interestSaved = result ? result.snowball.totalInterestPaid - result.avalanche.totalInterestPaid : 0;
   const monthsSaved = result ? result.snowball.monthsToFreedom - result.avalanche.monthsToFreedom : 0;
+  const avalancheFaster = monthsSaved > 0;
 
   return (
     <div className="w-full max-w-5xl mx-auto bg-white p-8 rounded-3xl shadow-sm border border-slate-100 flex flex-col lg:flex-row gap-8">
@@ -173,7 +174,7 @@ export default function DebtVisualizer() {
                 <Sparkles className="w-6 h-6 text-emerald-500 shrink-0" />
                 <div>
                   <p className="text-sm font-bold text-emerald-800">Avalanche is Optimal</p>
-                  <p className="text-xs text-emerald-700 mt-1">By prioritizing high-interest debt first, you will save <span className="font-bold">{formatCurrency(interestSaved)}</span> and be debt-free <span className="font-bold">{monthsSaved} months earlier</span> than the Snowball method.</p>
+                  <p className="text-xs text-emerald-700 mt-1">By prioritizing high-interest debt first, you will save <span className="font-bold">{formatCurrency(interestSaved)}</span>{avalancheFaster ? <> and be debt-free <span className="font-bold">{monthsSaved} months earlier</span> than the Snowball method.</> : <> compared to the Snowball method.</>}</p>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Problem

In `src/components/DebtVisualizer.tsx`, two correctness issues from issue #1528:
1. `monthsSaved = snowball.monthsToFreedom - avalanche.monthsToFreedom` could be `0` or negative (when avalanche finishes later/equal), yet the "Avalanche is Optimal" banner always claimed "be debt-free {monthsSaved} months earlier", producing text like "be debt-free -3 months earlier".
2. The two strategies can have different trajectory lengths; the chart merged them by index with `|| 0`, so the shorter strategy's line dropped to `0` (implying an outstanding balance) at months where it had already finished.

## Fix

- Added `avalancheFaster = monthsSaved > 0`. The "months earlier" claim is now only rendered when avalanche genuinely finishes sooner; otherwise the banner states the comparison to Snowball without a misleading negative month count.
- Changed the chart merge to stop each series at its own length (`undefined` beyond `trajectory.length`) instead of padding with `0`, so finished strategies no longer appear to carry a balance.

## Files changed

- `src/components/DebtVisualizer.tsx` — conditional months-saved text and length-aware chart series merge.

## Testing

Static review only: dependencies are not installed, so no build/run was performed. Verified by re-reading the edited region that `avalancheFaster` gates the months text and that trajectory values are `undefined` past each strategy's own length.

Closes #1528
