### PR TITLE
fix(debt): default extraPayment to 0 to avoid NaN amortization (#1510)

### DIFF
--- a/src/api/debt-snowball.ts
+++ b/src/api/debt-snowball.ts
@@ -20,11 +20,14 @@ export async function calculateDebtPayoff(req: any, res: any) {
       return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const { debts, extraPayment } = req.body as { debts: Debt[], extraPayment: number };
+    const { debts, extraPayment } = req.body as { debts: Debt[], extraPayment?: number };
 
     if (!debts || debts.length === 0) {
       return res.status(400).json({ error: "No debts provided." });
     }
+
+    // Treat omitted/NaN/non-finite extraPayment as 0 so amortization is valid.
+    const safeExtraPayment = Number.isFinite(extraPayment) ? extraPayment! : 0;
 
     // A helper function to run the amortization loop based on a specific sorting strategy
     const runStrategy = (sortFn: (a: Debt, b: Debt) => number): StrategyResult => {
@@ -54,7 +57,7 @@ export async function calculateDebtPayoff(req: any, res: any) {
         currentDebts = currentDebts.filter(d => d.balance > 0).sort(sortFn);
         
         // 1. Pay minimums on everything
-        let availableCash = extraPayment;
+        let availableCash = safeExtraPayment;
         for (let d of currentDebts) {
           availableCash += d.minimumPayment;
         }


### PR DESCRIPTION
## Problem

In `src/api/debt-snowball.ts`, `calculateDebtPayoff` destructured `extraPayment` from the request body with no default. When a caller omitted `extraPayment` (or sent `0`), `availableCash` became `undefined`, and `availableCash += d.minimumPayment` evaluated to `NaN`. Every downstream balance update became `NaN`, the loop ran to the 600-month cap, and the function returned `success: true` with `NaN` months/interest — the client rendered "NaN months" / "$NaN interest". See issue #1510.

## Fix

- Changed the destructured type to `extraPayment?: number`.
- Added `safeExtraPayment = Number.isFinite(extraPayment) ? extraPayment! : 0` to treat omitted/`NaN`/`non-finite` values as `0`.
- Seeded `availableCash` from `safeExtraPayment` instead of the raw value.

Amortization now computes a valid schedule using only per-debt minimum payments when `extraPayment` is omitted or invalid.

## Files changed

- src/api/debt-snowball.ts — default/validate `extraPayment` before use.

## Testing

Static review of the amortization loop; `node`/`npm` deps not installed so no build executed. Verified the finite-number guard and default path cover the omitted/`0`/non-finite cases.

Closes #1510
