### PR TITLE
fix: skip empty amounts when building category baselines

### DIFF
--- a/src/lib/anomalyStats.ts
+++ b/src/lib/anomalyStats.ts
@@ -43,6 +43,7 @@ export function calculateCategoryBaseline(
   grouped.forEach((items, category) => {
     if (items.length === 0) return;
     const amounts = items.map((item) => Math.abs(item.amount));
+    if (amounts.length === 0) return;
     const mean =
       amounts.length > 0
         ? amounts.reduce((sum, amount) => sum + amount, 0) / amounts.length


### PR DESCRIPTION
## Summary

fix: skip empty amounts when building category baselines

## Changes

- Return early for categories with no amount samples after mapping.

Fixes #850
