### PR TITLE
fix(zkp): persist sharing token and add public verify route (#1509)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,7 @@ import rateLimit from "express-rate-limit";
 import DOMPurify from "isomorphic-dompurify";
 import logger from "./src/lib/logger.js";
 import { repairTruncatedJSON } from "./src/lib/jsonRepairEngine.js";
+import { verifyZKPShareRoute } from "./src/api/zkp-verifier.js";
 
 dotenv.config({ quiet: true });
 
@@ -736,6 +737,11 @@ async function startServer() {
       checks,
     });
   });
+
+  // Public, unauthenticated endpoint that resolves a ZKP income-verification
+  // sharing token minted by verifyIncomeZKP. Placed before the /api auth
+  // middleware so a landlord/creditor can view verified status without logging in.
+  app.get("/verify/zkp/:token", verifyZKPShareRoute);
 
   // Require a valid Firebase ID token on every other /api/* route so a
   // route added in the future can't accidentally ship without auth.

--- a/src/api/zkp-verifier.ts
+++ b/src/api/zkp-verifier.ts
@@ -1,6 +1,21 @@
 import logger from "../lib/logger.js";
 import crypto from "crypto";
 
+interface ZKPShare {
+  userId: string;
+  threshold: number;
+  verifiedAt: number;
+  expiresAt: number;
+}
+
+// In-memory store mapping sharingToken -> record. In production this would be
+// persisted to a database so the public verify route below can resolve it.
+const zkpShares = new Map<string, ZKPShare>();
+
+export function resolveZKPShare(token: string): ZKPShare | undefined {
+  return zkpShares.get(token);
+}
+
 export async function verifyIncomeZKP(req: any, res: any) {
   try {
     const user = req.user;
@@ -39,9 +54,15 @@ export async function verifyIncomeZKP(req: any, res: any) {
     // to view the verified status without logging in.
     const sharingToken = crypto.randomBytes(24).toString('hex');
     const verificationUrl = `https://finsight.app/verify/zkp/${sharingToken}`;
+    const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
 
-    // Store the mapping in DB (token -> { userId, threshold, verifiedAt: Date.now() })
-    // ...
+    // Persist the mapping so the public verify route can resolve it.
+    zkpShares.set(sharingToken, {
+      userId: user.uid,
+      threshold,
+      verifiedAt: Date.now(),
+      expiresAt
+    });
 
     logger.info(`[ZKP_VERIFIED] User ${user.uid} successfully proved income > $${threshold}/mo.`);
 
@@ -51,12 +72,44 @@ export async function verifyIncomeZKP(req: any, res: any) {
         verified: true,
         threshold,
         verificationUrl,
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() // Valid for 7 days
+        expiresAt: new Date(expiresAt).toISOString() // Valid for 7 days
       }
     });
 
   } catch (error: any) {
     logger.error("ZKP_VERIFICATION_ERROR", { message: error.message });
     res.status(500).json({ error: "Failed to verify Zero-Knowledge Proof" });
+  }
+}
+
+// Public, unauthenticated endpoint that resolves a sharing token minted by
+// verifyIncomeZKP and reports the verified income status. Unknown or expired
+// tokens are rejected so an issued link can only ever show a live verification.
+export async function verifyZKPShareRoute(req: any, res: any) {
+  try {
+    const { token } = req.params;
+
+    const record = resolveZKPShare(token);
+    if (!record) {
+      return res
+        .status(404)
+        .json({ verified: false, error: "Unknown or revoked sharing token." });
+    }
+
+    if (Date.now() > record.expiresAt) {
+      return res
+        .status(410)
+        .json({ verified: false, error: "Sharing token has expired." });
+    }
+
+    res.json({
+      verified: true,
+      threshold: record.threshold,
+      verifiedAt: new Date(record.verifiedAt).toISOString(),
+      expiresAt: new Date(record.expiresAt).toISOString(),
+    });
+  } catch (error: any) {
+    logger.error("ZKP_SHARE_RESOLVE_ERROR", { message: error.message });
+    res.status(500).json({ verified: false, error: "Failed to resolve sharing token" });
   }
 }


### PR DESCRIPTION
## Problem

The ZKP income-verification flow minted a "verifiable" sharing link for a landlord/creditor, but the token was never stored and the link pointed at a route that did not exist, so the core sharing feature could not work. `src/api/zkp-verifier.ts` generated `sharingToken` and built `verificationUrl = https://finsight.app/verify/zkp/${sharingToken}`, but the "Store the mapping in DB..." step was never implemented, and no `/verify/zkp/:token` route existed in `server.ts` or `api/`. Recipients of the link got a 404 and `expiresAt` was never enforced. See issue #1509.

## Fix

- Persisted the `token -> { userId, threshold, verifiedAt, expiresAt }` mapping in `verifyIncomeZKP` (in-process store) right after a successfully verified proof.
- Added `resolveZKPShare(token)` and a public, unauthenticated `verifyZKPShareRoute` handler that resolves the record, rejects unknown tokens with 404, and rejects expired tokens with 410.
- Registered `GET /verify/zkp/:token` in `server.ts` (placed before the `/api` auth middleware so a landlord/creditor can view verified status without logging in).

## Files changed

- src/api/zkp-verifier.ts — persist sharing token mapping and add public resolve route.
- server.ts — register the public `GET /verify/zkp/:token` endpoint.

## Testing

Static review of token issuance, persistence, and the public resolve handler (unknown/expired rejection). Deps not installed so no build executed. Note: full proof verification depends on upstream #1480; here the lifecycle gap for an already-issued token is closed.

Closes #1509
