### PR TITLE
fix(api): collapse nested documents/delete registration and respond (#1507)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1605,12 +1605,10 @@ CRITICAL RULES:
   // object in one operation. Firestore deletes do not cascade, and a bare
   // client-side deleteDoc would leave the PDF readable via signed URLs
   // forever. Ownership is verified against the Firestore record before any
-  // metadata or object is removed.
-  app.post("/api/documents/delete", documentDeleteRateLimiter, async (req: any, res) => {
   // metadata or object is removed. Local-fallback documents (Issue #1343)
   // have no Firestore record, so they are purged from Storage directly after
   // the same namespace + uploadedBy ownership checks.
-  app.post("/api/documents/delete", async (req: any, res) => {
+  app.post("/api/documents/delete", documentDeleteRateLimiter, async (req: any, res) => {
     try {
       const { documentId, storagePath: bodyStoragePath } = req.body;
 


### PR DESCRIPTION
## Problem

In `server.ts`, the rate-limited deletion route (`/api/documents/delete`) nested a second `app.post("/api/documents/delete", ...)` registration inside its request handler and then returned without calling `res.send`/`res.json`/`next`. On each `DELETE /api/documents/delete` request the outer handler merely registered a nested route and the request hung until client timeout; the real purge logic (the inner handler) never executed for that request. See issue #1507.

## Fix

- Collapsed the two registrations into one: removed the spurious outer wrapper and attached `documentDeleteRateLimiter` to the single real handler.
- The consolidated handler performs the purge (Firestore `documents`/`analyses` subcollection batch delete plus Storage object delete) and responds on every code path (400/403/404/503/500/200), including the `catch` block.

Deletion now rate-limits and responds on every path with no nested registration.

## Files changed

- server.ts — merge nested `/api/documents/delete` handlers into a single rate-limited, responding handler.

## Testing

Static review of the collapsed handler; confirmed `documentDeleteRateLimiter` is applied and every branch returns via `res.status(...).json(...)` or the final `catch`. Deps not installed so no build executed.

Closes #1507
