### PR TITLE
fix(security): require email_verified for admin storage access (#1504)

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -87,6 +87,7 @@ service firebase.storage {
 //      by hand — nothing enforces this automatically.
 function isAdmin(uid) {
   return request.auth != null &&
+    request.auth.token.email_verified == true &&
     firestore.exists(/databases/(default)/documents/users/$(uid)) &&
     firestore.get(/databases/(default)/documents/users/$(uid)).data.role == 'admin';
 }


### PR DESCRIPTION
## Problem

In `storage.rules`, every `allow` for `users/{userId}/documents/...` and `analyses/{userId}/...` requires `request.auth.token.email_verified == true`. However the `admin/{allPaths=**}` match only calls `isAdmin(request.auth.uid)`, and `isAdmin` only checked `request.auth != null && role == 'admin'` — it did not require `email_verified`. An authenticated-but-unverified user whose `users/{uid}.role == 'admin'` could read/delete any user's files under `admin/`, inconsistent with the rest of the rules and with `firestore.rules`' `isAdmin()` (which uses `isSignedIn()` → `email_verified == true`). See issue #1504.

## Fix

- Added `request.auth.token.email_verified == true &&` as the second condition in `isAdmin(uid)` so admin Storage access now requires a verified email, consistent with the other matches and with `firestore.rules`.

## Files changed

- storage.rules — require `email_verified` in `isAdmin()` for admin Storage access.

## Testing

Static review of the `storage.rules` logic; `node`/`npm`/firebase tooling not installed so no rules emulator executed. Verified the admin match (which calls `isAdmin`) now enforces `email_verified` alongside `request.auth != null` and `role == 'admin'`.

Closes #1504
