### PR TITLE
fix(debt-snowball): report failure and remaining balance when unpaid after horizon (#1511)

### DIFF
--- a/src/api/debt-snowball.ts
+++ b/src/api/debt-snowball.ts
@@ -11,6 +11,8 @@ interface StrategyResult {
   monthsToFreedom: number;
   totalInterestPaid: number;
   trajectory: number[];
+  paidOff: boolean;
+  remainingBalance: number;
 }
 
 export async function calculateDebtPayoff(req: any, res: any) {
@@ -77,9 +79,11 @@ export async function calculateDebtPayoff(req: any, res: any) {
       }
 
       return {
-        monthsToFreedom: monthsPassed,
+        monthsToFreedom: totalBalance > 0 ? -1 : monthsPassed,
         totalInterestPaid: parseFloat(totalInterestPaid.toFixed(2)),
-        trajectory
+        trajectory,
+        paidOff: totalBalance <= 0,
+        remainingBalance: parseFloat(totalBalance.toFixed(2))
       };
     };
 
@@ -90,7 +94,7 @@ export async function calculateDebtPayoff(req: any, res: any) {
     const avalanche = runStrategy((a, b) => b.interestRate - a.interestRate);
 
     res.json({
-      success: true,
+      success: snowball.paidOff && avalanche.paidOff,
       data: {
         snowball,
         avalanche


### PR DESCRIPTION
## Problem

calculateDebtPayoff in debt-snowball.ts bounded its amortization loop at 600 months but returned `success: true` unconditionally once the loop ended, even when the debt was never cleared. The UI then misleadingly reported "debt-free in 600 months" while showing a remaining balance (issue #1511).

## Fix

- StrategyResult now carries `paidOff` and `remainingBalance` fields.
- After the loop, `monthsToFreedom` is `-1` (not 600) when the balance is still outstanding, `paidOff` reflects whether the debt cleared, and `remainingBalance` reports the leftover amount.
- The top-level `success` flag is now `snowball.paidOff && avalanche.paidOff` instead of always `true`, so an unpaid schedule is reported as a failure with the outstanding balance.

## Files changed

- src/api/debt-snowball.ts — report unpaid status and remaining balance after the horizon

## Testing

Static review. Dependencies are not installed, so no build was run.

Closes #1511
