### PR TITLE
fix(insights): forward threshold to detectAnomaliesCore in detectAnomalies (#1501)

### DIFF
--- a/src/lib/insightsUtils.ts
+++ b/src/lib/insightsUtils.ts
@@ -248,7 +248,7 @@ export function detectAnomalies(
     type: tx.type,
   } as any));
 
-  const anomalies = detectAnomaliesCore(coreTransactions);
+  const anomalies = detectAnomaliesCore(coreTransactions, threshold);
   const insights: Insight[] = anomalies
     .filter((a) => a.type === "large_transaction") // insights only surfaces large-transaction anomalies
     .filter((a) => !ignoredTransactionIds?.has(a.transactionId))


### PR DESCRIPTION
## Problem

`detectAnomalies` in `src/lib/insightsUtils.ts` documented a 2x default threshold but never forwarded it to the core detector — it called `detectAnomaliesCore(coreTransactions)` while the underlying `detectAnomalies` in `anomalyUtils.ts` defaulted `threshold` to 3. So every insights anomaly used the 3x default and the documented 2x behavior was unreachable, surfacing fewer spending anomalies than promised. (Issue #1501)

## Fix

- Forward the `threshold` argument: `detectAnomaliesCore(coreTransactions, threshold)`.
- Verified `anomalyUtils.detectAnomalies` accepts `threshold` and uses it in the comparison (`amount > mean * threshold`), so the documented 2x contract is now honored.

## Files changed

- src/lib/insightsUtils.ts — pass `threshold` through to the core anomaly detector.

## Testing

Static review only (deps not installed). Confirmed `anomalyUtils.detectAnomalies` signature `(transactions, threshold = 3)` and usage at the comparison; the forwarded value now drives the threshold.

Closes #1501
