### PR TITLE
fix(storage): persist encryption key so offline document cache survives reload (#1542)

### DIFF
--- a/src/lib/storageUtils.ts
+++ b/src/lib/storageUtils.ts
@@ -2,6 +2,12 @@
 
 const LOCAL_DOCS_KEY = "fin_local_documents_v1";
 
+// The AES-GCM key is persisted (wrapped via raw export) so the encrypted
+// localStorage mirror can be decrypted after a page reload, making offline
+// persistence actually work. Previously a fresh key was generated every
+// session and the persisted blob became permanently undecryptable.
+const LOCAL_KEY_KEY = "fin_local_docs_key_v1";
+
 // Bounded local cache: keep at most this many documents in the localStorage
 // mirror so the 5 MB quota can never be exhausted by unbounded growth.
 const MAX_LOCAL_DOCS = 50;
@@ -31,22 +37,65 @@ function isQuotaError(err: unknown): boolean {
  *
  * We therefore keep a decrypted, in-memory mirror for the active session and
  * persist only an AES-GCM-encrypted blob to `localStorage`. The encryption key
- * is generated once per page session and lives only in memory, so:
- *   - the at-rest data is unreadable by other scripts / after an XSS, and
- *   - it does not survive logout or a page reload (a fresh session cannot
- *     decrypt the previous blob), which bounds the exposure window.
+ * is generated once and persisted (wrapped as raw key material) in
+ * `localStorage`, so the blob can be decrypted after a page reload and the
+ * offline document mirror actually survives refreshes. Because the key lives
+ * in `localStorage` it is still readable by any script on the origin (e.g. via
+ * XSS), so the encrypted blob only protects against passive inspection of the
+ * stored value, not active script execution on the page.
  */
 const memoryCache: Record<string, CachedAnalysisPayload> = {};
 
 let sessionCacheKey: CryptoKey | null = null;
 
+// Persist the raw key material so the encrypted blob remains decryptable
+// across page reloads (the key must be extractable for this to work).
+async function persistSessionKey(key: CryptoKey): Promise<void> {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = await crypto.subtle.exportKey("raw", key);
+    window.localStorage.setItem(LOCAL_KEY_KEY, bufToBase64(raw));
+  } catch {
+    // Key export/storage failed — the in-memory key still works for this session.
+  }
+}
+
+// Recover a previously persisted key, if one exists and is valid.
+async function loadPersistedKey(): Promise<CryptoKey | null> {
+  if (typeof window === "undefined") return null;
+  try {
+    const b64 = window.localStorage.getItem(LOCAL_KEY_KEY);
+    if (!b64) return null;
+    const raw = base64ToBuf(b64);
+    return await crypto.subtle.importKey(
+      "raw",
+      raw,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"],
+    );
+  } catch {
+    return null;
+  }
+}
+
 async function getSessionCacheKey(): Promise<CryptoKey> {
   if (sessionCacheKey) return sessionCacheKey;
+
+  // Reuse the key persisted from a previous session so the encrypted
+  // localStorage mirror survives a reload.
+  const persisted = await loadPersistedKey();
+  if (persisted) {
+    sessionCacheKey = persisted;
+    return sessionCacheKey;
+  }
+
   sessionCacheKey = await crypto.subtle.generateKey(
     { name: "AES-GCM", length: 256 },
-    false,
+    true,
     ["encrypt", "decrypt"],
   );
+  await persistSessionKey(sessionCacheKey);
   return sessionCacheKey;
 }
 
@@ -302,6 +351,7 @@ export function clearAllLocalData(userId?: string): void {
 
   try {
     window.localStorage.removeItem(LOCAL_DOCS_KEY);
+    window.localStorage.removeItem(LOCAL_KEY_KEY);
     if (userId) {
       // Remove every per-user localStorage key so privacy/retention/analytics
       // preferences, starting-balance and alert actions don't survive account


### PR DESCRIPTION
## Problem

`src/lib/storageUtils.ts` persisted an AES-GCM-encrypted blob of the local document cache to `localStorage`, but the encryption key was regenerated on every page load and never persisted. After a reload `decryptString` failed (caught → `null`) and `getLocalDocuments` only read the empty in-memory `memoryCache`, so the persisted blob was permanently undecryptable — the advertised offline persistence was dead. (issue #1542)

## Fix

- Made the generated AES-GCM key extractable (`true`) and now persist its raw key material to `localStorage` under `fin_local_docs_key_v1` via `persistSessionKey`.
- `getSessionCacheKey` now recovers the persisted key (via `loadPersistedKey`) on a fresh session if present, so the encrypted blob is decryptable after reload and the offline mirror works as intended.
- `clearAllLocalData` now also removes the persisted key (`fin_local_docs_key_v1`) so no means to decrypt survives logout / account erasure.
- Updated the module doc comment, which previously claimed the key was session-only and did not survive reload.

## Files changed

- src/lib/storageUtils.ts — persist and recover the encryption key across reloads; clear it on data wipe.

## Testing

Static review only; dependencies are not installed so no build/lint was run. Assumption: the issue's expected behaviour is that the offline document cache genuinely survives a reload, so the fix persists the key (accepting that the key in `localStorage` is readable by same-origin scripts — the encryption still prevents passive inspection of the stored value).

Closes #1542
