### PR TITLE
fix(goal): auto-complete fully-funded goals during contribution writes (#1524)

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -238,6 +238,13 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
       toast.error('Failed to update goal');
     } finally {
       updatingGoalIds.current.delete(goalId);
+      // Directly auto-complete a fully-funded goal here so completion does not
+      // depend on the auto-complete effect, which skips goals still present in
+      // updatingGoalIds and can leave a 100%-funded goal stuck as 'active'.
+      const projectedAmount = goal.currentAmount + addedAmount;
+      if (goal.status === 'active' && projectedAmount >= goal.targetAmount) {
+        updateGoalStatus(goalId, 'completed', projectedAmount);
+      }
     }
   };
 


### PR DESCRIPTION
## Problem

`src/components/goals/GoalPlanner.tsx` has an auto-complete effect that marks fully-funded active goals as `completed`, but it early-returns for any goal currently in `updatingGoalIds`. Because `updateGoalAmount` keeps the goal in `updatingGoalIds` until the Firestore write settles, a goal that reaches 100% during/right after a contribution write is never auto-completed — it stays stuck as `active` even though fully funded (#1524).

## Fix

- After `updateGoalAmount` removes the goal from `updatingGoalIds` (in `.finally`), it directly checks completion via the projected amount (`currentAmount + addedAmount`) and calls `updateGoalStatus(goalId, 'completed', projectedAmount)` when `status === 'active'` and the projected amount meets the target.
- This decouples completion from the in-flight guard so a fully-funded goal is auto-completed even if a contribution write was in flight.

## Files changed

- src/components/goals/GoalPlanner.tsx — auto-complete fully-funded goals within `updateGoalAmount`.

## Testing

- Static review; deps not installed.

Closes #1524
