### PR TITLE
fix(zkp): verify Groth16 proof instead of hardcoding valid (#1520)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pdf-parse": "^1.1.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "snarkjs": "^0.7.5",
     "react-markdown": "^10.1.0",
     "recharts": "^3.10.1",
     "sonner": "^2.0.7",

--- a/src/api/zkp-verifier.ts
+++ b/src/api/zkp-verifier.ts
@@ -1,5 +1,7 @@
 import logger from "../lib/logger.js";
 import crypto from "crypto";
+import fs from "fs";
+import path from "path";
 
 export async function verifyIncomeZKP(req: any, res: any) {
   try {
@@ -10,29 +12,43 @@ export async function verifyIncomeZKP(req: any, res: any) {
 
     const { proof, publicSignals, threshold } = req.body;
 
-    if (!proof || !publicSignals || !threshold) {
-      return res.status(400).json({ error: "Missing required ZKP parameters (proof, signals, threshold)" });
+    if (
+      !proof ||
+      !Array.isArray(publicSignals) ||
+      publicSignals.length === 0 ||
+      threshold == null
+    ) {
+      return res.status(400).json({ error: "Missing or malformed ZKP parameters (proof, signals, threshold)" });
     }
 
-    // In a production environment with circom/snarkjs, we would load our Verification Key (vkey.json)
-    // and run `await snarkjs.groth16.verify(vkey, publicSignals, proof)`
-    
-    // Simulating heavy cryptographic verification delay
-    await new Promise(resolve => setTimeout(resolve, 1500));
-
-    // Mocking the verification outcome. A valid proof from the frontend will pass.
-    // If the public signal doesn't match the requested threshold, it's a tampered request.
-    const isProofValid = true; 
-    const signalThreshold = parseInt(publicSignals[0], 10);
-
-    if (signalThreshold !== threshold) {
-      logger.warn(`[ZKP_TAMPERING] User ${user.uid} sent mismatched public signals.`);
-      return res.status(400).json({ error: "Cryptographic signals do not match the requested threshold." });
+    // Cryptographically verify the Groth16 proof against the trusted verification
+    // key. The proof is never trusted: a valid attestation is only issued when
+    // snarkjs confirms the proof matches the public signals.
+    let isProofValid = false;
+    try {
+      // @ts-ignore - snarkjs is an optional runtime dependency (added to package.json)
+      const snarkjs = await import("snarkjs");
+      const vkey = JSON.parse(
+        fs.readFileSync(path.join(process.cwd(), "verification_key.json"), "utf8"),
+      );
+      isProofValid = await snarkjs.groth16.verify(vkey, publicSignals, proof);
+    } catch (verifyErr: any) {
+      logger.error("ZKP_VERIFY_LOAD_ERROR", { message: verifyErr?.message });
+      return res.status(500).json({ error: "Verification key unavailable; cannot verify proof." });
     }
 
     if (!isProofValid) {
-      logger.warn(`[ZKP_REJECTED] User ${user.uid} submitted invalid proof.`);
+      logger.warn(`[ZKP_REJECTED] User ${user.uid} submitted an invalid proof.`);
       return res.status(400).json({ error: "Cryptographic proof is mathematically invalid." });
+    }
+
+    // Bind the attested income to the VERIFIED public signal (publicSignals[0])
+    // rather than the client-supplied `threshold` copy, which the caller could
+    // otherwise tamper with to self-assert any income.
+    const verifiedThreshold = parseInt(String(publicSignals[0]), 10);
+    if (Number.isNaN(verifiedThreshold)) {
+      logger.warn(`[ZKP_TAMPERING] User ${user.uid} sent a non-numeric public signal.`);
+      return res.status(400).json({ error: "Cryptographic signals do not match the requested threshold." });
     }
 
     // Generate a secure sharing token that a landlord/creditor can hit
@@ -43,13 +59,13 @@ export async function verifyIncomeZKP(req: any, res: any) {
     // Store the mapping in DB (token -> { userId, threshold, verifiedAt: Date.now() })
     // ...
 
-    logger.info(`[ZKP_VERIFIED] User ${user.uid} successfully proved income > $${threshold}/mo.`);
+    logger.info(`[ZKP_VERIFIED] User ${user.uid} successfully proved income > $${verifiedThreshold}/mo.`);
 
     res.json({
       success: true,
       data: {
         verified: true,
-        threshold,
+        threshold: verifiedThreshold,
         verificationUrl,
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() // Valid for 7 days
       }


### PR DESCRIPTION
## Problem

`src/api/zkp-verifier.ts` issued "verified income" attestations with the real zero-knowledge verification commented out and `isProofValid` hardcoded to `true` (line 25). The only gate was `signalThreshold !== threshold`, where both `publicSignals[0]` and `threshold` are attacker-controlled (sent in the request body). Any caller could self-assert any income threshold with an arbitrary (even empty) proof (#1520).

## Fix

- Actually run `snarkjs.groth16.verify(vkey, publicSignals, proof)` against the trusted verification key (added `snarkjs` to package.json).
- Gate issuance on cryptographic validity: return 400 when the proof is invalid and 500 if the verification key cannot be loaded.
- Bind the attested threshold to the verified public signal `publicSignals[0]` rather than the client-supplied `threshold` copy, which the caller could otherwise tamper with.
- Added input validation for `proof` / `publicSignals` / `threshold`.

## Files changed

- src/api/zkp-verifier.ts — real Groth16 verification; bind threshold to verified signal.
- package.json — add `snarkjs` dependency.

## Testing

- Static review; deps not installed.

Closes #1520
