### PR TITLE
fix(multi-sig): per-account inbox + self-approval rejection (#1525)

### DIFF
--- a/src/api/expense-approval.ts
+++ b/src/api/expense-approval.ts
@@ -8,21 +8,37 @@ interface ExpenseApproval {
   category: string;
   date: string;
   status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  approver?: string;
 }
 
-// Mock Database of shared account pending expenses
-let sharedExpenseInbox: ExpenseApproval[] = [
+// Per-account pending-expense inboxes. Earlier this was a single module-level
+// array shared across every user, which broke multi-tenant isolation. Each
+// account now owns its own queue, keyed by the authenticated user's uid.
+const expenseInboxes = new Map<string, ExpenseApproval[]>();
+
+// Seed each account with an isolated copy of the demo expenses on first access
+// so no account can see or act on another account's pending approvals.
+const SEED_EXPENSES: ExpenseApproval[] = [
   { id: "exp_101", initiator: "Partner A", merchant: "Apple Store", amount: 1299.00, category: "Electronics", date: new Date().toISOString(), status: 'PENDING' },
   { id: "exp_102", initiator: "Partner A", merchant: "Delta Airlines", amount: 645.50, category: "Travel", date: new Date(Date.now() - 86400000).toISOString(), status: 'PENDING' },
 ];
+
+function getUserInbox(uid: string): ExpenseApproval[] {
+  let inbox = expenseInboxes.get(uid);
+  if (!inbox) {
+    inbox = SEED_EXPENSES.map(exp => ({ ...exp }));
+    expenseInboxes.set(uid, inbox);
+  }
+  return inbox;
+}
 
 export async function getPendingApprovals(req: any, res: any) {
   try {
     const user = req.user;
     if (!user) return res.status(401).json({ error: "Unauthorized" });
 
-    // Filter to only show PENDING in the inbox
-    const pending = sharedExpenseInbox.filter(exp => exp.status === 'PENDING');
+    // Only show this account's own PENDING expenses.
+    const pending = getUserInbox(user.uid).filter(exp => exp.status === 'PENDING');
     
     res.json({ success: true, data: pending });
   } catch (error: any) {
@@ -42,29 +58,41 @@ export async function reviewExpenseApproval(req: any, res: any) {
       return res.status(400).json({ error: "Invalid action" });
     }
 
-    const expenseIndex = sharedExpenseInbox.findIndex(exp => exp.id === expenseId);
+    const inbox = getUserInbox(user.uid);
+    const expenseIndex = inbox.findIndex(exp => exp.id === expenseId);
     
     if (expenseIndex === -1) {
       return res.status(404).json({ error: "Expense not found" });
     }
 
-    // In a real app, verify that the 'initiator' is NOT the same as the 'approver' (req.user)
-    // to enforce true multi-signature consensus.
+    // Enforce true multi-signature consensus: the approver must be a DIFFERENT
+    // user than the initiator. Match on uid, falling back to email when the uid
+    // is not recorded on the expense.
+    const initiator = inbox[expenseIndex].initiator;
+    const isSelf =
+      initiator === user.uid ||
+      (user.email && initiator === user.email);
+    if (isSelf) {
+      logger.warn(`[MULTI_SIG] User ${user.uid} attempted to self-approve expense ${expenseId}.`);
+      return res.status(403).json({ error: "You cannot approve your own expense (multi-signature required)." });
+    }
 
-    sharedExpenseInbox[expenseIndex].status = action === 'APPROVE' ? 'APPROVED' : 'REJECTED';
+    inbox[expenseIndex].status = action === 'APPROVE' ? 'APPROVED' : 'REJECTED';
+    inbox[expenseIndex].approver = user.uid;
     
     if (action === 'APPROVED') {
-      logger.info(`[MULTI_SIG] Expense ${expenseId} approved. Releasing funds to ledger.`);
+      logger.info(`[MULTI_SIG] Expense ${expenseId} approved by ${user.uid}. Releasing funds to ledger.`);
       // Proceed to update standard Budget Ledger
     } else {
-      logger.info(`[MULTI_SIG] Expense ${expenseId} rejected. Blocking ledger update.`);
+      logger.info(`[MULTI_SIG] Expense ${expenseId} rejected by ${user.uid}. Blocking ledger update.`);
     }
 
     res.json({ 
       success: true, 
       data: { 
         id: expenseId, 
-        status: sharedExpenseInbox[expenseIndex].status 
+        status: inbox[expenseIndex].status,
+        approver: inbox[expenseIndex].approver,
       } 
     });
 


### PR DESCRIPTION
## Problem

Issue #1525: The multi-signature expense approval feature allowed a user to approve their own expenses and stored all pending approvals in a single module-level array shared across every account. This broke multi-tenant isolation (any user could see/act on another account's pending approvals) and defeated the multi-signature consensus guarantee.

## Fix

- Replaced the single shared `sharedExpenseInbox` array with a per-account `Map` keyed by the authenticated user's `uid` (`expenseInboxes`), so each account only sees its own pending expenses.
- Added `getUserInbox(uid)` which lazily seeds an isolated copy of the demo expenses for that account.
- Enforced true multi-signature consensus in `reviewExpenseApproval`: approval/rejection is rejected with HTTP 403 when the actor (`req.user.uid` or `req.user.email`) matches the expense `initiator`. The approver uid is recorded on the expense.

## Files changed

- src/api/expense-approval.ts — per-account inbox isolation + self-approval guard

## Testing

Static review of the edited region; the change is localized and uses the already-imported `logger`. Dependencies are not installed in the worktree, so a full build was not run.

Closes #1525
