### PR TITLE
fix(e2ee): use random per-document PBKDF2 salt and persist it (#1512)

### DIFF
--- a/src/api/e2ee-vault.ts
+++ b/src/api/e2ee-vault.ts
@@ -8,6 +8,7 @@ interface EncryptedDocumentRecord {
   uploadDate: string;
   fileSize: number;
   iv: string; // Base64 Initialization Vector used by the client for AES-GCM
+  salt: string; // Base64 PBKDF2 salt, unique per document, persisted so the key can be re-derived
   ciphertextBlobId: string; // Reference to S3/GCS bucket object
 }
 
@@ -19,9 +20,9 @@ export async function uploadEncryptedDocument(req: any, res: any) {
     const user = req.user;
     if (!user) return res.status(401).json({ error: "Unauthorized" });
 
-    const { filename, fileSize, iv, ciphertextBase64 } = req.body;
+    const { filename, fileSize, iv, salt, ciphertextBase64 } = req.body;
 
-    if (!filename || !iv || !ciphertextBase64) {
+    if (!filename || !iv || !salt || !ciphertextBase64) {
       return res.status(400).json({ error: "Missing required encryption parameters." });
     }
 
@@ -37,6 +38,7 @@ export async function uploadEncryptedDocument(req: any, res: any) {
       uploadDate: new Date().toISOString(),
       fileSize,
       iv,
+      salt,
       ciphertextBlobId: mockBlobId
     };
 
@@ -71,7 +73,8 @@ export async function getVaultDocuments(req: any, res: any) {
       filename: d.filename,
       uploadDate: d.uploadDate,
       fileSize: d.fileSize,
-      iv: d.iv
+      iv: d.iv,
+      salt: d.salt
       // Note: We don't send the raw ciphertext here to save bandwidth, 
       // the client would request the specific blob via a separate /download endpoint
     }));

--- a/src/components/E2EEVault.tsx
+++ b/src/components/E2EEVault.tsx
@@ -25,9 +25,10 @@ export default function E2EEVault() {
       "raw", enc.encode(pass), { name: "PBKDF2" }, false, ["deriveBits", "deriveKey"]
     );
     
-    // In production, salt should be stored per-user. Mocking static salt for demo.
-    const salt = enc.encode("finsight-static-salt-v1"); 
-    
+    // Generate a cryptographically random salt per document so identical
+    // passwords derive different keys. Persisted alongside the ciphertext.
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+
     const key = await window.crypto.subtle.deriveKey(
       { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
       keyMaterial,
@@ -49,7 +50,8 @@ export default function E2EEVault() {
 
     return {
       ciphertextBuffer: ciphertext,
-      ivBase64: btoa(String.fromCharCode(...iv))
+      ivBase64: btoa(String.fromCharCode(...iv)),
+      saltBase64: btoa(String.fromCharCode(...salt))
     };
   };
 
@@ -59,14 +61,15 @@ export default function E2EEVault() {
     try {
       // Step 1: Encrypt locally
       setEncrypting(true);
-      const { ciphertextBuffer, ivBase64 } = await encryptFileClientSide(selectedFile, password);
+      const { ciphertextBuffer, ivBase64, saltBase64 } = await encryptFileClientSide(selectedFile, password);
       setEncrypting(false);
 
       // Convert buffer to base64 for JSON transport (in prod, use multipart form for large files)
       const cipherArray = Array.from(new Uint8Array(ciphertextBuffer));
       const ciphertextBase64 = btoa(String.fromCharCode.apply(null, cipherArray as unknown as number[]));
 
-      // Step 2: Upload to server
+      // Step 2: Upload to server (salt persisted with the record so the key
+      // can be re-derived from the same password on download/decrypt)
       setUploading(true);
       const res = await fetch('/api/vault/upload', {
         method: 'POST',
@@ -75,6 +78,7 @@ export default function E2EEVault() {
           filename: selectedFile.name,
           fileSize: selectedFile.size,
           iv: ivBase64,
+          salt: saltBase64,
           ciphertextBase64
         })
       });


### PR DESCRIPTION
## Problem

E2EEVault.tsx derived the AES-GCM key from the user's password using PBKDF2 with a hardcoded, application-wide static salt. Identical passwords therefore derived identical keys, defeating rainbow-table/precomputation defenses and weakening the "zero-knowledge" claim (issue #1512).

## Fix

- Client now generates a cryptographically random 16-byte salt per document via `crypto.getRandomValues` instead of a static constant.
- The generated salt is base64-encoded (`saltBase64`) and sent with the upload payload so it is persisted with the ciphertext record.
- Server `EncryptedDocumentRecord` gained a `salt` field; `uploadEncryptedDocument` now requires and stores `salt`, and `getVaultDocuments` returns it so the client can re-derive the same key for decryption.

## Files changed

- src/components/E2EEVault.tsx — random per-document salt; persist saltBase64 in upload
- src/api/e2ee-vault.ts — add/store/return salt on the document record

## Testing

Static review of the crypto flow. Dependencies are not installed, so no build was run.

Closes #1512
