### PR TITLE
fix(portfolio): exclude soft-deleted holdings in lookup and clear deleted on merge (#1354)

### DIFF
--- a/src/lib/portfolioUtils.ts
+++ b/src/lib/portfolioUtils.ts
@@ -338,7 +338,12 @@ export async function addTransaction(userId: string, input: TransactionInput): P
     let legacyHoldingRef: ReturnType<typeof doc> | null = null;
     if (!input.holdingId && (input.type === 'buy' || input.type === 'sell')) {
       const holdingsSnap = await getDocs(
-        query(holdings, where('userId', '==', userId), where('symbol', '==', symbol)),
+        query(
+          holdings,
+          where('userId', '==', userId),
+          where('symbol', '==', symbol),
+          where('deleted', '==', false),
+        ),
       );
       if (!holdingsSnap.empty) {
         legacyHoldingRef = holdingsSnap.docs[0].ref;
@@ -407,6 +412,7 @@ export async function addTransaction(userId: string, input: TransactionInput): P
               : existing.avgCost || 0;
 
           const update: Record<string, unknown> = {
+            deleted: false,
             quantity,
             avgCost,
             portfolioId: input.portfolioId,


### PR DESCRIPTION
## Problem

In `src/lib/portfolioUtils.ts`, `addTransaction` looked up an existing holding by symbol without excluding soft-deleted ones, while `removeHolding` only sets `deleted: true`. Inside the transaction the UPDATE branch merged new quantity/price into the stale doc **without clearing `deleted`**. After a user "removes" a holding, a subsequent BUY/SELL for that symbol matched the hidden doc, resurrected it (clears nothing), and merged corrupted quantity/price — and the user would likely "Add Holding" again, creating a duplicate for the same instrument. This is real data-integrity corruption, distinct from the TOCTOU duplicate issue. (Issue #1354)

## Fix

- Excluded soft-deleted holdings from the legacy symbol lookup query by adding `where('deleted', '==', false)`, so a buy/sell no longer matches a hidden (soft-deleted) holding via the fallback path.
- In the UPDATE (merge) branch, explicitly set `deleted: false` so that if a soft-deleted holding is intentionally re-activated by a new transaction, its flag is cleared and it becomes visible/consistent rather than silently staying hidden while its quantity/price are merged.

## Files changed

- `src/lib/portfolioUtils.ts` — added `where('deleted', '==', false)` to the legacy holding lookup; added `deleted: false` to the UPDATE merge object.

## Testing

- Static review only; dependencies are not installed, so no build/typecheck was run. Changes are minimal and consistent with the existing `where`/update patterns already used in the function.

Closes #1354
