### PR TITLE
fix(api): mount all advanced-feature endpoints in server.ts (#1497)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -17,6 +17,20 @@ import DOMPurify from "isomorphic-dompurify";
 import logger from "./src/lib/logger.js";
 import { repairTruncatedJSON } from "./src/lib/jsonRepairEngine.js";
 
+// Advanced-feature handlers. These were implemented in src/api/* but never
+// mounted, so the corresponding UI features 404'd. (Issue #1497)
+import { calculateDebtPayoff } from "./src/api/debt-snowball.js";
+import { optimizeTaxLots } from "./src/api/tax-optimization.js";
+import { calculateRebalance } from "./src/api/portfolio-rebalance.js";
+import { verifyIncomeZKP } from "./src/api/zkp-verifier.js";
+import { uploadEncryptedDocument } from "./src/api/e2ee-vault.js";
+import { runFIRESimulation } from "./src/api/fire-simulator.js";
+import { predictOverdraftRisk } from "./src/api/overdraft-protection.js";
+import { detectWashSales } from "./src/api/wash-sale-detector.js";
+import { getPendingApprovals, reviewExpenseApproval } from "./src/api/expense-approval.js";
+import { searchTransactionsSemantic } from "./src/api/semantic-search.js";
+import { handlePlaidWebhook, getReconciliationLogs } from "./src/api/plaid-webhook.js";
+
 dotenv.config({ quiet: true });
 
 logger.info("Server starting", { hfKeyExists: !!process.env.HUGGINGFACE_API_KEY });
@@ -474,6 +488,7 @@ async function requireFirebaseAuth(req: any, res: any, next: any) {
     }
     req.ownerId = decoded.uid;
     req.idToken = idToken;
+    req.user = { uid: decoded.uid, emailVerified: decoded.email_verified === true };
     next();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } catch (err: any) {
@@ -1790,6 +1805,25 @@ CRITICAL RULES:
       });
     }
   });
+
+  // Advanced-feature routes. Each is backed by the handler in src/api/* that
+  // the corresponding React component calls, and is protected by the global
+  // requireFirebaseAuth middleware registered above (app.use("/api", ...)).
+  // These were previously implemented but never mounted, so every feature
+  // 404'd. Paths match the URLs the components fetch exactly. (Issue #1497)
+  app.post("/api/planning/debt-snowball", calculateDebtPayoff);
+  app.post("/api/tax/optimize-sale", optimizeTaxLots);
+  app.post("/api/portfolio/rebalance", calculateRebalance);
+  app.post("/api/privacy/verify-income-zkp", verifyIncomeZKP);
+  app.post("/api/vault/upload", uploadEncryptedDocument);
+  app.post("/api/retirement/fire-simulator", runFIRESimulation);
+  app.post("/api/liquidity/predict-overdraft", predictOverdraftRisk);
+  app.post("/api/tax/detect-wash-sales", detectWashSales);
+  app.get("/api/shared-accounts/approvals", getPendingApprovals);
+  app.post("/api/shared-accounts/review", reviewExpenseApproval);
+  app.get("/api/transactions/semantic-search", searchTransactionsSemantic);
+  app.get("/api/plaid/reconciliation-logs", getReconciliationLogs);
+  app.post("/api/plaid/webhook", handlePlaidWebhook);
 
   // Catches errors from the upload.single("file") middleware above —
   // oversized files (LIMIT_FILE_SIZE) and non-PDF rejections from


### PR DESCRIPTION
## Problem

All 11 newly implemented advanced-feature endpoints (debt-snowball, tax optimize-sale, portfolio rebalance, income ZKP, e2ee vault upload, FIRE simulator, overdraft prediction, wash-sale detection, shared-account approvals/review, semantic search, plaid reconciliation/webhook) were implemented in `src/api/*` but never mounted on the Express app. The corresponding React components call these URLs and receive 404. (Issue #1497)

## Fix

- Import the 11 advanced-feature handlers from `src/api/*` in `server.ts`.
- Mount each handler at the exact path the components fetch (`/api/...`), behind the existing global `requireFirebaseAuth` middleware.
- Attach `req.user` (uid + emailVerified) in `requireFirebaseAuth` so handlers relying on `req.user` work.

## Files changed

- server.ts — mount all advanced-feature endpoints and populate `req.user` in auth middleware.

## Testing

Static review only (deps not installed). Route paths verified to match the URLs referenced by the React components.

Closes #1497
