### PR TITLE
fix(chat): remove duplicate client-side callModel so agent uses server-bound inference (#1491)

### DIFF
--- a/src/lib/chatAgent.ts
+++ b/src/lib/chatAgent.ts
@@ -415,40 +415,6 @@ function summariseObservation(obs: unknown): string {
   }
 }
 
-async function callModel(
-  systemPrompt: string,
-  messages: { role: "user" | "assistant"; content: string }[],
-): Promise<string | null> {
-  const token = getHfToken();
-  if (!token) return null;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const hf = new HfInference(token);
-    // Abort the HF request if the model does not respond within the per-call
-    // budget. Without this a hung API call would block the agent loop until
-    // the platform function/request timeout. (Issue #1036)
-    const controller = new AbortController();
-    timer = setTimeout(() => controller.abort(), MODEL_CALL_TIMEOUT_MS);
-    const completion = await hf.chatCompletion(
-      {
-        model: DEFAULT_AGENT_MODEL,
-        messages: [
-          { role: "system", content: systemPrompt },
-          ...messages,
-        ] as any,
-        max_tokens: 800,
-        temperature: 0.2,
-      },
-      { signal: controller.signal },
-    );
-    return (completion as any)?.choices?.[0]?.message?.content ?? null;
-  } catch {
-    return null;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
 /**
  * Run the agentic tool-calling loop. Returns null when no model/token is
  * configured or the model cannot produce a valid answer, so callers can fall


### PR DESCRIPTION
## Problem

`src/lib/chatAgent.ts` declared two functions named `callModel`. The second (lines 418–450) overrode the server-bound implementation due to function hoisting. It called `getHfToken()`, which is never defined or imported, so it threw and returned `null`. As a result `runAgentLoop` always received `null`, the agentic copilot silently degraded to the deterministic keyword router, and the security model ("inference never happens in the browser") was at risk. See issue #1491.

## Fix

- Deleted the duplicate client-side `callModel` (the `getHfToken` / `HfInference` copy).
- This leaves the single server-bound `callModel` (lines 292–327) that forwards to `/api/agent-chat` with the user's auth token, so `runAgentLoop` now uses the correct implementation and inference stays server-side.
- Verified no `getHfToken` or `HfInference` reference remains in the file.

## Files changed

- src/lib/chatAgent.ts — removed the bogus second `callModel` declaration; kept the fetch-based server-bound one.

## Testing

Static review performed (dependencies not installed, so no build/test run). Confirmed via grep that only one `callModel` remains and no `getHfToken`/`HfInference` references exist, so the server-bound path is the effective binding.

Closes #1491
