### PR TITLE
fix(tax): implement LIFO, pick best strategy, configurable tax rate (#1487)

### DIFF
--- a/src/api/tax-optimization.ts
+++ b/src/api/tax-optimization.ts
@@ -46,14 +46,31 @@ export async function optimizeTaxLots(req: any, res: any) {
     }
 
     // Optimization Strategies
-    
+
     // 1. FIFO (First In, First Out)
     const lotsFIFO = [...mockLots].sort((a, b) => new Date(a.purchaseDate).getTime() - new Date(b.purchaseDate).getTime());
     const resultFIFO = calculateLiquidation(lotsFIFO, targetLiquidationAmount, currentPrice, 'FIFO');
 
-    // 2. HIFO (Highest In, First Out) - Minimizes Capital Gains
+    // 2. LIFO (Last In, First Out)
+    const lotsLIFO = [...mockLots].sort((a, b) => new Date(b.purchaseDate).getTime() - new Date(a.purchaseDate).getTime());
+    const resultLIFO = calculateLiquidation(lotsLIFO, targetLiquidationAmount, currentPrice, 'LIFO');
+
+    // 3. HIFO (Highest In, First Out) - Minimizes Capital Gains
     const lotsHIFO = [...mockLots].sort((a, b) => b.purchasePrice - a.purchasePrice);
     const resultHIFO = calculateLiquidation(lotsHIFO, targetLiquidationAmount, currentPrice, 'HIFO');
+
+    // Use the user's effective capital-gains rate when supplied, otherwise default to 15%.
+    const taxRate = typeof req.body?.taxRate === 'number' && req.body.taxRate >= 0 ? req.body.taxRate : 15;
+    const taxRateDecimal = taxRate / 100;
+
+    // Choose the strategy with the lowest total capital gains across all three strategies.
+    const strategyResults: OptimizationResult[] = [resultFIFO, resultLIFO, resultHIFO];
+    const recommendedStrategy = strategyResults.reduce((best, r) =>
+      r.totalCapitalGains < best.totalCapitalGains ? r : best
+    , strategyResults[0]).strategy;
+
+    const maxGains = Math.max(...strategyResults.map(r => r.totalCapitalGains));
+    const minGains = Math.min(...strategyResults.map(r => r.totalCapitalGains));
 
     res.json({
       success: true,
@@ -63,10 +80,11 @@ export async function optimizeTaxLots(req: any, res: any) {
         targetLiquidationAmount,
         strategies: {
           FIFO: resultFIFO,
+          LIFO: resultLIFO,
           HIFO: resultHIFO
         },
-        recommendedStrategy: resultHIFO.totalCapitalGains < resultFIFO.totalCapitalGains ? 'HIFO' : 'FIFO',
-        taxSavingsEstimated: Math.max(0, resultFIFO.totalCapitalGains - resultHIFO.totalCapitalGains) * 0.15 // Assuming 15% Cap Gains Tax
+        recommendedStrategy,
+        taxSavingsEstimated: Math.max(0, maxGains - minGains) * taxRateDecimal
       }
     });
 

--- a/src/components/TaxLotOptimizer.tsx
+++ b/src/components/TaxLotOptimizer.tsx
@@ -100,7 +100,7 @@ export default function TaxLotOptimizer() {
                 <CheckCircle2 className="w-5 h-5" /> Recommended Strategy: {data.recommendedStrategy}
               </h3>
               <p className="text-emerald-700 text-sm mt-1">
-                By selecting specific tax lots (Highest In, First Out), you lower your recognized capital gains.
+                 By selecting specific tax lots ({data.recommendedStrategy}), you lower your recognized capital gains.
               </p>
             </div>
             <div className="bg-white px-6 py-4 rounded-xl shadow-sm text-center border border-emerald-100">
@@ -109,13 +109,13 @@ export default function TaxLotOptimizer() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* HIFO Column */}
             <div className="border border-emerald-200 rounded-2xl overflow-hidden shadow-sm relative">
               <div className="absolute top-0 left-0 w-full h-1 bg-emerald-500"></div>
               <div className="p-5 bg-slate-50 border-b border-slate-200 flex justify-between items-center">
-                <h4 className="font-bold text-slate-800">HIFO Strategy (Optimized)</h4>
-                <span className="bg-emerald-100 text-emerald-700 text-xs font-bold px-3 py-1 rounded-full">Winner</span>
+                <h4 className="font-bold text-slate-800">HIFO Strategy</h4>
+                {data.recommendedStrategy === 'HIFO' && <span className="bg-emerald-100 text-emerald-700 text-xs font-bold px-3 py-1 rounded-full">Winner</span>}
               </div>
               <div className="p-5">
                 <div className="flex justify-between items-end mb-6">
@@ -156,6 +156,34 @@ export default function TaxLotOptimizer() {
                 <p className="text-xs font-bold text-slate-400 mb-3 uppercase tracking-wider">Lots to Sell:</p>
                 <div className="space-y-2 opacity-75">
                   {data.strategies.FIFO.lotsSold.map((lot: any) => (
+                    <div key={lot.lotId} className="flex justify-between text-sm p-3 bg-white rounded-lg border border-slate-100">
+                      <span className="font-medium text-slate-500">{lot.sharesSold} sh @ {formatCurrency(lot.costBasis / lot.sharesSold)}</span>
+                      <span className={`${lot.gainLoss > 0 ? 'text-rose-400' : 'text-emerald-400'} font-semibold`}>
+                        {lot.gainLoss > 0 ? '+' : ''}{formatCurrency(lot.gainLoss)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* LIFO Column */}
+            <div className="border border-slate-200 rounded-2xl overflow-hidden shadow-sm">
+              <div className="p-5 bg-slate-50 border-b border-slate-200 flex justify-between items-center">
+                <h4 className="font-bold text-slate-800">LIFO Strategy</h4>
+                {data.recommendedStrategy === 'LIFO' && <span className="bg-emerald-100 text-emerald-700 text-xs font-bold px-3 py-1 rounded-full">Winner</span>}
+              </div>
+              <div className="p-5">
+                <div className="flex justify-between items-end mb-6">
+                  <div>
+                    <p className="text-xs text-slate-500 uppercase tracking-wider font-semibold mb-1">Total Cap Gains</p>
+                    <p className="text-2xl font-bold text-slate-500">{formatCurrency(data.strategies.LIFO.totalCapitalGains)}</p>
+                  </div>
+                </div>
+
+                <p className="text-xs font-bold text-slate-400 mb-3 uppercase tracking-wider">Lots to Sell:</p>
+                <div className="space-y-2 opacity-75">
+                  {data.strategies.LIFO.lotsSold.map((lot: any) => (
                     <div key={lot.lotId} className="flex justify-between text-sm p-3 bg-white rounded-lg border border-slate-100">
                       <span className="font-medium text-slate-500">{lot.sharesSold} sh @ {formatCurrency(lot.costBasis / lot.sharesSold)}</span>
                       <span className={`${lot.gainLoss > 0 ? 'text-rose-400' : 'text-emerald-400'} font-semibold`}>


### PR DESCRIPTION
## Problem

The Tax-Lot Optimization engine (`src/api/tax-optimization.ts`) promised `'FIFO' | 'LIFO' | 'HIFO'` strategies, but LIFO was never computed, the recommended strategy excluded LIFO, and `taxSavingsEstimated` hard-coded a 15% rate. The UI (`src/components/TaxLotOptimizer.tsx`) only rendered FIFO/HIFO and hard-coded HIFO as the "Winner." See issue #1487.

## Fix

- Implemented `LIFO` by sorting lots by `purchaseDate` descending and including it in the `strategies` result.
- `recommendedStrategy` is now chosen by minimizing `totalCapitalGains` across all three computed strategies (`resultFIFO`, `resultLIFO`, `resultHIFO`).
- The tax rate is now configurable: it uses `req.body.taxRate` when supplied (a non-negative number), defaulting to 15, instead of the magic constant. `taxSavingsEstimated` uses this derived rate (`maxGains - minGains`).
- Updated the UI to a 3-column layout rendering the LIFO strategy and to show the "Winner" badge on whichever strategy is actually recommended, instead of hard-coding HIFO.

## Files changed

- src/api/tax-optimization.ts — implement LIFO, minimize across all strategies, configurable tax rate.
- src/components/TaxLotOptimizer.tsx — render LIFO column, dynamic Winner badge.

## Testing

Static review performed (dependencies not installed, so no build/test run). Verified LIFO is computed and returned, recommendation spans all three strategies, and the tax rate is no longer a hard-coded constant.

Closes #1487
