### PR TITLE
fix(plaid): authenticate webhook and attribute by item_id (#1483)

### DIFF
--- a/src/api/plaid-webhook.ts
+++ b/src/api/plaid-webhook.ts
@@ -1,4 +1,5 @@
 import logger from "../lib/logger.js";
+import crypto from "crypto";
 
 interface Transaction {
   id: string;
@@ -19,6 +20,31 @@ interface ReconciliationLog {
   merchantName: string;
 }
 
+// Persisted Plaid item_id -> owning FinSight userId mapping. In production this
+// would live in Firestore; here it resolves which user a webhook belongs to so
+// reconciled transactions are never attributed to a constant fake user.
+const itemToUser: Record<string, string> = {
+  "item_demo": "usr_123",
+};
+
+// Verify Plaid's webhook signature (Plaid-Webhook-Verification-Code). The header
+// is an HMAC-SHA256 of the raw request body keyed by the client secret, base64
+// encoded. We reject unauthenticated calls with 401.
+function verifyPlaidSignature(rawBody: string, headerValue: string | undefined): boolean {
+  const secret = process.env.PLAID_WEBHOOK_SECRET;
+  if (!secret) {
+    // No secret configured: an untrusted endpoint must not be allowed to mutate
+    // the ledger, so reject the request.
+    return false;
+  }
+  if (!headerValue) return false;
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("base64");
+  // Constant-time comparison to avoid timing attacks.
+  const a = Buffer.from(expected);
+  const b = Buffer.from(headerValue);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
 // Mock Database of active transactions
 let transactionsDb: Transaction[] = [
   // A pending transaction that hasn't cleared yet
@@ -30,14 +56,34 @@ let reconciliationLogs: ReconciliationLog[] = [];
 
 export async function handlePlaidWebhook(req: any, res: any) {
   try {
-    // In production, verify the Plaid webhook signature using plaid-node client
+    // 1. Verify the Plaid webhook signature before processing anything.
+    const signatureHeader =
+      req.headers["plaid-webhook-verification-code"] ||
+      req.headers["Plaid-Webhook-Verification-Code"];
+    const rawBody = typeof req.rawBody === "string"
+      ? req.rawBody
+      : JSON.stringify(req.body);
+    if (!verifyPlaidSignature(rawBody, signatureHeader)) {
+      logger.warn(`[PLAID_WEBHOOK] Rejected unauthenticated webhook (missing/invalid signature).`);
+      return res.status(401).json({ error: "Invalid webhook signature" });
+    }
+
+    // 2. Resolve the owning FinSight user from the Plaid item_id. Never trust a
+    //    constant userId — unknown items are rejected to prevent cross-account
+    //    ledger corruption.
     const { webhook_type, webhook_code, item_id, new_transactions } = req.body;
+
+    const ownerUserId = itemToUser[item_id];
+    if (!ownerUserId) {
+      logger.warn(`[PLAID_WEBHOOK] Rejected webhook for unknown item_id ${item_id}.`);
+      return res.status(401).json({ error: "Unknown Plaid item" });
+    }
 
     if (webhook_type !== 'TRANSACTIONS' || webhook_code !== 'DEFAULT_UPDATE') {
       return res.status(200).send("Webhook ignored");
     }
 
-    logger.info(`[PLAID_WEBHOOK] Received transactions update for item ${item_id}. Running deduplication worker.`);
+    logger.info(`[PLAID_WEBHOOK] Received transactions update for item ${item_id} (user ${ownerUserId}). Running deduplication worker.`);
 
     // Mock incoming "POSTED" transactions from Plaid's /transactions/get endpoint
     const fetchedPostedTransactions = [
@@ -100,7 +146,7 @@ export async function handlePlaidWebhook(req: any, res: any) {
         // No match found, safe to insert as a brand new transaction
         const newTx: Transaction = {
           id: `tx_local_${Date.now()}`,
-          userId: "usr_123",
+          userId: ownerUserId,
           amount: postedTx.amount,
           date: postedTx.date,
           merchantName: postedTx.merchant_name || "Unknown",


### PR DESCRIPTION
## Problem

The Plaid reconciliation webhook (`handlePlaidWebhook`) had no authentication and pinned every transaction to a hardcoded `usr_123` userId, corrupting multi-tenant data: any reachable caller could inject/merge transactions, and all real users' posted transactions landed in one account. (issue #1483)

## Fix

- Added `verifyPlaidSignature`, which validates the `Plaid-Webhook-Verification-Code` header as an HMAC-SHA256 (base64) of the raw body keyed by `PLAID_WEBHOOK_SECRET`, using constant-time comparison. Missing/invalid signatures return `401`.
- Added an `itemToUser` mapping and resolve the owning `userId` from the incoming `item_id`; unknown items return `401`.
- Newly created transactions now use the resolved `ownerUserId` instead of the constant `usr_123`.

## Files changed

- src/api/plaid-webhook.ts — signature verification, item_id->userId resolution, removed hardcoded userId on insert.

## Testing

Static review only (dependencies are not installed). Assumes `PLAID_WEBHOOK_SECRET` is configured in production; an unset secret deliberately rejects webhooks so the ledger cannot be mutated by unauthenticated callers.

Closes #1483
