### PR TITLE
fix(text-to-sql): strip nested injection operators recursively (#1521)

### DIFF
--- a/src/api/text-to-sql.ts
+++ b/src/api/text-to-sql.ts
@@ -79,17 +79,38 @@ Output valid JSON only with keys: "collection", "where", "orderBy", "limit".`;
       return res.status(401).json({ error: "Unauthorized" });
     }
 
+    // Recursively strip any tenant scoping or NoSQL-injection operators
+    // (keys starting with `$`, e.g. $gt/$in/$or) at EVERY depth of the query
+    // object — not just the top level of `where` — so a nested operator such as
+    // `{ "status": { "$ne": "rejected" } }` or `{ "and": [ { "amount": { "$gt": 100 } } ] }`
+    // cannot survive and be executed against the database.
+    let foundInjectionOperator = false;
+    const stripUnsafeKeys = (node: any): void => {
+      if (Array.isArray(node)) {
+        node.forEach(stripUnsafeKeys);
+        return;
+      }
+      if (node && typeof node === "object") {
+        for (const key of Object.keys(node)) {
+          if (key === "tenantId" || key.startsWith("$")) {
+            delete node[key];
+            foundInjectionOperator = true;
+            continue;
+          }
+          stripUnsafeKeys(node[key]);
+        }
+      }
+    };
+    stripUnsafeKeys(parsedQuery);
+    if (foundInjectionOperator) {
+      return res.status(400).json({ error: "Unsupported query operators detected in request." });
+    }
+
     const where =
       (parsedQuery as any).where && typeof (parsedQuery as any).where === "object" && !(parsedQuery as any).where instanceof Array
         ? (parsedQuery as any).where
         : {};
 
-    // Strip any tenant scoping or injection operators the model tried to inject.
-    for (const key of Object.keys(where)) {
-      if (key === "tenantId" || key.startsWith("$")) {
-        delete where[key];
-      }
-    }
     // Force the authenticated user's tenant id — multi-tenant isolation is
     // guaranteed here, regardless of what the model emitted.
     where.tenantId = user.uid;


### PR DESCRIPTION
## Problem

`handleTextToQuery` in `src/api/text-to-sql.ts` "hardened" the LLM-produced query by stripping injection operators, but only inspected the **top-level** keys of the `where` clause. Nested operators such as `{ "status": { "$ne": "rejected" } }` or `{ "and": [ { "amount": { "$gt": 100 } } ] }` survived sanitization and could still be executed against the database (#1521).

## Fix

- Added `stripUnsafeKeys` that recursively walks the entire parsed query (objects and arrays) and deletes any key equal to `tenantId` or starting with `$` at **any** depth.
- If any injection operator is found, the request is rejected with a 400 response.
- Tenant isolation is still guaranteed by force-setting `where.tenantId = user.uid` after sanitization.

## Files changed

- src/api/text-to-sql.ts — recursive sanitization of `$` operators at all depths.

## Testing

- Static review; deps not installed.

Closes #1521
