### PR TITLE
Fix: Shorten search bar placeholder text

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/.idea/FinSight-AI.iml
+++ b/.idea/FinSight-AI.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="24" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/FinSight-AI.iml" filepath="$PROJECT_DIR$/.idea/FinSight-AI.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1116,7 +1116,7 @@ export default function App() {
                 size={16}
               />
               <Input
-                placeholder="Search portfolios, assets, or records... (Win+O or Ctrl+Space)"
+                placeholder="Search... (Win+O or Ctrl+Space)"
                 className="bg-slate-900/50 border-slate-800 shadow-inner pl-10 focus-visible:border-indigo-500 focus-visible:ring-1 focus-visible:ring-indigo-500/50 transition-all"
               />
             </div>


### PR DESCRIPTION
This PR shortens the placeholder text in the global search bar so that the keyboard shortcuts are no longer cut off.

Fixes #1670
(Writing "Fixes #1670" is a magic word in GitHub that will automatically close the issue once your code is approved).