### PR TITLE
fix(tax): make Calculate button recompute breakdown via handleCalculate (#1502)

### DIFF
--- a/src/components/tax/TaxEstimation.tsx
+++ b/src/components/tax/TaxEstimation.tsx
@@ -166,6 +166,21 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
     }
   };
 
+  const handleCalculate = () => {
+    if (annualIncome <= 0) {
+      toast.error('Enter a valid income to estimate first');
+      return;
+    }
+    const deductionsValue = parseFloat(deductionsInput);
+    const result = calculateTax(annualIncome, countryCode, regionCode, {
+      filingStatus: countryCode === 'US' ? filingStatus : undefined,
+      deductions:
+        !isNaN(deductionsValue) && deductionsValue > 0 ? deductionsValue : undefined,
+    });
+    setBreakdown(result);
+    toast.success('Estimate updated');
+  };
+
   const handleDownloadPDF = () => {
     if (!breakdown) {
       toast.error('Nothing to download yet');
@@ -370,12 +385,8 @@ export function TaxEstimation({ user }: TaxEstimationProps) {
             </div>
 
             <Button
-              onClick={() => {
-                if (annualIncome > 0 && breakdown) {
-                  toast.success('Estimate updated');
-                }
-              }}
-              disabled={!breakdown}
+              onClick={handleCalculate}
+              disabled={annualIncome <= 0}
               className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold h-12"
             >
               <Calculator className="mr-2" size={16} />


### PR DESCRIPTION
## Problem

In `src/components/tax/TaxEstimation.tsx` the "Calculate" button only fired a success toast inside its `onClick` and was disabled unless a breakdown already existed (`disabled={!breakdown}`). It never recomputed anything, so editing inputs (annual income, frequency, filing status, deductions) after the first render never refreshed the displayed breakdown — the button was purely decorative. (Issue #1502)

## Fix

- Extracted the estimate computation into `handleCalculate`, which validates the income, calls `calculateTax(...)` with the current `annualIncome`, `countryCode`, `regionCode`, `filingStatus`, and `deductions`, then `setBreakdown(result)` and toasts.
- Wired the button to `onClick={handleCalculate}` and changed `disabled` to `annualIncome <= 0` so the button is actionable from any valid input state.

## Files changed

- src/components/tax/TaxEstimation.tsx — add `handleCalculate` and bind the Calculate button to it.

## Testing

Static review only (deps not installed). `calculateTax` signature matches the existing render-time call; the handler reuses the same arguments and updates `breakdown`.

Closes #1502
