### PR TITLE
fix(debt): pay each debt's own minimum before applying extra payment (#1494)

### DIFF
--- a/src/api/debt-snowball.ts
+++ b/src/api/debt-snowball.ts
@@ -53,23 +53,19 @@ export async function calculateDebtPayoff(req: any, res: any) {
         // Sort active debts based on the strategy
         currentDebts = currentDebts.filter(d => d.balance > 0).sort(sortFn);
         
-        // 1. Pay minimums on everything
-        let availableCash = extraPayment;
+        // 1. Pay each debt's own legally-due minimum first
         for (let d of currentDebts) {
-          availableCash += d.minimumPayment;
+          const pay = Math.min(d.minimumPayment, d.balance);
+          d.balance -= pay;
         }
 
-        // 2. Cascade payments down the sorted list
+        // 2. Apply the leftover extra payment to the priority target only
+        let extra = extraPayment;
         for (let d of currentDebts) {
-          if (availableCash <= 0) break;
-          
-          if (d.balance <= availableCash) {
-            availableCash -= d.balance; // Pay off entirely, roll remaining cash forward
-            d.balance = 0;
-          } else {
-            d.balance -= availableCash; // Apply all remaining cash to this debt
-            availableCash = 0;
-          }
+          if (extra <= 0) break;
+          const pay = Math.min(extra, d.balance);
+          d.balance -= pay;
+          extra -= pay;
         }
 
         totalBalance = currentDebts.reduce((sum, d) => sum + d.balance, 0);


### PR DESCRIPTION
## Problem

In `src/api/debt-snowball.ts` (`runStrategy`, lines 56–73), every debt's minimum payment was pooled into a single `availableCash` amount and then cascaded down the sorted priority list. This meant a debt's own legally-due minimum was not guaranteed to be applied to that debt — the pooled cash was diverted to clear the highest-priority balance first, leaving lower-priority debts underpaid and producing incorrect payoff timelines and total interest versus the standard debt-snowball/avalanche method. See issue #1494.

## Fix

- Each debt now receives its own `minimumPayment` first (`pay = Math.min(d.minimumPayment, d.balance)`), guaranteeing required minimums are applied to the correct debt.
- Only the leftover `extraPayment` is then applied, in priority order, to accelerate payoff.
- This preserves the strategy's intent (deciding where the *extra* cash goes) without reallocating required minimums.

## Files changed

- src/api/debt-snowball.ts — replaced the pooled-cash cascade with per-debt minimum application followed by priority-based extra payment.

## Testing

Static review performed (dependencies not installed, so no build/test run). The new logic applies each debt's minimum before distributing extra cash, matching the standard snowball/avalanche method.

Closes #1494
