### PR TITLE
fix(analyze): clear Promise.race timeout timer (#1535)

### DIFF
--- a/api/analyze.ts
+++ b/api/analyze.ts
@@ -714,6 +714,7 @@ CRITICAL SECURITY NOTE:
 Return ONLY valid JSON with keys: summary, key_metrics, risk_assessment, action_items, sentiment_score, entities, full_report.
 full_report MUST be at least 300 words. No markdown, no code blocks, no explanations outside JSON.`;
 
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
         const completion = await Promise.race([
           hfClient.chatCompletion({
             model: "Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -727,10 +728,12 @@ full_report MUST be at least 300 words. No markdown, no code blocks, no explanat
             max_tokens: 3000,
             temperature: 0.2,
           }),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("Hugging Face API request timed out (15s)")), 15000),
-          ),
-        ]);
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(() => reject(new Error("Hugging Face API request timed out (15s)")), 15000);
+          }),
+        ]).finally(() => {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+        });
 
         const rawText = completion.choices?.[0]?.message?.content || "{}";
         const parsed = safeJsonParse(rawText);


### PR DESCRIPTION
## Problem

In `api/analyze.ts` the HuggingFace call uses `Promise.race` with a `setTimeout` rejection that is never cleared (lines 717–733). When the model call resolves first, the 15s rejection timer keeps running — a dangling resource leak. `server.ts` and `api/process.ts` already handle this correctly; `api/analyze.ts` did not (#1535).

## Fix

- Captured the `setTimeout` handle into `timeoutHandle`.
- Added `.finally(() => { if (timeoutHandle) clearTimeout(timeoutHandle); })` so the timer is cleared once the race settles, matching the other call sites.

## Files changed

- api/analyze.ts — capture and clear the Promise.race timeout handle.

## Testing

- Reviewed the edited region for correctness; deps not installed so static review only.

Closes #1535
