### PR TITLE
fix(fire-sim): validate withdrawalRate to prevent divide-by-zero/Infinity (#1526)

### DIFF
--- a/src/api/fire-simulator.ts
+++ b/src/api/fire-simulator.ts
@@ -27,8 +27,16 @@ export async function runFIRESimulation(req: any, res: any) {
       return res.status(400).json({ error: "Missing required FIRE parameters." });
     }
 
+    if (!isFinite(withdrawalRate) || withdrawalRate <= 0 || withdrawalRate > 100) {
+      return res.status(400).json({ error: "Withdrawal rate must be a positive percentage between 0 and 100." });
+    }
+
     // FIRE Number Formula: Target Annual Expenses / (Withdrawal Rate / 100)
     const fireNumber = targetAnnualExpenses / (withdrawalRate / 100);
+
+    if (!isFinite(fireNumber)) {
+      return res.status(400).json({ error: "Invalid FIRE target computed from the provided parameters." });
+    }
 
     // Run a deterministic Monte-Carlo style projection based on historical S&P 500 averages
     // Adjusted for inflation (Real Return of ~7%)


### PR DESCRIPTION
## Problem

In `src/api/fire-simulator.ts`, `fireNumber = targetAnnualExpenses / (withdrawalRate / 100)` is computed with no validation of `withdrawalRate`. The existing `!withdrawalRate` check only catches `0`/`undefined`, not negatives or NaN. A `withdrawalRate` of `0` yields `Infinity` (`fireNumber: Infinity`, `isFI` true immediately, bogus `successProbability`), while a negative rate yields a negative/non-sensical target. Covered by issue #1526.

## Fix

- Added validation after the missing-params check: `withdrawalRate` must be a finite, positive percentage `> 0` and `<= 100`; otherwise returns HTTP `400` with a clear message.
- Added a non-finite guard on the computed `fireNumber` returning HTTP `400` before any trajectory math or response.

## Files changed

- `src/api/fire-simulator.ts` — validate `withdrawalRate` range and guard `fireNumber` against non-finite results.

## Testing

Static review only: dependencies are not installed, so no build/run was performed. Verified by re-reading the edited region that `withdrawalRate <= 0`, `> 100`, and non-finite values are rejected with 400 before the division and before the response is built.

Closes #1526
