### PR TITLE
fix(subscriptions): make annual-burn bar currency-aware (#1534)

### DIFF
--- a/src/components/subscriptions/SubscriptionAnalyzer.tsx
+++ b/src/components/subscriptions/SubscriptionAnalyzer.tsx
@@ -104,14 +104,20 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
     }
   };
 
-  const summary = useMemo(() => {
+  const estimatedMonthlyIncome = useMemo(() => {
     const incomeTxns = recentTransactions.filter((t) => t.type === "income");
     const months =
       new Set(incomeTxns.map((t) => format(t.date, "yyyy-MM"))).size || 1;
-    const estimatedMonthlyIncome =
-      incomeTxns.reduce((s, t) => s + t.amount, 0) / months;
+    return incomeTxns.reduce((s, t) => s + t.amount, 0) / months;
+  }, [recentTransactions]);
+
+  const summary = useMemo(() => {
     return generateSubscriptionSummary(subscriptions, estimatedMonthlyIncome);
-  }, [subscriptions, recentTransactions]);
+  }, [subscriptions, estimatedMonthlyIncome]);
+
+  // Currency-aware reference for the annual-burn bar: scale against the user's
+  // own annual income (in base currency) instead of a hardcoded USD amount.
+  const annualBurnReference = estimatedMonthlyIncome * 12;
 
   const filteredSubscriptions = useMemo(() => {
     let result = [...subscriptions];
@@ -230,20 +236,22 @@ export function SubscriptionAnalyzer({ user }: { user: any }) {
                   Total yearly burn
                 </p>
                 <div className="mt-3">
-                  <Progress
-                    value={Math.min(
-                      (summary.totalYearly / 60000) * 100,
-                      100,
-                    )}
-                    className="h-1.5 bg-slate-800"
-                  >
-                    <div
-                      className="h-full bg-emerald-500 rounded-full"
-                      style={{
-                        width: `${Math.min((summary.totalYearly / 60000) * 100, 100)}%`,
-                      }}
-                    />
-                  </Progress>
+                  {annualBurnReference > 0 ? (
+                    <Progress
+                      value={Math.min(
+                        (summary.totalYearly / annualBurnReference) * 100,
+                        100,
+                      )}
+                      className="h-1.5 bg-slate-800"
+                    >
+                      <div
+                        className="h-full bg-emerald-500 rounded-full"
+                        style={{
+                          width: `${Math.min((summary.totalYearly / annualBurnReference) * 100, 100)}%`,
+                        }}
+                      />
+                    </Progress>
+                  ) : null}
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Problem

`src/components/subscriptions/SubscriptionAnalyzer.tsx` scaled the "Annual Cost" progress bar against a hardcoded 60,000 USD (lines ~234–244). `summary.totalYearly` is already converted to the user's base currency, so for any non-USD base currency the bar is mis-scaled and saturates at an arbitrary 60,000 (#1534).

## Fix

- Computed `estimatedMonthlyIncome` in its own `useMemo` (reused by the summary).
- Derived `annualBurnReference = estimatedMonthlyIncome * 12`, which is base-currency-aware.
- Scaled the Progress bar against `annualBurnReference` instead of the magic `60000`.
- Dropped the absolute percentage bar entirely when no income reference is available (`reference <= 0`), showing only the total.

## Files changed

- src/components/subscriptions/SubscriptionAnalyzer.tsx — currency-aware annual-burn reference.

## Testing

- Static review; deps not installed.

Closes #1534
