### PR TITLE
fix(portfolio): guard rebalance against zero price/value division (#1496)

### DIFF
--- a/src/api/portfolio-rebalance.ts
+++ b/src/api/portfolio-rebalance.ts
@@ -22,7 +22,7 @@ export async function calculateRebalance(req: any, res: any) {
     }
 
     const { assets } = req.body as { assets: Asset[] };
-    
+
     if (!assets || assets.length === 0) {
       return res.status(400).json({ error: "No assets provided for rebalancing." });
     }
@@ -33,6 +33,11 @@ export async function calculateRebalance(req: any, res: any) {
       return res.status(400).json({ error: `Target percentages must equal 100%. Currently: ${totalTarget}%` });
     }
 
+    // Validate inputs: each asset must have a positive price to avoid divide-by-zero
+    if (assets.some(a => !(a.currentPrice > 0))) {
+      return res.status(400).json({ error: "Each asset must have a positive currentPrice." });
+    }
+
     // 1. Calculate total portfolio value
     let totalValue = 0;
     const currentAllocations = assets.map(asset => {
@@ -40,6 +45,10 @@ export async function calculateRebalance(req: any, res: any) {
       totalValue += value;
       return { ...asset, currentValue: value };
     });
+
+    if (totalValue <= 0) {
+      return res.status(400).json({ error: "Portfolio total value must be greater than zero." });
+    }
 
     const orders: RebalanceOrder[] = [];
     let driftWarning = false;


### PR DESCRIPTION
## Problem

`calculateRebalance` in `src/api/portfolio-rebalance.ts` divides by per-asset `currentPrice` and by the portfolio `totalValue` with no guards. When an asset's `currentPrice` is 0 (or non-positive) it yields NaN/Infinity orders, and when all `shares*currentPrice` are 0 the `totalValue` becomes 0, causing a divide-by-zero crash at `currentPercentage = (asset.currentValue / totalValue) * 100`. See issue #1496.

## Fix

- Added input validation that every asset has a strictly positive `currentPrice`; otherwise the request is rejected with HTTP 400.
- Added a guard that rejects the request with HTTP 400 when the computed `totalValue` is not greater than zero.
- These guarantees ensure only well-formed, finite BUY/SELL orders are produced; degenerate inputs are surfaced as clear validation errors instead of NaN/Infinity values or a crash.

## Files changed

- src/api/portfolio-rebalance.ts — added zero/positive price and totalValue guards before the division operations.

## Testing

Static review performed (dependencies not installed, so no build/test run). The added guards short-circuit before any division by zero and keep the existing control flow intact.

Closes #1496
