### PR TITLE
fix(goals): sort goals by Firestore Timestamp via toDate (#1498)

### DIFF
--- a/src/components/goals/GoalPlanner.tsx
+++ b/src/components/goals/GoalPlanner.tsx
@@ -43,7 +43,7 @@ import { Input } from '@/src/components/ui/input';
 import { Badge } from '@/src/components/ui/badge';
 import { Progress, ProgressTrack, ProgressIndicator } from '@/src/components/ui/progress';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/src/components/ui/dialog';
-import { cn, formatCurrency } from '@/src/lib/utils';
+import { cn, formatCurrency, toDate } from '@/src/lib/utils';
 import { GoalCard } from './GoalCard';
 import {
   type Goal,
@@ -114,7 +114,9 @@ export function GoalPlanner({ user }: GoalPlannerProps) {
         fetchedGoals.sort((a, b) => {
           if (a.status === 'completed' && b.status !== 'completed') return 1;
           if (a.status !== 'completed' && b.status === 'completed') return -1;
-          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          const ta = a.createdAt ? toDate(a.createdAt)?.getTime() ?? 0 : 0;
+          const tb = b.createdAt ? toDate(b.createdAt)?.getTime() ?? 0 : 0;
+          return tb - ta;
         });
 
         setGoals(fetchedGoals);


### PR DESCRIPTION
## Problem

`src/components/goals/GoalPlanner.tsx` persisted goals with `createdAt: serverTimestamp()` (a Firestore `Timestamp`), but the sort comparator did `new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()`. `new Date()` on a Firestore Timestamp object yields `Invalid Date` → `NaN`, so newly created goals got a `NaN` comparator and sorted arbitrarily instead of newest-first. (Issue #1498)

## Fix

- Import `toDate` from `@/src/lib/utils` (which converts a Firestore `Timestamp` to a `Date`, or returns `null` for missing/invalid values).
- Replace the comparator with `toDate(a.createdAt)?.getTime() ?? 0` / `toDate(b.createdAt)?.getTime() ?? 0`, normalizing missing `createdAt` to 0, and order by `tb - ta` (newest first).

## Files changed

- src/components/goals/GoalPlanner.tsx — use `toDate()` for the createdAt sort comparator; import `toDate`.

## Testing

Static review only (deps not installed). Verified `toDate` handles Firestore Timestamps (`value.toDate()` / `value.seconds`); null/missing values fall back to 0, eliminating `NaN` ordering.

Closes #1498
