### PR TITLE
fix(fire-sim): real Monte-Carlo success rate and inflation-adjusted contributions (#1488)

### DIFF
--- a/src/api/fire-simulator.ts
+++ b/src/api/fire-simulator.ts
@@ -14,6 +14,45 @@ interface SimulationYear {
   isFI: boolean;
 }
 
+// Standard-normal sample via Box-Muller, used by the Monte-Carlo below.
+function gaussianRandom(mean: number, stdDev: number): number {
+  const u1 = Math.random() || 1e-9;
+  const u2 = Math.random();
+  const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+  return mean + z * stdDev;
+}
+
+// Estimate the empirical probability (0-100) of reaching `fireNumber` within
+// `years` by simulating many randomized return paths. This replaces the old
+// fabricated scalar so the reported "Success Rate" has a real statistical basis
+// (it now reflects return volatility and sequence-of-returns risk).
+function runMonteCarloSuccessProbability(
+  currentNetWorth: number,
+  annualSavings0: number,
+  fireNumber: number,
+  inflationRate: number,
+  paths = 1000,
+  years = 40,
+): number {
+  let successes = 0;
+  for (let p = 0; p < paths; p++) {
+    let nw = currentNetWorth;
+    let annualSavings = annualSavings0;
+    let reached = false;
+    for (let year = 1; year <= years; year++) {
+      const annualReturn = gaussianRandom(0.07, 0.15);
+      nw = nw * (1 + annualReturn) + annualSavings;
+      annualSavings *= 1 + inflationRate; // contributions rise with inflation
+      if (nw >= fireNumber) {
+        reached = true;
+        break;
+      }
+    }
+    if (reached) successes++;
+  }
+  return parseFloat(((successes / paths) * 100).toFixed(1));
+}
+
 export async function runFIRESimulation(req: any, res: any) {
   try {
     const user = req.user;
@@ -30,11 +69,13 @@ export async function runFIRESimulation(req: any, res: any) {
     // FIRE Number Formula: Target Annual Expenses / (Withdrawal Rate / 100)
     const fireNumber = targetAnnualExpenses / (withdrawalRate / 100);
 
-    // Run a deterministic Monte-Carlo style projection based on historical S&P 500 averages
-    // Adjusted for inflation (Real Return of ~7%)
+    // Deterministic base projection. The ~7% real return already accounts for
+    // inflation eroding investment growth; fixed contributions are grown by the
+    // inflation rate each year so their future value is not overstated.
     const annualRealReturn = 0.07;
-    const annualSavings = monthlySavings * 12;
-    
+    const inflationRate = 0.03;
+    let annualSavings = monthlySavings * 12;
+
     let simulatedNetWorth = currentNetWorth;
     const trajectory: SimulationYear[] = [];
     let yearsToFI = 0;
@@ -44,7 +85,7 @@ export async function runFIRESimulation(req: any, res: any) {
     for (let year = 1; year <= 40; year++) { // Project out up to 40 years
       simulatedNetWorth = (simulatedNetWorth * (1 + annualRealReturn)) + annualSavings;
       const isFI = simulatedNetWorth >= fireNumber;
-      
+
       trajectory.push({
         year: new Date().getFullYear() + year,
         age: currentAge + year,
@@ -57,11 +98,19 @@ export async function runFIRESimulation(req: any, res: any) {
         yearsToFI = year;
         targetAge = currentAge + year;
       }
+
+      // Future contributions rise with inflation to preserve real value.
+      annualSavings *= 1 + inflationRate;
     }
 
-    // In a real Monte Carlo simulation, we would run 10,000 iterations using randomized historical returns
-    // to calculate a "Probability of Success". Mocking a high probability if FI is reached within 40 years.
-    const successProbability = reachedFI ? Math.max(99 - (yearsToFI * 0.5), 50) : 0;
+    // Real Monte-Carlo: empirical probability of reaching the FIRE number across
+    // 1000 randomized return paths (no fabricated formula).
+    const successProbability = runMonteCarloSuccessProbability(
+      currentNetWorth,
+      monthlySavings * 12,
+      fireNumber,
+      inflationRate,
+    );
 
     logger.info(`[FIRE_SIM] User ${user.uid} ran simulation. FI Target: $${fireNumber}. Years to FI: ${yearsToFI}`);
 


### PR DESCRIPTION
## Problem

The FIRE simulator (`src/api/fire-simulator.ts`) reported a "Success Rate" that was fabricated and modeled contributions without inflation adjustment.

- `successProbability` (line 64) was `reachedFI ? Math.max(99 - (yearsToFI * 0.5), 50) : 0` — a made-up formula with no relationship to return volatility, sequence-of-returns risk, or the user's inputs. The UI (`src/components/FIRESimulator.tsx`) displayed it as a real "Success Rate" next to the FI Number.
- The projection loop added a fixed `annualSavings` each year with no inflation modeling, overstating the future value of fixed contributions. See issue #1488.

## Fix

- Replaced the fabricated scalar with a real **Monte-Carlo** estimate (`runMonteCarloSuccessProbability`): it simulates 1000 randomized return paths (Box-Muller normal draws around ~7% mean / 15% std) and reports the empirical fraction that reaches the `fireNumber` within 40 years. The "Success Rate" now has a genuine statistical basis.
- Added an `inflationRate` (3%) and grow `annualSavings` by it each year so future contributions preserve real value (the deterministic projection already uses a ~7% real return, which accounts for inflation eroding investment growth).

## Files changed

- src/api/fire-simulator.ts — added `gaussianRandom`/`runMonteCarloSuccessProbability`; replaced fabricated probability with empirical Monte-Carlo result; grew contributions with inflation.

## Testing

Static review performed (dependencies not installed, so no build/test run). Verified the probability now derives from simulated paths rather than a fixed formula and that contributions rise with inflation inside the projection loop.

Closes #1488
