### PR TITLE
fix(forecast): classify zero/flat series as stable in calculateTrend (#1499)

### DIFF
--- a/src/lib/forecastUtils.ts
+++ b/src/lib/forecastUtils.ts
@@ -276,7 +276,8 @@ export function calculateTrend(data: { month: string; value: number }[]): 'up' |
   const recent = data.slice(-3).reduce((s, d) => s + d.value, 0) / 3;
   const older = data.slice(0, -3).reduce((s, d) => s + d.value, 0) / (data.length - 3);
   const diff = recent - older;
-  if (Math.abs(diff) < older * 0.05) return 'stable';
+  const EPSILON = 1e-9;
+  if (older <= 0 || Math.abs(diff) < Math.max(older * 0.05, EPSILON)) return 'stable';
   return diff > 0 ? 'up' : 'down';
 }
 


### PR DESCRIPTION
## Problem

`calculateTrend` in `src/lib/forecastUtils.ts` returns `'down'` for a flat or zero series. When `older` is 0 (or negative) the check `Math.abs(diff) < older * 0.05` collapses to `Math.abs(diff) < 0`, so any non-zero (or zero) difference is classified as `'down'`, producing a false negative trend for flat/zero data. (Issue #1499)

## Fix

- Treat series with non-positive `older` baseline as `'stable'` instead of `'down'`.
- Use `Math.max(older * 0.05, EPSILON)` for the stability threshold so a genuinely flat/zero series (diff ≈ 0) is classified as `'stable'`.

## Files changed

- src/lib/forecastUtils.ts — classify zero/flat series as stable in `calculateTrend`.

## Testing

Static review only (deps not installed). Logic verified for flat/zero and normal up/down cases.

Closes #1499
