### PR TITLE
fix(expense-approval): prevent self-approval and scope multi-sig inbox per user (#1482)

### DIFF
--- a/src/api/expense-approval.ts
+++ b/src/api/expense-approval.ts
@@ -3,26 +3,42 @@ import logger from "../lib/logger.js";
 interface ExpenseApproval {
   id: string;
   initiator: string;
+  initiatorUid: string;
   merchant: string;
   amount: number;
   category: string;
   date: string;
   status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  householdId: string;
 }
 
-// Mock Database of shared account pending expenses
-let sharedExpenseInbox: ExpenseApproval[] = [
-  { id: "exp_101", initiator: "Partner A", merchant: "Apple Store", amount: 1299.00, category: "Electronics", date: new Date().toISOString(), status: 'PENDING' },
-  { id: "exp_102", initiator: "Partner A", merchant: "Delta Airlines", amount: 645.50, category: "Travel", date: new Date(Date.now() - 86400000).toISOString(), status: 'PENDING' },
-];
+// Per-household inbox. Previously this was a single global array shared by
+// every request, leaking one household's pending expenses to all users and
+// allowing ID collisions across accounts. Now expenses are scoped by the
+// owning household/account id derived from the authenticated user.
+const sharedExpenseInbox: Record<string, ExpenseApproval[]> = {
+  "household_demo": [
+    { id: "exp_101", initiator: "Partner A", initiatorUid: "usr_partner_a", merchant: "Apple Store", amount: 1299.00, category: "Electronics", date: new Date().toISOString(), status: 'PENDING', householdId: "household_demo" },
+    { id: "exp_102", initiator: "Partner A", initiatorUid: "usr_partner_a", merchant: "Delta Airlines", amount: 645.50, category: "Travel", date: new Date(Date.now() - 86400000).toISOString(), status: 'PENDING', householdId: "household_demo" },
+  ],
+};
+
+function getHouseholdId(req: any): string {
+  // A real deployment resolves the user's household/account id; fall back to
+  // the user's own uid when no explicit household membership is present.
+  return req.user?.householdId || req.user?.uid || "";
+}
 
 export async function getPendingApprovals(req: any, res: any) {
   try {
     const user = req.user;
     if (!user) return res.status(401).json({ error: "Unauthorized" });
 
-    // Filter to only show PENDING in the inbox
-    const pending = sharedExpenseInbox.filter(exp => exp.status === 'PENDING');
+    const householdId = getHouseholdId(req);
+    const inbox = sharedExpenseInbox[householdId] || [];
+
+    // Filter to only show this household's PENDING expenses.
+    const pending = inbox.filter(exp => exp.status === 'PENDING');
     
     res.json({ success: true, data: pending });
   } catch (error: any) {
@@ -42,29 +58,37 @@ export async function reviewExpenseApproval(req: any, res: any) {
       return res.status(400).json({ error: "Invalid action" });
     }
 
-    const expenseIndex = sharedExpenseInbox.findIndex(exp => exp.id === expenseId);
+    const householdId = getHouseholdId(req);
+    const inbox = sharedExpenseInbox[householdId] || [];
+    const expenseIndex = inbox.findIndex(exp => exp.id === expenseId);
     
     if (expenseIndex === -1) {
       return res.status(404).json({ error: "Expense not found" });
     }
 
-    // In a real app, verify that the 'initiator' is NOT the same as the 'approver' (req.user)
-    // to enforce true multi-signature consensus.
+    const expense = inbox[expenseIndex];
 
-    sharedExpenseInbox[expenseIndex].status = action === 'APPROVE' ? 'APPROVED' : 'REJECTED';
+    // Enforce true multi-signature: the approver must NOT be the initiator.
+    if (expense.initiatorUid && expense.initiatorUid === user.uid) {
+      return res.status(409).json({
+        error: "Self-approval denied: the initiator cannot approve their own expense.",
+      });
+    }
+
+    expense.status = action === 'APPROVE' ? 'APPROVED' : 'REJECTED';
     
     if (action === 'APPROVED') {
-      logger.info(`[MULTI_SIG] Expense ${expenseId} approved. Releasing funds to ledger.`);
+      logger.info(`[MULTI_SIG] Expense ${expenseId} approved by ${user.uid}. Releasing funds to ledger.`);
       // Proceed to update standard Budget Ledger
     } else {
-      logger.info(`[MULTI_SIG] Expense ${expenseId} rejected. Blocking ledger update.`);
+      logger.info(`[MULTI_SIG] Expense ${expenseId} rejected by ${user.uid}. Blocking ledger update.`);
     }
 
     res.json({ 
       success: true, 
       data: { 
         id: expenseId, 
-        status: sharedExpenseInbox[expenseIndex].status 
+        status: expense.status 
       } 
     });
 


### PR DESCRIPTION
## Problem

The Joint Approval (multi-sig) feature in `src/api/expense-approval.ts` defeated its own guarantee and leaked data across users: (1) any user could approve their own expense because there was no `initiator !== approver` check; (2) the inbox was a single module-level array shared by every request, so all users saw and could act on the same global items and IDs collided across accounts; (3) approvals lived only in process memory and were lost on restart. (issue #1482)

## Fix

- Scoped the inbox per household/account via `getHouseholdId(req)` derived from the authenticated user, so each user only sees their own pending expenses.
- Enforced true multi-signature: `reviewExpenseApproval` now rejects (409) when `expense.initiatorUid === user.uid`.
- Tracking each expense's `householdId` and `initiatorUid`, and logging the acting approver. (Persistence to Firestore would replace the in-memory store in a production deployment.)

## Files changed

- src/api/expense-approval.ts — per-household inbox scoping; self-approval rejection; clearer audit logging.

## Testing

Static review only (dependencies not installed). The deterministic reconciliation path and authorization checks are localized and preserve existing response shapes.

Closes #1482
